### PR TITLE
New service api auth header

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@
 
 # Endpoints
 REPAIRS_SERVICE_API_URL=http://localdev/api/v2
-REPAIRS_SERVICE_API_KEY=repairsApiToken
+REPAIRS_SERVICE_API_KEY=repairsApiKey
 
 # Hackney authorised Google user groups
 GSSO_URL=https://auth.hackney.gov.uk/auth?redirect_uri=

--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@
 
 # Endpoints
 REPAIRS_SERVICE_API_URL=http://localdev/api/v2
-REPAIRS_SERVICE_API_TOKEN=repairsApiToken
+REPAIRS_SERVICE_API_KEY=repairsApiToken
 
 # Hackney authorised Google user groups
 GSSO_URL=https://auth.hackney.gov.uk/auth?redirect_uri=

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,7 +34,7 @@ functions:
       subnetIds: ${self:custom.subnets.${self:provider.stage}}
     environment:
       REPAIRS_SERVICE_API_URL: ${ssm:/repairs-hub/${self:provider.stage}/repairs-service-api-url}
-      REPAIRS_SERVICE_API_KEY: ${ssm:/repairs-hub/${self:provider.stage}/repairs-service-api-token}
+      REPAIRS_SERVICE_API_KEY: ${ssm:/repairs-hub/${self:provider.stage}/repairs-service-api-key}
       GSSO_URL: ${ssm:/repairs-hub/${self:provider.stage}/gsso-url}
       GSSO_TOKEN_NAME: ${ssm:/repairs-hub/${self:provider.stage}/gsso-token-name}
       HACKNEY_JWT_SECRET: ${ssm:/repairs-hub/${self:provider.stage}/hackney-jwt-secret}

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,7 +34,7 @@ functions:
       subnetIds: ${self:custom.subnets.${self:provider.stage}}
     environment:
       REPAIRS_SERVICE_API_URL: ${ssm:/repairs-hub/${self:provider.stage}/repairs-service-api-url}
-      REPAIRS_SERVICE_API_TOKEN: ${ssm:/repairs-hub/${self:provider.stage}/repairs-service-api-token}
+      REPAIRS_SERVICE_API_KEY: ${ssm:/repairs-hub/${self:provider.stage}/repairs-service-api-token}
       GSSO_URL: ${ssm:/repairs-hub/${self:provider.stage}/gsso-url}
       GSSO_TOKEN_NAME: ${ssm:/repairs-hub/${self:provider.stage}/gsso-token-name}
       HACKNEY_JWT_SECRET: ${ssm:/repairs-hub/${self:provider.stage}/hackney-jwt-secret}

--- a/src/utils/service-api-client/properties.js
+++ b/src/utils/service-api-client/properties.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_TOKEN } = process.env
 
-const headers = { Authorization: `Bearer ${REPAIRS_SERVICE_API_TOKEN}` }
+const headers = { 'x-api-key': REPAIRS_SERVICE_API_TOKEN }
 
 export const getProperties = async (params) => {
   const { data } = await axios.get(`${REPAIRS_SERVICE_API_URL}/properties`, {

--- a/src/utils/service-api-client/properties.js
+++ b/src/utils/service-api-client/properties.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
-const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_TOKEN } = process.env
+const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_KEY } = process.env
 
-const headers = { 'x-api-key': REPAIRS_SERVICE_API_TOKEN }
+const headers = { 'x-api-key': REPAIRS_SERVICE_API_KEY }
 
 export const getProperties = async (params) => {
   const { data } = await axios.get(`${REPAIRS_SERVICE_API_URL}/properties`, {

--- a/src/utils/service-api-client/properties.test.js
+++ b/src/utils/service-api-client/properties.test.js
@@ -1,9 +1,9 @@
 import { getProperties, getProperty } from './properties'
 import mockAxios from '../__mocks__/axios'
 
-const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_TOKEN } = process.env
+const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_KEY } = process.env
 
-const headers = { 'x-api-key': REPAIRS_SERVICE_API_TOKEN }
+const headers = { 'x-api-key': REPAIRS_SERVICE_API_KEY }
 
 describe('repairs APIs', () => {
   describe('getProperties', () => {

--- a/src/utils/service-api-client/properties.test.js
+++ b/src/utils/service-api-client/properties.test.js
@@ -3,7 +3,7 @@ import mockAxios from '../__mocks__/axios'
 
 const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_TOKEN } = process.env
 
-const headers = { Authorization: `Bearer ${REPAIRS_SERVICE_API_TOKEN}` }
+const headers = { 'x-api-key': REPAIRS_SERVICE_API_TOKEN }
 
 describe('repairs APIs', () => {
   describe('getProperties', () => {


### PR DESCRIPTION
### Description of change

Updates the auth header key for connecting to the new [service API](https://github.com/LBHackney-IT/repairs-api-dotnet) for this frontend.

### Story Link

https://trello.com/c/JxvxkZU3/294-moving-the-front-end-to-the-new-api

### Checklist for before CD deploy

- [x] Update staging service API URL in Parameter Store
- [x] Add repairs-hub/staging/repairs-service-api-key to Parameter Store
