### PR TITLE
Add address field to cautionary_alerts

### DIFF
--- a/src/components/Property/AddressAlerts.js
+++ b/src/components/Property/AddressAlerts.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types'
+
+const AddressAlerts = ({ cautionaryAlerts }) => {
+  let alertsToShow = (adrAlerts) => {
+    if (adrAlerts.length != 0) {
+      let alertsHtml = adrAlerts.map((alert, index) => {
+        return (
+          <li key={index}>
+            {alert.description} (
+            <span className="govuk-!-font-weight-bold">{alert.alertCode}</span>)
+          </li>
+        )
+      })
+
+      return (
+        <ul className="govuk-tag bg-orange">Address alerts: {alertsHtml}</ul>
+      )
+    } else {
+      return ''
+    }
+  }
+
+  return (
+    <>
+      <div className="hackney-property-alerts">
+        {alertsToShow(cautionaryAlerts)}
+      </div>
+    </>
+  )
+}
+
+AddressAlerts.propTypes = {
+  cautionaryAlerts: PropTypes.array.isRequired,
+}
+
+export default AddressAlerts

--- a/src/components/Property/PropertyDetails.js
+++ b/src/components/Property/PropertyDetails.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
+import AddressAlerts from './AddressAlerts'
 
-const PropertyDetails = ({ address, hierarchyType }) => (
+const PropertyDetails = ({ address, hierarchyType, cautionaryAlerts }) => (
   <div>
     <h1 className="govuk-heading-l">
       {hierarchyType.subTypeDescription}: {address.addressLine}
@@ -8,7 +9,7 @@ const PropertyDetails = ({ address, hierarchyType }) => (
 
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-one-half">
-        <p className="govuk-body-s">
+        <div className="govuk-body-s">
           <span className="govuk-body-xs">Property details</span>
           <br></br>
           <span className="govuk-!-font-weight-bold text-green">
@@ -25,7 +26,8 @@ const PropertyDetails = ({ address, hierarchyType }) => (
           )}
           <span className="govuk-body-xs text-green">{address.postalCode}</span>
           <br></br>
-        </p>
+          <AddressAlerts cautionaryAlerts={cautionaryAlerts} />
+        </div>
       </div>
     </div>
   </div>
@@ -35,6 +37,7 @@ PropertyDetails.propTypes = {
   propertyReference: PropTypes.string.isRequired,
   address: PropTypes.object.isRequired,
   hierarchyType: PropTypes.object.isRequired,
+  cautionaryAlerts: PropTypes.array.isRequired,
 }
 
 export default PropertyDetails

--- a/src/components/Property/PropertyDetails.test.js
+++ b/src/components/Property/PropertyDetails.test.js
@@ -16,6 +16,17 @@ describe('PropertyDetails component', () => {
         subTypeCode: 'DWE',
         subTypeDescription: 'Dwelling',
       },
+      cautionaryAlerts: {
+        propertyReference: '00012345',
+        alerts: [
+          {
+            alertCode: 'DIS',
+            description: 'Property Under Disrepair',
+            startDate: '2011-02-16',
+            endDate: null,
+          },
+        ],
+      },
     },
   }
 
@@ -25,6 +36,7 @@ describe('PropertyDetails component', () => {
         propertyReference={props.property.propertyReference}
         address={props.property.address}
         hierarchyType={props.property.hierarchyType}
+        cautionaryAlerts={props.property.cautionaryAlerts.alerts}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Property/PropertyView.js
+++ b/src/components/Property/PropertyView.js
@@ -4,9 +4,11 @@ import PropertyDetails from './PropertyDetails'
 import Spinner from '../Spinner/Spinner'
 import ErrorMessage from '../Errors/ErrorMessage/ErrorMessage'
 import { getProperty } from '../../utils/api/repairs/properties/properties'
+import { getAlerts } from '../../utils/api/repairs/properties/cautionary_alerts'
 
 const PropertyView = ({ propertyReference }) => {
   const [property, setProperty] = useState({})
+  const [addressAlerts, setaddressAlerts] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
 
@@ -27,10 +29,28 @@ const PropertyView = ({ propertyReference }) => {
     setLoading(false)
   }
 
+  const getAlertsView = async (propertyReference) => {
+    setError(null)
+
+    try {
+      const data = await getAlerts(propertyReference)
+      setaddressAlerts(data.alerts)
+    } catch (e) {
+      setaddressAlerts([])
+      console.log('An error has occured:', e.response)
+      setError(
+        `Oops an error occurred with error status: ${e.response?.status}`
+      )
+    }
+
+    setLoading(false)
+  }
+
   useEffect(() => {
     setLoading(true)
 
     getPropertyView(propertyReference)
+    getAlertsView(propertyReference)
   }, [])
 
   return (
@@ -44,6 +64,7 @@ const PropertyView = ({ propertyReference }) => {
               propertyReference={propertyReference}
               address={property.address}
               hierarchyType={property.hierarchyType}
+              cautionaryAlerts={addressAlerts}
             />
           )}
           {error && <ErrorMessage label={error} />}

--- a/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
+++ b/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
@@ -14,7 +14,7 @@ exports[`PropertyDetails component should render properly 1`] = `
       <div
         class="govuk-grid-column-one-half"
       >
-        <p
+        <div
           class="govuk-body-s"
         >
           <span
@@ -41,7 +41,25 @@ exports[`PropertyDetails component should render properly 1`] = `
             E9 6PT
           </span>
           <br />
-        </p>
+          <div
+            class="hackney-property-alerts"
+          >
+            <ul
+              class="govuk-tag bg-orange"
+            >
+              Address alerts: 
+              <li>
+                Property Under Disrepair (
+                <span
+                  class="govuk-!-font-weight-bold"
+                >
+                  DIS
+                </span>
+                )
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -7,3 +7,4 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
 
 @import 'components/button';
 @import 'components/header';
+@import 'components/property-details';

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -2,6 +2,7 @@ $repairs-hub-colours: (
   'housing-1': #005f61,
   'housing-2': #009ca6,
   'housing-3': #2dccd3,
+  'bg-orange': #ffa300,
 );
 
 @function repairs-hub-colour($colour) {

--- a/src/styles/components/property-details.scss
+++ b/src/styles/components/property-details.scss
@@ -1,0 +1,16 @@
+.hackney-property-alerts {
+  width: 60%;
+  padding: 0;
+
+  li {
+    font-family: Arial, Helvetica, sans-serif !important;
+    text-transform: capitalize;
+    margin-bottom: 5px;
+    padding: 4px 8px;
+    font-weight: normal;
+  }
+}
+
+.bg-orange {
+  background-color: repairs-hub-colour('bg-orange') !important;
+}

--- a/src/utils/api/repairs/properties/cautionary_alerts.js
+++ b/src/utils/api/repairs/properties/cautionary_alerts.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+import AuthHeader from '../../../../utils/AuthHeader'
+
+const { NEXT_PUBLIC_ENDPOINT_API } = process.env
+
+export const getAlerts = async (propertyReference) => {
+  const {
+    data,
+  } = await axios.get(
+    `${NEXT_PUBLIC_ENDPOINT_API}/properties/${propertyReference}/cautionary-alerts`,
+    { headers: AuthHeader() }
+  )
+
+  return data
+}

--- a/src/utils/api/repairs/properties/cautionary_alerts.test.js
+++ b/src/utils/api/repairs/properties/cautionary_alerts.test.js
@@ -1,0 +1,38 @@
+import AuthHeader from '../../../../utils/AuthHeader'
+import { getAlerts } from './cautionary_alerts'
+import mockAxios from '../__mocks__/axios'
+
+const { NEXT_PUBLIC_ENDPOINT_API } = process.env
+
+describe('getAlerts', () => {
+  it('fetches successfully data from an API', async () => {
+    const alerts = {
+      propertyReference: '00012345',
+      alerts: [
+        {
+          alertCode: 'DIS',
+          description: 'Property Under Disrepair',
+          startDate: '2011-02-16',
+          endDate: null,
+        },
+      ],
+    }
+
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: alerts,
+      })
+    )
+
+    const response = await getAlerts('00012345')
+
+    expect(response).toEqual(alerts)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(
+      mockAxios.get
+    ).toHaveBeenCalledWith(
+      `${NEXT_PUBLIC_ENDPOINT_API}/properties/00012345/cautionary-alerts`,
+      { headers: AuthHeader() }
+    )
+  })
+})


### PR DESCRIPTION
### Description of change

Show address alerts on property description
Implement styling to address alerts field

### Story Link

https://trello.com/c/No3ca2yv/168-as-a-user-i-need-to-see-cautionary-alerts-on-the-property-so-that-i-can-keep-our-operatives-safe


If property doesn't have alerts:

![Screenshot 2020-11-27 at 13 48 24](https://user-images.githubusercontent.com/51852726/100455821-4635a000-30b7-11eb-964f-3e4dbd8e3f09.png)

If property has alerts:

![Screenshot 2020-12-01 at 15 57 02](https://user-images.githubusercontent.com/51852726/100764091-e0665280-33ed-11eb-80ad-da0edd12883a.png)


