### PR TITLE
Avoid static rendering of title

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,6 +1,7 @@
 import '../styles/all.scss'
 import App from 'next/app'
 import Layout from '../components/Layout'
+import Head from 'next/head'
 
 const { NEXT_PUBLIC_ALLOWED_IP_ADDRESSES } = process.env
 
@@ -10,6 +11,9 @@ class MyApp extends App {
     return (
       <>
         <Layout>
+          <Head>
+            <title>Hackney Repairs Hub</title>
+          </Head>
           <Component {...pageProps} />
         </Layout>
       </>

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -6,7 +6,6 @@ class AppDocument extends Document {
       <Html lang="en" className="govuk-template lbh-template">
         <Head>
           <link rel="icon" href="/favicon.ico" />
-          <title>Hackney Repairs Hub</title>
         </Head>
         <body className="govuk-template__body lbh-template__body js-enabled">
           <Main />


### PR DESCRIPTION
Following Next JS warning.

https://github.com/vercel/next.js/blob/master/errors/no-document-title.md