### PR TITLE
Remove node version initialization from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "repairs-hub-frontend",
   "version": "0.1.0",
   "private": true,
-  "engines": {
-    "node": "12.19.0"
-  },
   "scripts": {
     "dev": "next dev -p 5000",
     "debug": "NODE_OPTIONS='--inspect' next dev -p 5000",


### PR DESCRIPTION
### Description of change

Remove node version initialization from `package.json`

Initializing node version on `package.json` is failing our [build](1)

[1]: https://app.circleci.com/pipelines/github/LBHackney-IT/repairs-hub-frontend/237/workflows/9a87f9e9-ae61-40e0-9b98-ad2e52aa6a07/jobs/554