### PR TITLE
Make styling changes to match designs

### DIFF
--- a/cypress/fixtures/properties/property.json
+++ b/cypress/fixtures/properties/property.json
@@ -16,7 +16,7 @@
   "alerts": {
     "locationAlert": [
       {
-        "code": "DIS",
+        "type": "DIS",
         "comments": "Property Under Disrepair",
         "startDate": "2011-02-16",
         "endDate": null
@@ -24,15 +24,22 @@
     ],
     "personAlert": [
       {
-        "code": "DIS",
-        "comments": "Property Under Disrepair",
-        "startDate": "2011-02-16",
+        "type": "CV",
+        "comments": "No Lone Visits",
+        "startDate": "2013-03-16",
+        "endDate": null
+      },
+      {
+        "type": "VA",
+        "comments": "Verbal Abuse or Threat of",
+        "startDate": "2014-02-10",
         "endDate": null
       }
     ]
   },
   "tenure": {
     "typeCode": "SEC",
-    "typeDescription": "Secure"
+    "typeDescription": "Secure",
+    "canRaiseRepair": true
   }
 }

--- a/cypress/fixtures/properties/property_no_tenure.json
+++ b/cypress/fixtures/properties/property_no_tenure.json
@@ -1,0 +1,21 @@
+{
+  "property": {
+    "propertyReference": "00012345",
+    "address": {
+      "shortAddress": "16 Pitcairn House  St Thomass Square",
+      "postalCode": "E9 6PT",
+      "addressLine": "16 Pitcairn House",
+      "streetSuffix": "St Thomass Square"
+    },
+    "hierarchyType": {
+      "levelCode": "7",
+      "subTypeCode": "DWE",
+      "subTypeDescription": "Dwelling"
+    }
+  },
+  "alerts": {
+    "locationAlert": [],
+    "personAlert": []
+  },
+  "tenure": null
+}

--- a/cypress/fixtures/properties/property_repair_not_raisable.json
+++ b/cypress/fixtures/properties/property_repair_not_raisable.json
@@ -1,0 +1,25 @@
+{
+  "property": {
+    "propertyReference": "00012345",
+    "address": {
+      "shortAddress": "16 Pitcairn House  St Thomass Square",
+      "postalCode": "E9 6PT",
+      "addressLine": "16 Pitcairn House",
+      "streetSuffix": "St Thomass Square"
+    },
+    "hierarchyType": {
+      "levelCode": "7",
+      "subTypeCode": "DWE",
+      "subTypeDescription": "Dwelling"
+    }
+  },
+  "alerts": {
+    "locationAlert": [],
+    "personAlert": []
+  },
+  "tenure": {
+    "typeCode": "LEA",
+    "typeDescription": "Leasehold (RTB)",
+    "canRaiseRepair": false
+  }
+}

--- a/cypress/integration/search_for_property.spec.js
+++ b/cypress/integration/search_for_property.spec.js
@@ -8,8 +8,6 @@ beforeEach(() => {
 
 describe('Search for property', () => {
   it('Search for property by postcode', () => {
-    cy.fixture('properties/property.json').as('property')
-
     // Stub request for search on properties by postcode
     cy.route('GET', 'api/v2/properties/?q=e9 6pt', '@propertiesList')
 
@@ -29,37 +27,11 @@ describe('Search for property', () => {
       cy.contains('th', 'Property reference')
     })
 
-    // Stub request for property response
-    cy.route('GET', 'api/v2/properties/00012345', '@property')
-
-    // Click property with reference 00012345
-    cy.get('.govuk-table__cell a').first().click()
-    cy.url().should('contains', 'properties/00012345')
-
-    cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
-
-    // Property details
-    cy.get('.govuk-grid-row').within(() => {
-      cy.contains('Property details')
-      cy.contains('16 Pitcairn House')
-      cy.contains('St Thomass Square')
-      cy.contains('E9 6PT')
-    })
-
-    // Tenure (raisable repair)
-    cy.get('.hackney-property-alerts li.bg-turquoise').within(() => {
-      cy.contains('Tenure: Secure')
-    })
-
-    // Alerts
-    cy.get('.hackney-property-alerts').within(() => {
-      // Location alerts
-      cy.contains('Address Alert: Property Under Disrepair (DIS)')
-
-      // Person alerts
-      cy.contains('Contact Alert: No Lone Visits (CV)')
-      cy.contains('Contact Alert: Verbal Abuse or Threat of (VA)')
-    })
+    cy.get('.govuk-table__cell a').should(
+      'have.attr',
+      'href',
+      '/properties/00012345'
+    )
   })
 
   it('Search for property by address', () => {
@@ -73,31 +45,5 @@ describe('Search for property', () => {
     cy.get('.govuk-heading-s').contains(
       'We found 2 matching results for: pitcairn'
     )
-  })
-
-  it('Search for property with unraisable repair', () => {
-    cy.fixture('properties/property_repair_not_raisable.json').as('property')
-
-    // Stub request for property with unraisable tenure code
-    cy.route('GET', 'api/v2/properties/00012345', '@property')
-
-    cy.visit('properties/00012345')
-
-    // Tenure (not raisable repair)
-    cy.get('.hackney-property-alerts li.bg-orange').within(() => {
-      cy.contains('Tenure: Leasehold (RTB)')
-    })
-  })
-
-  it('Search for property with no tenure information', () => {
-    cy.fixture('properties/property_no_tenure.json').as('property')
-
-    // Stub request for property with unraisable tenure code
-    cy.route('GET', 'api/v2/properties/00012345', '@property')
-
-    cy.visit('properties/00012345')
-
-    cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
-    cy.contains('Tenure').should('not.exist')
   })
 })

--- a/cypress/integration/search_for_property.spec.js
+++ b/cypress/integration/search_for_property.spec.js
@@ -88,4 +88,16 @@ describe('Search for property', () => {
       cy.contains('Tenure: Leasehold (RTB)')
     })
   })
+
+  it('Search for property with no tenure information', () => {
+    cy.fixture('properties/property_no_tenure.json').as('property')
+
+    // Stub request for property with unraisable tenure code
+    cy.route('GET', 'api/v2/properties/00012345', '@property')
+
+    cy.visit('properties/00012345')
+
+    cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
+    cy.contains('Tenure').should('not.exist')
+  })
 })

--- a/cypress/integration/show_property.spec.js
+++ b/cypress/integration/show_property.spec.js
@@ -1,0 +1,60 @@
+/// <reference types="cypress" />
+
+beforeEach(() => {
+  cy.server()
+})
+
+describe('Show property', () => {
+  it('Display property details, tenure and alerts', () => {
+    // Stub request with property response
+    cy.fixture('properties/property.json').as('property')
+    cy.route('GET', 'api/v2/properties/00012345', '@property')
+    cy.visit('properties/00012345')
+
+    // Property details
+    cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
+    cy.get('.govuk-grid-row').within(() => {
+      cy.contains('Property details')
+      cy.contains('16 Pitcairn House')
+      cy.contains('St Thomass Square')
+      cy.contains('E9 6PT')
+    })
+
+    // Tenure (raisable repair)
+    cy.get('.hackney-property-alerts li.bg-turquoise').within(() => {
+      cy.contains('Tenure: Secure')
+    })
+
+    // Alerts
+    cy.get('.hackney-property-alerts').within(() => {
+      // Location alerts
+      cy.contains('Address Alert: Property Under Disrepair (DIS)')
+
+      // Person alerts
+      cy.contains('Contact Alert: No Lone Visits (CV)')
+      cy.contains('Contact Alert: Verbal Abuse or Threat of (VA)')
+    })
+  })
+
+  it('Display property with a tenure type that does not permit raising a repair', () => {
+    // Stub request with property response
+    cy.fixture('properties/property_repair_not_raisable.json').as('property')
+    cy.route('GET', 'api/v2/properties/00012345', '@property')
+    cy.visit('properties/00012345')
+
+    // Tenure (not raisable repair)
+    cy.get('.hackney-property-alerts li.bg-orange').within(() => {
+      cy.contains('Tenure: Leasehold (RTB)')
+    })
+  })
+
+  it('Display property with no tenure type', () => {
+    // Stub request with property response
+    cy.fixture('properties/property_no_tenure.json').as('property')
+    cy.route('GET', 'api/v2/properties/00012345', '@property')
+    cy.visit('properties/00012345')
+
+    cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
+    cy.contains('Tenure').should('not.exist')
+  })
+})

--- a/src/components/Property/LocationAlerts.js
+++ b/src/components/Property/LocationAlerts.js
@@ -5,16 +5,13 @@ const LocationAlerts = ({ locationAlerts }) => {
     if (lctAlerts.length != 0) {
       let alertsHtml = lctAlerts.map((alert, index) => {
         return (
-          <li key={index}>
-            {alert.comments} (
-            <span className="govuk-!-font-weight-bold">{alert.code}</span>)
+          <li className="bg-orange" key={index}>
+            Address Alert: {alert.comments} (<strong>{alert.type}</strong>)
           </li>
         )
       })
 
-      return (
-        <ul className="govuk-tag bg-orange">Address alerts: {alertsHtml}</ul>
-      )
+      return <>{alertsHtml}</>
     } else {
       return ''
     }

--- a/src/components/Property/PersonAlerts.js
+++ b/src/components/Property/PersonAlerts.js
@@ -5,16 +5,13 @@ const PersonAlerts = ({ personAlerts }) => {
     if (prsnAlerts.length != 0) {
       let alertsHtml = prsnAlerts.map((alert, index) => {
         return (
-          <li key={index}>
-            {alert.comments} (
-            <span className="govuk-!-font-weight-bold">{alert.code}</span>)
+          <li className="bg-orange" key={index}>
+            Contact Alert: {alert.comments} (<strong>{alert.type}</strong>)
           </li>
         )
       })
 
-      return (
-        <ul className="govuk-tag bg-orange">Person alerts: {alertsHtml}</ul>
-      )
+      return <>{alertsHtml}</>
     } else {
       return ''
     }

--- a/src/components/Property/PropertyDetails.js
+++ b/src/components/Property/PropertyDetails.js
@@ -18,27 +18,31 @@ const PropertyDetails = ({
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-one-half">
         <div className="govuk-body-s">
-          <span className="govuk-body-xs">Property details</span>
-          <br></br>
-          <span className="govuk-!-font-weight-bold text-green">
-            {address.addressLine}
-          </span>
-          <br></br>
-          {address.streetSuffix && (
-            <>
-              <span className="govuk-!-font-weight-bold text-green">
-                {address.streetSuffix}
-              </span>
-              <br></br>
-            </>
-          )}
-          <span className="govuk-body-xs text-green">{address.postalCode}</span>
-          <br></br>
-          <div className="hackney-property-alerts">
+          <div className="property-details-main-section">
+            <span className="govuk-body-xs">Property details</span>
+            <br></br>
+            <span className="govuk-!-font-weight-bold text-green">
+              {address.addressLine}
+            </span>
+            <br></br>
+            {address.streetSuffix && (
+              <>
+                <span className="govuk-!-font-weight-bold text-green">
+                  {address.streetSuffix}
+                </span>
+                <br></br>
+              </>
+            )}
+            <span className="govuk-body-xs text-green">
+              {address.postalCode}
+            </span>
+          </div>
+
+          <ul className="hackney-property-alerts">
+            <Tenure tenure={tenure} />
             <LocationAlerts locationAlerts={locationAlerts} />
             <PersonAlerts personAlerts={personAlerts} />
-            <Tenure tenure={tenure} />
-          </div>
+          </ul>
         </div>
       </div>
     </div>

--- a/src/components/Property/PropertyDetails.test.js
+++ b/src/components/Property/PropertyDetails.test.js
@@ -47,9 +47,9 @@ describe('PropertyDetails component', () => {
         propertyReference={props.property.propertyReference}
         address={props.property.address}
         hierarchyType={props.property.hierarchyType}
+        tenure={props.tenure}
         locationAlerts={props.alerts.locationAlert}
         personAlerts={props.alerts.personAlert}
-        tenure={props.tenure}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Property/PropertyDetails.test.js
+++ b/src/components/Property/PropertyDetails.test.js
@@ -38,6 +38,7 @@ describe('PropertyDetails component', () => {
     tenure: {
       typeCode: 'SEC',
       typeDescription: 'Secure',
+      canRaiseRepair: true,
     },
   }
 

--- a/src/components/Property/PropertyView.js
+++ b/src/components/Property/PropertyView.js
@@ -21,7 +21,7 @@ const PropertyView = ({ propertyReference }) => {
       setProperty(data.property)
       setLocationAlerts(data.alerts.locationAlert)
       setPersonAlerts(data.alerts.personAlert)
-      setTenure(data.tenure)
+      setTenure(data.tenure || {})
     } catch (e) {
       setProperty(null)
       console.log('An error has occured:', e.response)
@@ -48,16 +48,16 @@ const PropertyView = ({ propertyReference }) => {
           {property &&
             property.address &&
             property.hierarchyType &&
+            tenure &&
             locationAlerts &&
-            personAlerts &&
-            tenure && (
+            personAlerts && (
               <PropertyDetails
                 propertyReference={propertyReference}
                 address={property.address}
                 hierarchyType={property.hierarchyType}
+                tenure={tenure}
                 locationAlerts={locationAlerts}
                 personAlerts={personAlerts}
-                tenure={tenure}
               />
             )}
           {error && <ErrorMessage label={error} />}

--- a/src/components/Property/Tenure.js
+++ b/src/components/Property/Tenure.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 const Tenure = ({ tenure }) => {
   let tenureToShow = (tenure) => {
-    if (tenure) {
+    if (tenure?.typeCode) {
       return (
         <li className={`bg-${tenure.canRaiseRepair ? 'turquoise' : 'orange'}`}>
           Tenure: {tenure.typeDescription}

--- a/src/components/Property/Tenure.js
+++ b/src/components/Property/Tenure.js
@@ -4,9 +4,9 @@ const Tenure = ({ tenure }) => {
   let tenureToShow = (tenure) => {
     if (tenure) {
       return (
-        <ul className="govuk-tag bg-turquoise">
-          <li>Tenure: {tenure.typeDescription}</li>
-        </ul>
+        <li className={`bg-${tenure.canRaiseRepair ? 'turquoise' : 'orange'}`}>
+          Tenure: {tenure.typeDescription}
+        </li>
       )
     } else {
       return ''

--- a/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
+++ b/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
@@ -17,65 +17,56 @@ exports[`PropertyDetails component should render properly 1`] = `
         <div
           class="govuk-body-s"
         >
-          <span
-            class="govuk-body-xs"
-          >
-            Property details
-          </span>
-          <br />
-          <span
-            class="govuk-!-font-weight-bold text-green"
-          >
-            16 Pitcairn House
-          </span>
-          <br />
-          <span
-            class="govuk-!-font-weight-bold text-green"
-          >
-            St Thomass Square
-          </span>
-          <br />
-          <span
-            class="govuk-body-xs text-green"
-          >
-            E9 6PT
-          </span>
-          <br />
           <div
+            class="property-details-main-section"
+          >
+            <span
+              class="govuk-body-xs"
+            >
+              Property details
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-weight-bold text-green"
+            >
+              16 Pitcairn House
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-weight-bold text-green"
+            >
+              St Thomass Square
+            </span>
+            <br />
+            <span
+              class="govuk-body-xs text-green"
+            >
+              E9 6PT
+            </span>
+          </div>
+          <ul
             class="hackney-property-alerts"
           >
-            <ul
-              class="govuk-tag bg-orange"
+            <li
+              class="bg-orange"
             >
-              Address alerts: 
-              <li>
-                 (
-                <span
-                  class="govuk-!-font-weight-bold"
-                />
-                )
-              </li>
-            </ul>
-            <ul
-              class="govuk-tag bg-orange"
+              Tenure: Secure
+            </li>
+            <li
+              class="bg-orange"
             >
-              Person alerts: 
-              <li>
-                 (
-                <span
-                  class="govuk-!-font-weight-bold"
-                />
-                )
-              </li>
-            </ul>
-            <ul
-              class="govuk-tag bg-turquoise"
+              Address Alert:  (
+              <strong />
+              )
+            </li>
+            <li
+              class="bg-orange"
             >
-              <li>
-                Tenure: Secure
-              </li>
-            </ul>
-          </div>
+              Contact Alert:  (
+              <strong />
+              )
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
+++ b/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
@@ -48,7 +48,7 @@ exports[`PropertyDetails component should render properly 1`] = `
             class="hackney-property-alerts"
           >
             <li
-              class="bg-orange"
+              class="bg-turquoise"
             >
               Tenure: Secure
             </li>

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -2,7 +2,7 @@ $repairs-hub-colours: (
   'housing-1': #005f61,
   'housing-2': #009ca6,
   'housing-3': #2dccd3,
-  'bg-orange': #ffa300,
+  'warning': #ffa300,
 );
 
 @function repairs-hub-colour($colour) {

--- a/src/styles/components/property-details.scss
+++ b/src/styles/components/property-details.scss
@@ -1,20 +1,22 @@
 .hackney-property-alerts {
-  width: 60%;
+  width: 50%;
+  color: white;
   padding: 0;
 
   li {
-    font-family: Arial, Helvetica, sans-serif !important;
-    text-transform: capitalize;
     margin-bottom: 5px;
     padding: 4px 8px;
-    font-weight: normal;
   }
-}
 
-.bg-orange {
-  background-color: repairs-hub-colour('bg-orange') !important;
-}
+  li:last-child {
+    margin-bottom: 0;
+  }
 
-.bg-turquoise {
-  background-color: repairs-hub-colour('housing-2') !important;
+  li.bg-orange {
+    background: repairs-hub-colour('warning');
+  }
+
+  li.bg-turquoise {
+    background: repairs-hub-colour('housing-2');
+  }
 }

--- a/src/utils/api/repairs/properties/properties.test.js
+++ b/src/utils/api/repairs/properties/properties.test.js
@@ -69,6 +69,29 @@ describe('getProperty', () => {
         subTypeCode: 'DWE',
         subTypeDescription: 'Dwelling',
       },
+      alerts: {
+        locationAlert: [
+          {
+            type: 'VA',
+            comments: 'Verbal Abuse or Threat of',
+            startDate: '2016-07-27',
+            endDate: null,
+          },
+        ],
+        personAlert: [
+          {
+            type: 'CV',
+            comments: 'No Lone Visits',
+            startDate: '2013-03-16',
+            endDate: null,
+          },
+        ],
+      },
+      tenure: {
+        typeCode: 'SEC',
+        typeDescription: 'Secure',
+        canRaiseRepair: true,
+      },
     }
 
     mockAxios.get.mockImplementationOnce(() =>


### PR DESCRIPTION
### Description of change

Update UI of Tenure and Alerts to match designs (dependent on https://github.com/LBHackney-IT/repairs-api/pull/23)

- Change `code` to `type` on alerts with previous API change
- Rearrange order of tenure/alerts inline with Repairs Hub V1 (using this as reference https://github.com/LBHackney-IT/repairs-management/blob/develop/app/views/shared/_tenure_and_cautionary_contact_info.html.erb)
- Update integration specs to match updated UI
- Add case for when tenure is not raisable and render correct class
- Update fixtures with canRaiseRepair
- Update property object from property.test with updated response object with alerts and tenures

Fix bug for when tenure returns null from the API to still render components

- Set tenure to empty object {} when null is returned
- Safely check if there is a typeCode on tenure before rendering component
- Add integration spec for this scenario


### **Previous version:**
![Screenshot 2020-12-16 at 12 38 05](https://user-images.githubusercontent.com/34001723/102360985-9adb8500-3faa-11eb-8403-1f79ab1d1d06.png)

### **Updated version:**
![Screenshot 2020-12-16 at 12 33 25](https://user-images.githubusercontent.com/34001723/102361024-a8910a80-3faa-11eb-96fd-570b9a519afa.png)

Updated version now matches screenshot in trello card: https://trello.com/c/No3ca2yv (Screenshot 2020-10-08 at 15.03.29 copy.jpg)