### PR TITLE
Update text

### DIFF
--- a/cypress/integration/show_property.spec.js
+++ b/cypress/integration/show_property.spec.js
@@ -54,9 +54,7 @@ describe('Show property', () => {
 
     // Tenure (not raisable repair)
     cy.get('.govuk-warning-text').within(() => {
-      cy.contains(
-        'Cannot raise a repair on this property due to tenancy status'
-      )
+      cy.contains('Cannot raise a repair on this property due to tenure type')
     })
     cy.get('.hackney-property-alerts li.bg-orange').within(() => {
       cy.contains('Tenure: Leasehold (RTB)')

--- a/src/components/Property/RaiseRepairStatus.js
+++ b/src/components/Property/RaiseRepairStatus.js
@@ -15,7 +15,7 @@ const RaiseRepairStatus = ({ canRaiseRepair, description }) => {
         </span>
         <strong className="govuk-warning-text__text">
           <span className="govuk-warning-text__assistive">Warning</span>
-          Cannot raise a repair on this property due to tenancy status
+          Cannot raise a repair on this property due to tenure type
         </strong>
       </div>
     )


### PR DESCRIPTION
### Description of change

Change text from "Cannot raise a repair on this property due to tenancy status"

to

"Cannot raise a repair on this property due to tenure type"

as Barnes requested

### Story Link

https://trello.com/c/3yBCDiDd/157-as-a-user-i-need-to-know-if-we-are-liable-for-repairs-at-this-property-so-i-dont-raise-a-repair-unnecessarily


