### PR TITLE
Add quantity to the raise repair form

### DIFF
--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -101,6 +101,39 @@ describe('Raise repair form', () => {
 
       cy.get('#sorCode').select('DES5R004')
 
+      // Enter a blank quantity
+      cy.get('#quantity').clear()
+      cy.get('#quantity-form-group .govuk-error-message').within(() => {
+        cy.contains('Please enter a quantity')
+      })
+
+      // Enter a non-number quantity
+      cy.get('#quantity').clear().type('x')
+      cy.get('#quantity-form-group .govuk-error-message').within(() => {
+        cy.contains('Quantity must be a whole number')
+      })
+
+      // Enter a non-integer quantity
+      cy.get('#quantity').clear().type('1.5')
+      cy.get('#quantity-form-group .govuk-error-message').within(() => {
+        cy.contains('Quantity must be a whole number')
+      })
+
+      // Enter a quantity less than the minimum
+      cy.get('#quantity').clear().type('0')
+      cy.get('#quantity-form-group .govuk-error-message').within(() => {
+        cy.contains('Quantity must be 1 or more')
+      })
+
+      // Enter a quantity more than the maximum
+      cy.get('#quantity').clear().type('51')
+      cy.get('#quantity-form-group .govuk-error-message').within(() => {
+        cy.contains('Quantity must be 50 or less')
+      })
+
+      // Enter a valid quantity
+      cy.get('#quantity').clear().type('1')
+
       // Go over the Repair description character limit
       cy.get('#descriptionOfWork').get('.govuk-textarea').type('x'.repeat(251))
       cy.get('#descriptionOfWork-form-group .govuk-error-message').within(

--- a/src/components/Form/NumberInput/NumberInput.js
+++ b/src/components/Form/NumberInput/NumberInput.js
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types'
+import TextInput from '../TextInput/TextInput'
+
+const NumberInput = ({ min, max, step, ...props }) => (
+  <TextInput {...props} type="number" min={min} max={max} step={step} />
+)
+
+NumberInput.propTypes = {
+  min: PropTypes.number,
+  max: PropTypes.number,
+  step: PropTypes.number,
+}
+
+export default NumberInput

--- a/src/components/Form/NumberInput/NumberInput.test.js
+++ b/src/components/Form/NumberInput/NumberInput.test.js
@@ -1,0 +1,33 @@
+import NumberInput from './NumberInput'
+import { fireEvent, render } from '@testing-library/react'
+
+describe('NumberInput', () => {
+  it('renders a number input', () => {
+    const inputName = 'my-number-input'
+    const inputLabel = 'My Input'
+    const { getByLabelText } = render(
+      <NumberInput name={inputName} label={inputLabel} />
+    )
+
+    const labelRegex = new RegExp(`s*${inputLabel}s*`)
+    const input = getByLabelText(labelRegex)
+
+    expect(input).toBeInTheDocument()
+    expect(input.id).toEqual(inputName)
+    expect(input.name).toEqual(inputName)
+  })
+
+  it('performs an action onChange', () => {
+    let newValue = ''
+    const myAction = jest.fn((e) => (newValue = e.target.value))
+    const { getByLabelText } = render(
+      <NumberInput name={'my-input'} label={'My Input'} onChange={myAction} />
+    )
+
+    fireEvent.change(getByLabelText(/\s*My Input\s*/), {
+      target: { value: '2423242526' },
+    })
+
+    expect(newValue).toEqual('2423242526')
+  })
+})

--- a/src/components/Form/TextInput/TextInput.js
+++ b/src/components/Form/TextInput/TextInput.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+import ErrorMessage from '../../Errors/ErrorMessage/ErrorMessage'
+
+const TextInput = ({
+  label,
+  hint,
+  name,
+  register,
+  error,
+  type = 'text',
+  widthClass,
+  ...otherProps
+}) => (
+  <div
+    id={`${name}-form-group`}
+    className={cx('govuk-form-group', {
+      'govuk-form-group--error': error,
+    })}
+  >
+    <label className="govuk-label" htmlFor={name}>
+      {label}
+    </label>
+    {hint && (
+      <span id={`${name}-hint`} className="govuk-hint">
+        {hint}
+      </span>
+    )}
+    {error && <ErrorMessage label={error.message} />}
+    <input
+      className={cx(`govuk-input ${widthClass}`, {
+        'govuk-input--error': error,
+      })}
+      id={name}
+      name={name}
+      type={type}
+      ref={register}
+      aria-describedby={hint && `${name}-hint`}
+      {...otherProps}
+    />
+  </div>
+)
+
+TextInput.propTypes = {
+  label: PropTypes.string,
+  hint: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  error: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+  }),
+  type: PropTypes.string,
+  register: PropTypes.func,
+  widthClass: PropTypes.string,
+}
+
+export default TextInput

--- a/src/components/Form/TextInput/TextInput.test.js
+++ b/src/components/Form/TextInput/TextInput.test.js
@@ -1,0 +1,33 @@
+import TextInput from './TextInput'
+import { fireEvent, render } from '@testing-library/react'
+
+describe('TextInput', () => {
+  it('renders a text input', () => {
+    const inputName = 'my-text-input'
+    const inputLabel = 'My Input'
+    const { getByLabelText } = render(
+      <TextInput name={inputName} label={inputLabel} />
+    )
+
+    const labelRegex = new RegExp(`s*${inputLabel}s*`)
+    const input = getByLabelText(labelRegex)
+
+    expect(input).toBeInTheDocument()
+    expect(input.id).toEqual(inputName)
+    expect(input.name).toEqual(inputName)
+  })
+
+  it('performs an action onChange', () => {
+    let newValue = ''
+    const myAction = jest.fn((e) => (newValue = e.target.value))
+    const { getByLabelText } = render(
+      <TextInput name={'my-input'} label={'My Input'} onChange={myAction} />
+    )
+
+    fireEvent.change(getByLabelText(/\s*My Input\s*/), {
+      target: { value: 'hello' },
+    })
+
+    expect(newValue).toEqual('hello')
+  })
+})

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -1,5 +1,6 @@
 import Button from './Button/Button'
 import Select from './Select/Select'
 import TextArea from './TextArea/TextArea'
+import TextInput from './TextInput/TextInput'
 
-export { Button, Select, TextArea }
+export { Button, Select, TextArea, TextInput }

--- a/src/components/Layout/Grid/GridColumn.js
+++ b/src/components/Layout/Grid/GridColumn.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types'
+
+const GridColumn = (props) => (
+  <div className={`govuk-grid-column-${props.width}`}>{props.children}</div>
+)
+
+GridColumn.propTypes = {
+  width: PropTypes.string.isRequired,
+}
+
+export default GridColumn

--- a/src/components/Layout/Grid/GridRow.js
+++ b/src/components/Layout/Grid/GridRow.js
@@ -1,0 +1,5 @@
+const GridRow = (props) => (
+  <div className="govuk-grid-row">{props.children}</div>
+)
+
+export default GridRow

--- a/src/components/Layout/Grid/index.js
+++ b/src/components/Layout/Grid/index.js
@@ -1,0 +1,4 @@
+import GridRow from './GridRow'
+import GridColumn from './GridColumn'
+
+export { GridRow, GridColumn }

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -3,8 +3,9 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import TenureAlertDetails from '../TenureAlertDetails'
 import BackButton from '../../Layout/BackButton/BackButton'
-import { Select, Button, TextArea } from '../../Form'
+import { Select, Button, TextArea, TextInput } from '../../Form'
 import { buildRaiseRepairFormData } from '../../../utils/hact/raise-repair-form'
+import { GridRow, GridColumn } from '../../Layout/Grid'
 
 const RaiseRepairForm = ({
   address,
@@ -110,27 +111,54 @@ const RaiseRepairForm = ({
             id="repair-request-form"
             onSubmit={handleSubmit(onSubmit)}
           >
-            <Select
-              name="sorCode"
-              label="SOR Code"
-              options={sorCodesList}
-              onChange={onSorCodeSelect}
-              register={register({
-                required: 'Please select an SOR code',
-                validate: (value) =>
-                  sorCodesList.includes(value) || 'SOR code is not valid',
-              })}
-              error={errors && errors.sorCode}
-              widthClass="govuk-!-width-full"
-            />
-            <input
-              id="sorCodeDescription"
-              name="sorCodeDescription"
-              label="sorCodeDescription"
-              type="hidden"
-              value={sorCodeDescription}
-              ref={register}
-            />
+            <GridRow>
+              <GridColumn width="two-thirds">
+                <Select
+                  name="sorCode"
+                  label="SOR Code"
+                  options={sorCodesList}
+                  onChange={onSorCodeSelect}
+                  register={register({
+                    required: 'Please select an SOR code',
+                    validate: (value) =>
+                      sorCodesList.includes(value) || 'SOR code is not valid',
+                  })}
+                  error={errors && errors.sorCode}
+                  widthClass="govuk-!-width-full"
+                />
+                <input
+                  id="sorCodeDescription"
+                  name="sorCodeDescription"
+                  type="hidden"
+                  value={sorCodeDescription}
+                  ref={register}
+                />
+              </GridColumn>
+              <GridColumn width="one-third">
+                <TextInput
+                  name="quantity"
+                  label="Quantity"
+                  error={errors && errors.quantity}
+                  widthClass="govuk-!-width-full"
+                  register={register({
+                    required: 'Please enter a quantity',
+                    valueAsNumber: true,
+                    validate: (value) => {
+                      if (!Number.isInteger(value)) {
+                        return 'Quantity must be a whole number'
+                      }
+                      if (value < 1) {
+                        return 'Quantity must be 1 or more'
+                      } else if (value > 50) {
+                        return 'Quantity must be 50 or less'
+                      } else {
+                        return true
+                      }
+                    },
+                  })}
+                />
+              </GridColumn>
+            </GridRow>
             <Select
               name="priorityDescription"
               label="Task priority"

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -64,42 +64,70 @@ exports[`RaiseRepairForm component should render properly 1`] = `
           role="form"
         >
           <div
-            class="govuk-form-group"
-            id="sorCode-form-group"
+            class="govuk-grid-row"
           >
-            <label
-              class="govuk-label"
-              for="sorCode"
+            <div
+              class="govuk-grid-column-two-thirds"
             >
-              SOR Code
-            </label>
-            <select
-              class="govuk-select govuk-!-width-full"
-              id="sorCode"
-              name="sorCode"
-            >
-              <option
+              <div
+                class="govuk-form-group"
+                id="sorCode-form-group"
+              >
+                <label
+                  class="govuk-label"
+                  for="sorCode"
+                >
+                  SOR Code
+                </label>
+                <select
+                  class="govuk-select govuk-!-width-full"
+                  id="sorCode"
+                  name="sorCode"
+                >
+                  <option
+                    value=""
+                  />
+                  <option
+                    value="DES5R003"
+                  >
+                    DES5R003
+                  </option>
+                  <option
+                    value="DES5R004"
+                  >
+                    DES5R004
+                  </option>
+                </select>
+              </div>
+              <input
+                id="sorCodeDescription"
+                name="sorCodeDescription"
+                type="hidden"
                 value=""
               />
-              <option
-                value="DES5R003"
+            </div>
+            <div
+              class="govuk-grid-column-one-third"
+            >
+              <div
+                class="govuk-form-group"
+                id="quantity-form-group"
               >
-                DES5R003
-              </option>
-              <option
-                value="DES5R004"
-              >
-                DES5R004
-              </option>
-            </select>
+                <label
+                  class="govuk-label"
+                  for="quantity"
+                >
+                  Quantity
+                </label>
+                <input
+                  class="govuk-input govuk-!-width-full"
+                  id="quantity"
+                  name="quantity"
+                  type="text"
+                />
+              </div>
+            </div>
           </div>
-          <input
-            id="sorCodeDescription"
-            label="sorCodeDescription"
-            name="sorCodeDescription"
-            type="hidden"
-            value=""
-          />
           <div
             class="govuk-form-group"
             id="priorityDescription-form-group"

--- a/src/utils/hact/raise-repair-form.js
+++ b/src/utils/hact/raise-repair-form.js
@@ -23,6 +23,9 @@ export const buildRaiseRepairFormData = (formData) => {
           {
             customCode: formData.sorCode,
             customName: formData.sorCodeDescription,
+            quantity: {
+              amount: Number.parseInt(formData.quantity),
+            },
           },
         ],
       },

--- a/src/utils/hact/raise-repair-form.test.js
+++ b/src/utils/hact/raise-repair-form.test.js
@@ -9,6 +9,7 @@ describe('buildRaiseRepairFormData', () => {
     const formData = {
       sorCode: 'DES5R006',
       sorCodeDescription: 'Urgent call outs',
+      quantity: '1',
       priorityDescription: 'U - Urgent (5 Working days)',
       priorityCode: '3',
       descriptionOfWork: 'This is an urgent test description',
@@ -27,7 +28,11 @@ describe('buildRaiseRepairFormData', () => {
       workElement: [
         {
           rateScheduleItem: [
-            { customCode: 'DES5R006', customName: 'Urgent call outs' },
+            {
+              customCode: 'DES5R006',
+              customName: 'Urgent call outs',
+              quantity: { amount: 1 },
+            },
           ],
         },
       ],


### PR DESCRIPTION
### Description of change

Add the quantity field to the raise repair form using a free text input and validating that a whole number is entered.

### Story Link

https://trello.com/c/63HWaUZG/278-as-a-user-i-need-to-be-able-to-enter-a-quantity-relating-to-a-repair-so-that-i-can-order-the-correct-amount-of-works

### Decisions

Added some additional validations to ensure that the quantity falls in the range 1..50 - need to confirm whether this is an acceptable range. This range validation helps prevent user error entering widely incorrect values such as 1 million.

### Known issues

The error messages cause the layout to jump around - it may be better to have quantity on a separate line.

### Screenshots

#### Valid input
![image](https://user-images.githubusercontent.com/6321/104974408-d0cbb900-59ef-11eb-8f27-db49b3a64c85.png)

#### Missing quantity
![image](https://user-images.githubusercontent.com/6321/104974422-e17c2f00-59ef-11eb-8c57-c9062ab6c5f2.png)

#### Invalid number
![image](https://user-images.githubusercontent.com/6321/104974471-0f617380-59f0-11eb-9bb2-04d7a7982caa.png)

#### Non-whole number
![image](https://user-images.githubusercontent.com/6321/104974491-20aa8000-59f0-11eb-9b86-822e009ddc90.png)

#### Number too small
![image](https://user-images.githubusercontent.com/6321/104974514-3029c900-59f0-11eb-958e-e95444b0a455.png)

#### Number too large
![image](https://user-images.githubusercontent.com/6321/104974542-4041a880-59f0-11eb-83e0-2d7c31bf4336.png)


