### PR TITLE
Work order show

### DIFF
--- a/cypress/fixtures/repairs/work-order.json
+++ b/cypress/fixtures/repairs/work-order.json
@@ -1,0 +1,10 @@
+{
+  "reference": 10000012,
+  "dateRaised": "2021-01-18T15:28:57.17811",
+  "lastUpdated": null,
+  "priority": "U - Urgent (5 Working days)",
+  "property": "16 Pitcairn House  St Thomass Square",
+  "owner": "",
+  "description": "This is an urgent repair description",
+  "propertyReference": "00012345"
+}

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -32,14 +32,16 @@ describe('Raise repair form', () => {
     // Property address details with tenure and alerts information
     cy.get('.govuk-caption-l').contains('New repair')
     cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
-    cy.get('.hackney-property-alerts li.bg-turquoise').within(() => {
-      cy.contains('Tenure: Secure')
-    })
-    cy.get('.hackney-property-alerts').within(() => {
-      cy.contains('Address Alert: Property Under Disrepair (DIS)')
-      cy.contains('Contact Alert: No Lone Visits (CV)')
-      cy.contains('Contact Alert: Verbal Abuse or Threat of (VA)')
-    })
+
+    cy.checkForTenureAlertDetails(
+      'Tenure: Secure',
+      ['Address Alert: Property Under Disrepair (DIS)'],
+      [
+        'Contact Alert: No Lone Visits (CV)',
+        'Contact Alert: Verbal Abuse or Threat of (VA)',
+      ]
+    )
+
     cy.get('.govuk-heading-m').contains('Repair task details')
 
     // Form section

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -170,7 +170,12 @@ describe('Raise repair form', () => {
         'href',
         '/properties/00012345'
       )
-      cy.contains('Start a new search')
+      cy.contains('Start a new search').should('have.attr', 'href', '/')
+      cy.contains('View work order').should(
+        'have.attr',
+        'href',
+        '/work-orders/10102030'
+      )
     })
 
     // Run lighthouse audit for accessibility report

--- a/cypress/integration/show_property.spec.js
+++ b/cypress/integration/show_property.spec.js
@@ -28,20 +28,14 @@ describe('Show property', () => {
       cy.contains('E9 6PT')
     })
 
-    // Tenure (raisable repair)
-    cy.get('.hackney-property-alerts li.bg-turquoise').within(() => {
-      cy.contains('Tenure: Secure')
-    })
-
-    // Alerts
-    cy.get('.hackney-property-alerts').within(() => {
-      // Location alerts
-      cy.contains('Address Alert: Property Under Disrepair (DIS)')
-
-      // Person alerts
-      cy.contains('Contact Alert: No Lone Visits (CV)')
-      cy.contains('Contact Alert: Verbal Abuse or Threat of (VA)')
-    })
+    cy.checkForTenureAlertDetails(
+      'Tenure: Secure',
+      ['Address Alert: Property Under Disrepair (DIS)'],
+      [
+        'Contact Alert: No Lone Visits (CV)',
+        'Contact Alert: Verbal Abuse or Threat of (VA)',
+      ]
+    )
 
     // Run lighthouse audit for accessibility report
     cy.audit()

--- a/cypress/integration/show_work_order.spec.js
+++ b/cypress/integration/show_work_order.spec.js
@@ -1,0 +1,63 @@
+/// <reference types="cypress" />
+
+import 'cypress-audit/commands'
+
+describe('Search for property', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.server()
+    // Stub request for work order and property
+    cy.fixture('repairs/work-order.json').as('workOrder')
+    cy.fixture('properties/property.json').as('property')
+    cy.route('GET', 'api/properties/00012345', '@property')
+    cy.route('GET', 'api/repairs/10000012', '@workOrder')
+  })
+
+  it('Displays the page for a work order', () => {
+    cy.visit(`${Cypress.env('HOST')}/work-orders/10000012`)
+
+    // Works order header with reference number
+    cy.get('.govuk-heading-l').within(() => {
+      cy.contains('Works order: 10000012')
+    })
+
+    // Repair description
+    cy.get('.govuk-body-m').within(() => {
+      cy.contains('This is an urgent repair description')
+    })
+
+    // Property details
+    cy.get('.govuk-grid-row').within(() => {
+      cy.contains('Dwelling')
+      cy.contains('16 Pitcairn House').should(
+        'have.attr',
+        'href',
+        '/properties/00012345'
+      )
+      cy.contains('St Thomass Square').should(
+        'have.attr',
+        'href',
+        '/properties/00012345'
+      )
+      cy.contains('E9 6PT')
+    })
+
+    // Tenure (raisable repair)
+    cy.get('.hackney-property-alerts li.bg-turquoise').within(() => {
+      cy.contains('Tenure: Secure')
+    })
+
+    // Alerts
+    cy.get('.hackney-property-alerts').within(() => {
+      // Location alerts
+      cy.contains('Address Alert: Property Under Disrepair (DIS)')
+
+      // Person alerts
+      cy.contains('Contact Alert: No Lone Visits (CV)')
+      cy.contains('Contact Alert: Verbal Abuse or Threat of (VA)')
+    })
+
+    // Run lighthouse audit for accessibility report
+    cy.audit()
+  })
+})

--- a/cypress/integration/show_work_order.spec.js
+++ b/cypress/integration/show_work_order.spec.js
@@ -42,20 +42,14 @@ describe('Search for property', () => {
       cy.contains('E9 6PT')
     })
 
-    // Tenure (raisable repair)
-    cy.get('.hackney-property-alerts li.bg-turquoise').within(() => {
-      cy.contains('Tenure: Secure')
-    })
-
-    // Alerts
-    cy.get('.hackney-property-alerts').within(() => {
-      // Location alerts
-      cy.contains('Address Alert: Property Under Disrepair (DIS)')
-
-      // Person alerts
-      cy.contains('Contact Alert: No Lone Visits (CV)')
-      cy.contains('Contact Alert: Verbal Abuse or Threat of (VA)')
-    })
+    cy.checkForTenureAlertDetails(
+      'Tenure: Secure',
+      ['Address Alert: Property Under Disrepair (DIS)'],
+      [
+        'Contact Alert: No Lone Visits (CV)',
+        'Contact Alert: Verbal Abuse or Threat of (VA)',
+      ]
+    )
 
     // Run lighthouse audit for accessibility report
     cy.audit()

--- a/cypress/support/common-steps/checkForTenureAlertDetails.js
+++ b/cypress/support/common-steps/checkForTenureAlertDetails.js
@@ -1,0 +1,22 @@
+Cypress.Commands.add(
+  'checkForTenureAlertDetails',
+  (tenure, addressAlerts, contactAlerts) => {
+    // Tenure
+    cy.get('.hackney-property-alerts li.bg-turquoise').within(() => {
+      cy.contains(tenure)
+    })
+
+    // Alerts
+    cy.get('.hackney-property-alerts').within(() => {
+      // Location alerts
+      addressAlerts.forEach((alert) => {
+        cy.contains(alert)
+      })
+
+      // Person alerts
+      contactAlerts.forEach((alert) => {
+        cy.contains(alert)
+      })
+    })
+  }
+)

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,6 +16,8 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 import './audit'
+// Common steps in integration tests
+import './common-steps/checkForTenureAlertDetails'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/src/components/Form/Select/Select.js
+++ b/src/components/Form/Select/Select.js
@@ -37,6 +37,7 @@ const Select = ({
       className={`govuk-select ${widthClass}`}
       id={name}
       name={name}
+      data-testid={name}
       ref={register}
       aria-describedby={hint && `${name}-hint`}
       onChange={(e) => onChange && onChange(e.target.value)}

--- a/src/components/Form/Select/Select.js
+++ b/src/components/Form/Select/Select.js
@@ -16,6 +16,7 @@ const Select = ({
   disabled,
   register,
   widthClass,
+  required,
 }) => (
   <div
     id={`${name}-form-group`}
@@ -24,7 +25,7 @@ const Select = ({
     })}
   >
     <label className="govuk-label" htmlFor={name}>
-      {label}
+      {label} {required && <span className="govuk-required">*</span>}
     </label>
     {hint && (
       <span id={`${name}-hint`} className="govuk-hint">

--- a/src/components/Form/Select/Select.test.js
+++ b/src/components/Form/Select/Select.test.js
@@ -1,0 +1,26 @@
+import { render, fireEvent } from '@testing-library/react'
+import Select from './Select'
+
+describe('Select component', () => {
+  const props = {
+    label: 'Foo select',
+    name: 'fooSelect',
+    options: ['foo', 'bar'],
+  }
+
+  it('should render properly', () => {
+    const { getByRole, getByTestId } = render(<Select {...props} />)
+
+    expect(getByTestId('fooSelect')).toBeInTheDocument()
+    expect(getByRole('option', { name: 'bar' })).toBeInTheDocument()
+    expect(getByRole('option', { name: 'foo' })).toBeInTheDocument()
+  })
+
+  it('should handle selected option', () => {
+    const { getByRole, getByTestId } = render(<Select {...props} />)
+
+    fireEvent.change(getByTestId('fooSelect'), { target: { value: 'foo' } })
+    expect(getByRole('option', { name: 'foo' }).selected).toBeTruthy()
+    expect(getByRole('option', { name: 'bar' }).selected).toBeFalsy()
+  })
+})

--- a/src/components/Form/TextArea/TextArea.js
+++ b/src/components/Form/TextArea/TextArea.js
@@ -11,6 +11,7 @@ const TextArea = ({
   rows = 4,
   register,
   error,
+  required,
   ...otherProps
 }) => (
   <div
@@ -21,7 +22,7 @@ const TextArea = ({
   >
     {label && (
       <label className="govuk-label" htmlFor={name}>
-        {label}
+        {label} {required && <span className="govuk-required">*</span>}
       </label>
     )}
     {hint && (

--- a/src/components/Form/TextArea/TextArea.test.js
+++ b/src/components/Form/TextArea/TextArea.test.js
@@ -1,0 +1,37 @@
+import { fireEvent, render } from '@testing-library/react'
+import TextArea from './TextArea'
+
+describe('TextArea component', () => {
+  it('should render properly', () => {
+    const inputName = 'my-text-area'
+    const inputLabel = 'My text area'
+    const { getByLabelText } = render(
+      <TextArea name={inputName} label={inputLabel} />
+    )
+
+    const labelRegex = new RegExp(`s*${inputLabel}s*`)
+    const input = getByLabelText(labelRegex)
+
+    expect(input).toBeInTheDocument()
+    expect(input.id).toEqual(inputName)
+    expect(input.name).toEqual(inputName)
+  })
+
+  it('performs an action onChange', () => {
+    let newValue = ''
+    const myAction = jest.fn((e) => (newValue = e.target.value))
+    const { getByLabelText } = render(
+      <TextArea
+        name={'my-text-area'}
+        label={'My text area'}
+        onChange={myAction}
+      />
+    )
+
+    fireEvent.change(getByLabelText(/\s*My text area\s*/), {
+      target: { value: 'hello' },
+    })
+
+    expect(newValue).toEqual('hello')
+  })
+})

--- a/src/components/Form/TextInput/TextInput.js
+++ b/src/components/Form/TextInput/TextInput.js
@@ -10,6 +10,7 @@ const TextInput = ({
   error,
   type = 'text',
   widthClass,
+  required,
   ...otherProps
 }) => (
   <div
@@ -19,7 +20,7 @@ const TextInput = ({
     })}
   >
     <label className="govuk-label" htmlFor={name}>
-      {label}
+      {label} {required && <span className="govuk-required">*</span>}
     </label>
     {hint && (
       <span id={`${name}-hint`} className="govuk-hint">

--- a/src/components/Property/PropertyDetails.js
+++ b/src/components/Property/PropertyDetails.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import RaiseRepairStatus from './RaiseRepairStatus'
-import TenureAlertDetails from './TenureAlertDetails'
+import PropertyDetailsGrid from './PropertyDetailsGrid'
 import BackButton from '../Layout/BackButton/BackButton'
 
 const PropertyDetails = ({
@@ -25,38 +25,14 @@ const PropertyDetails = ({
           propertyReference={propertyReference}
         />
       </div>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-one-half">
-          <div className="govuk-body-s">
-            <div className="property-details-main-section">
-              <span className="govuk-body-xs">Property details</span>
-              <br></br>
-              <span className="govuk-!-font-weight-bold text-green">
-                {address.addressLine}
-              </span>
-              <br></br>
-              {address.streetSuffix && (
-                <>
-                  <span className="govuk-!-font-weight-bold text-green">
-                    {address.streetSuffix}
-                  </span>
-                  <br></br>
-                </>
-              )}
-              <span className="govuk-body-xs text-green">
-                {address.postalCode}
-              </span>
-            </div>
-
-            <TenureAlertDetails
-              canRaiseRepair={canRaiseRepair}
-              tenure={tenure}
-              locationAlerts={locationAlerts}
-              personAlerts={personAlerts}
-            />
-          </div>
-        </div>
-      </div>
+      <PropertyDetailsGrid
+        address={address}
+        locationAlerts={locationAlerts}
+        personAlerts={personAlerts}
+        subTypeDescription="Property details"
+        tenure={tenure}
+        canRaiseRepair={canRaiseRepair}
+      />
     </div>
   )
 }

--- a/src/components/Property/PropertyDetailsAddress.js
+++ b/src/components/Property/PropertyDetailsAddress.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types'
+
+const PropertyDetailsAddress = ({ address }) => {
+  return (
+    <>
+      {address.addressLine}
+      <br></br>
+      {address.streetSuffix && (
+        <>
+          <span className="govuk-!-font-weight-bold text-green">
+            {address.streetSuffix}
+          </span>
+          <br></br>
+        </>
+      )}
+
+      <span className="govuk-body-xs text-green">{address.postalCode}</span>
+    </>
+  )
+}
+
+PropertyDetailsAddress.propTypes = {
+  address: PropTypes.object.isRequired,
+}
+
+export default PropertyDetailsAddress

--- a/src/components/Property/PropertyDetailsGrid.js
+++ b/src/components/Property/PropertyDetailsGrid.js
@@ -1,0 +1,78 @@
+import PropTypes from 'prop-types'
+import TenureAlertDetails from './TenureAlertDetails'
+import Link from 'next/link'
+
+const PropertyDetailsGrid = ({
+  propertyReference,
+  address,
+  subTypeDescription,
+  locationAlerts,
+  personAlerts,
+  tenure,
+  hasLinkToProperty,
+  canRaiseRepair,
+}) => {
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-one-half">
+        <div className="govuk-body-s">
+          <div className="property-details-main-section">
+            <span className="govuk-body-xs">{subTypeDescription}</span>
+            <br></br>
+            <span className="govuk-!-font-weight-bold text-green">
+              {hasLinkToProperty ? (
+                <>
+                  <Link href={`/properties/${propertyReference}`}>
+                    <a>{address.addressLine}</a>
+                  </Link>
+                </>
+              ) : (
+                <>{address.addressLine}</>
+              )}
+            </span>
+            <br></br>
+            {address.streetSuffix && (
+              <>
+                <span className="govuk-!-font-weight-bold text-green">
+                  {hasLinkToProperty ? (
+                    <>
+                      <Link href={`/properties/${propertyReference}`}>
+                        <a>{address.streetSuffix}</a>
+                      </Link>
+                    </>
+                  ) : (
+                    <>{address.streetSuffix}</>
+                  )}
+                </span>
+                <br></br>
+              </>
+            )}
+            <span className="govuk-body-xs text-green">
+              {address.postalCode}
+            </span>
+          </div>
+
+          <TenureAlertDetails
+            tenure={tenure}
+            locationAlerts={locationAlerts}
+            personAlerts={personAlerts}
+            canRaiseRepair={canRaiseRepair}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+PropertyDetailsGrid.propTypes = {
+  propertyReference: PropTypes.string,
+  address: PropTypes.object.isRequired,
+  subTypeDescription: PropTypes.string,
+  locationAlerts: PropTypes.array.isRequired,
+  personAlerts: PropTypes.array.isRequired,
+  tenure: PropTypes.object.isRequired,
+  hasLinkToProperty: PropTypes.bool,
+  canRaiseRepair: PropTypes.bool,
+}
+
+export default PropertyDetailsGrid

--- a/src/components/Property/PropertyDetailsGrid.js
+++ b/src/components/Property/PropertyDetailsGrid.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import PropertyDetailsAddress from './PropertyDetailsAddress'
 import TenureAlertDetails from './TenureAlertDetails'
 import Link from 'next/link'
 
@@ -21,34 +22,14 @@ const PropertyDetailsGrid = ({
             <br></br>
             <span className="govuk-!-font-weight-bold text-green">
               {hasLinkToProperty ? (
-                <>
-                  <Link href={`/properties/${propertyReference}`}>
-                    <a>{address.addressLine}</a>
-                  </Link>
-                </>
+                <Link href={`/properties/${propertyReference}`}>
+                  <a>
+                    <PropertyDetailsAddress address={address} />
+                  </a>
+                </Link>
               ) : (
-                <>{address.addressLine}</>
+                <PropertyDetailsAddress address={address} />
               )}
-            </span>
-            <br></br>
-            {address.streetSuffix && (
-              <>
-                <span className="govuk-!-font-weight-bold text-green">
-                  {hasLinkToProperty ? (
-                    <>
-                      <Link href={`/properties/${propertyReference}`}>
-                        <a>{address.streetSuffix}</a>
-                      </Link>
-                    </>
-                  ) : (
-                    <>{address.streetSuffix}</>
-                  )}
-                </span>
-                <br></br>
-              </>
-            )}
-            <span className="govuk-body-xs text-green">
-              {address.postalCode}
             </span>
           </div>
 

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -8,6 +8,7 @@ import { buildRaiseRepairFormData } from '../../../utils/hact/raise-repair-form'
 import { GridRow, GridColumn } from '../../Layout/Grid'
 
 const RaiseRepairForm = ({
+  propertyReference,
   address,
   hierarchyType,
   canRaiseRepair,
@@ -26,7 +27,6 @@ const RaiseRepairForm = ({
   ]
 
   const onSubmit = async (formData) => {
-    console.log(formData)
     const raiseRepairFormData = buildRaiseRepairFormData(formData)
 
     onFormSubmit(raiseRepairFormData)
@@ -206,6 +206,22 @@ const RaiseRepairForm = ({
               </span>{' '}
               characters remaining.
             </span>
+            <input
+              id="propertyReference"
+              name="propertyReference"
+              label="propertyReference"
+              type="hidden"
+              value={propertyReference}
+              ref={register}
+            />
+            <input
+              id="shortAddress"
+              name="shortAddress"
+              label="shortAddress"
+              type="hidden"
+              value={address.shortAddress}
+              ref={register}
+            />
             <Button label="Create works order" type="submit" />
           </form>
         </div>
@@ -215,6 +231,7 @@ const RaiseRepairForm = ({
 }
 
 RaiseRepairForm.propTypes = {
+  propertyReference: PropTypes.string.isRequired,
   address: PropTypes.object.isRequired,
   hierarchyType: PropTypes.object.isRequired,
   canRaiseRepair: PropTypes.bool.isRequired,

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -120,6 +120,7 @@ const RaiseRepairForm = ({
                   label="SOR Code"
                   options={sorCodesList}
                   onChange={onSorCodeSelect}
+                  required={true}
                   register={register({
                     required: 'Please select an SOR code',
                     validate: (value) =>
@@ -142,6 +143,7 @@ const RaiseRepairForm = ({
                   label="Quantity"
                   error={errors && errors.quantity}
                   widthClass="govuk-!-width-full"
+                  required={true}
                   register={register({
                     required: 'Please enter a quantity',
                     valueAsNumber: true,
@@ -166,6 +168,7 @@ const RaiseRepairForm = ({
               label="Task priority"
               options={priorityList}
               onChange={onPrioritySelect}
+              required={true}
               register={register({
                 required: 'Please select a priority',
                 validate: (value) =>
@@ -186,6 +189,7 @@ const RaiseRepairForm = ({
               name="descriptionOfWork"
               label="Repair description"
               onKeyUp={characterCount}
+              required={true}
               register={register({
                 required: 'Please enter a repair description',
                 maxLength: {

--- a/src/components/Property/RaiseRepair/RaiseRepairFormSuccess.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormSuccess.js
@@ -21,6 +21,14 @@ const RaiseRepairFormSuccess = ({
 
       <ul className="govuk-list govuk-!-margin-top-9">
         <li>
+          <Link href={`/work-orders/${workOrderReference}`}>
+            <a>
+              <strong>View work order</strong>
+            </a>
+          </Link>
+        </li>
+
+        <li>
           <Link href={`/properties/${propertyReference}`}>
             <a>
               <strong>Back to {shortAddress}</strong>

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -73,7 +73,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
         <Spinner />
       ) : (
         <>
-          {formSuccess && (
+          {formSuccess && workOrderReference && (
             <RaiseRepairFormSuccess
               propertyReference={propertyReference}
               workOrderReference={workOrderReference}

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -89,6 +89,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
             personAlerts &&
             sorCodes && (
               <RaiseRepairForm
+                propertyReference={propertyReference}
                 address={property.address}
                 hierarchyType={property.hierarchyType}
                 canRaiseRepair={property.canRaiseRepair}

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -81,6 +81,7 @@ exports[`RaiseRepairForm component should render properly 1`] = `
                 </label>
                 <select
                   class="govuk-select govuk-!-width-full"
+                  data-testid="sorCode"
                   id="sorCode"
                   name="sorCode"
                 >
@@ -140,6 +141,7 @@ exports[`RaiseRepairForm component should render properly 1`] = `
             </label>
             <select
               class="govuk-select govuk-!-width-full"
+              data-testid="priorityDescription"
               id="priorityDescription"
               name="priorityDescription"
             >

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -217,6 +217,20 @@ exports[`RaiseRepairForm component should render properly 1`] = `
             </span>
              characters remaining.
           </span>
+          <input
+            id="propertyReference"
+            label="propertyReference"
+            name="propertyReference"
+            type="hidden"
+            value="00012345"
+          />
+          <input
+            id="shortAddress"
+            label="shortAddress"
+            name="shortAddress"
+            type="hidden"
+            value="16 Pitcairn House  St Thomass Square"
+          />
           <div
             class="govuk-form-group"
           >

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -77,7 +77,12 @@ exports[`RaiseRepairForm component should render properly 1`] = `
                   class="govuk-label"
                   for="sorCode"
                 >
-                  SOR Code
+                  SOR Code 
+                  <span
+                    class="govuk-required"
+                  >
+                    *
+                  </span>
                 </label>
                 <select
                   class="govuk-select govuk-!-width-full"
@@ -118,7 +123,12 @@ exports[`RaiseRepairForm component should render properly 1`] = `
                   class="govuk-label"
                   for="quantity"
                 >
-                  Quantity
+                  Quantity 
+                  <span
+                    class="govuk-required"
+                  >
+                    *
+                  </span>
                 </label>
                 <input
                   class="govuk-input govuk-!-width-full"
@@ -137,7 +147,12 @@ exports[`RaiseRepairForm component should render properly 1`] = `
               class="govuk-label"
               for="priorityDescription"
             >
-              Task priority
+              Task priority 
+              <span
+                class="govuk-required"
+              >
+                *
+              </span>
             </label>
             <select
               class="govuk-select govuk-!-width-full"
@@ -175,7 +190,12 @@ exports[`RaiseRepairForm component should render properly 1`] = `
               class="govuk-label"
               for="descriptionOfWork"
             >
-              Repair description
+              Repair description 
+              <span
+                class="govuk-required"
+              >
+                *
+              </span>
             </label>
             <textarea
               aria-describedby="descriptionOfWork-hint descriptionOfWork-error"

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairFormSuccess.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairFormSuccess.test.js.snap
@@ -28,6 +28,15 @@ exports[`RaiseRepairFormSuccess component should render properly 1`] = `
     >
       <li>
         <a
+          href="/work-orders/10000000"
+        >
+          <strong>
+            View work order
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
           href="/properties/00012345"
         >
           <strong>

--- a/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
+++ b/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
@@ -49,18 +49,18 @@ exports[`PropertyDetails component should render properly 1`] = `
               class="govuk-!-font-weight-bold text-green"
             >
               16 Pitcairn House
-            </span>
-            <br />
-            <span
-              class="govuk-!-font-weight-bold text-green"
-            >
-              St Thomass Square
-            </span>
-            <br />
-            <span
-              class="govuk-body-xs text-green"
-            >
-              E9 6PT
+              <br />
+              <span
+                class="govuk-!-font-weight-bold text-green"
+              >
+                St Thomass Square
+              </span>
+              <br />
+              <span
+                class="govuk-body-xs text-green"
+              >
+                E9 6PT
+              </span>
             </span>
           </div>
           <ul

--- a/src/components/WorkOrder/WorkOrderDetails.js
+++ b/src/components/WorkOrder/WorkOrderDetails.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types'
+import PropertyDetailsGrid from '../Property/PropertyDetailsGrid'
+
+const WorkOrderDetails = ({
+  propertyReference,
+  workOrder,
+  address,
+  subTypeDescription,
+  locationAlerts,
+  personAlerts,
+  tenure,
+  canRaiseRepair,
+}) => {
+  return (
+    <div>
+      <h1 className="govuk-heading-l">Works order: {workOrder.reference}</h1>
+      <p className="govuk-body-m">{workOrder.description}</p>
+
+      <PropertyDetailsGrid
+        propertyReference={propertyReference}
+        address={address}
+        locationAlerts={locationAlerts}
+        personAlerts={personAlerts}
+        subTypeDescription={subTypeDescription}
+        tenure={tenure}
+        hasLinkToProperty={true}
+        canRaiseRepair={canRaiseRepair}
+      />
+    </div>
+  )
+}
+
+WorkOrderDetails.propTypes = {
+  propertyReference: PropTypes.string.isRequired,
+  workOrder: PropTypes.object.isRequired,
+  address: PropTypes.object.isRequired,
+  subTypeDescription: PropTypes.string.isRequired,
+  locationAlerts: PropTypes.array.isRequired,
+  personAlerts: PropTypes.array.isRequired,
+  tenure: PropTypes.object.isRequired,
+  canRaiseRepair: PropTypes.bool.isRequired,
+}
+
+export default WorkOrderDetails

--- a/src/components/WorkOrder/WorkOrderDetails.test.js
+++ b/src/components/WorkOrder/WorkOrderDetails.test.js
@@ -1,8 +1,18 @@
 import { render } from '@testing-library/react'
-import RaiseRepairForm from './RaiseRepairForm'
+import WorkOrderDetails from './WorkOrderDetails'
 
-describe('RaiseRepairForm component', () => {
+describe('WorkOrderDetails component', () => {
   const props = {
+    workOrder: {
+      reference: 10000012,
+      dateRaised: '2021-01-18T15:28:57.17811',
+      lastUpdated: null,
+      priority: 'U - Urgent (5 Working days)',
+      property: '',
+      owner: '',
+      description: 'This is an urgent repair description',
+      propertyReference: '00014888',
+    },
     property: {
       propertyReference: '00012345',
       address: {
@@ -40,44 +50,20 @@ describe('RaiseRepairForm component', () => {
       typeCode: 'SEC',
       typeDescription: 'Secure',
     },
-    sorCodes: [
-      {
-        customCode: 'DES5R003',
-        customName: 'Immediate call outs',
-        priority: {
-          priorityCode: 1,
-          description: 'I - Immediate (2 hours)',
-        },
-        sorContractor: {
-          reference: 'H01',
-        },
-      },
-      {
-        customCode: 'DES5R004',
-        customName: 'Emergency call outs',
-        priority: {
-          priorityCode: 2,
-          description: 'E - Emergency (24 hours)',
-        },
-        sorContractor: {
-          reference: 'H01',
-        },
-      },
-    ],
-    onFormSubmit: jest.fn(),
   }
 
   it('should render properly', () => {
     const { asFragment } = render(
-      <RaiseRepairForm
+      <WorkOrderDetails
         propertyReference={props.property.propertyReference}
+        workOrder={props.workOrder}
         address={props.property.address}
-        hierarchyType={props.property.hierarchyType}
-        canRaiseRepair={props.property.canRaiseRepair}
+        subTypeDescription={props.property.hierarchyType.subTypeDescription}
         tenure={props.tenure}
         locationAlerts={props.alerts.locationAlert}
         personAlerts={props.alerts.personAlert}
-        sorCodes={props.sorCodes}
+        hasLinkToProperty={true}
+        canRaiseRepair={props.property.canRaiseRepair}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/WorkOrder/WorkOrderView.js
+++ b/src/components/WorkOrder/WorkOrderView.js
@@ -1,0 +1,83 @@
+import PropTypes from 'prop-types'
+import { useState, useEffect } from 'react'
+import WorkOrderDetails from './WorkOrderDetails'
+import Spinner from '../Spinner/Spinner'
+import ErrorMessage from '../Errors/ErrorMessage/ErrorMessage'
+import { getRepair } from '../../utils/frontend-api-client/repairs'
+import { getProperty } from '../../utils/frontend-api-client/properties'
+
+const WorkOrderView = ({ workOrderReference }) => {
+  const [property, setProperty] = useState({})
+  const [workOrder, setWorkOrder] = useState({})
+  const [locationAlerts, setLocationAlerts] = useState([])
+  const [personAlerts, setPersonAlerts] = useState([])
+  const [tenure, setTenure] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState()
+
+  const getWorkOrderView = async (workOrderReference) => {
+    setError(null)
+
+    try {
+      const workOrder = await getRepair(workOrderReference)
+      const propertyObject = await getProperty(workOrder.propertyReference)
+
+      setWorkOrder(workOrder)
+      setProperty(propertyObject.property)
+      setLocationAlerts(propertyObject.alerts.locationAlert)
+      setPersonAlerts(propertyObject.alerts.personAlert)
+      if (propertyObject.tenure) setTenure(propertyObject.tenure)
+    } catch (e) {
+      setWorkOrder(null)
+      setProperty(null)
+      console.log('An error has occured:', e.response)
+      setError(
+        `Oops an error occurred with error status: ${e.response?.status}`
+      )
+    }
+
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    setLoading(true)
+
+    getWorkOrderView(workOrderReference)
+  }, [])
+
+  return (
+    <>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <>
+          {property &&
+            property.address &&
+            property.hierarchyType &&
+            tenure &&
+            locationAlerts &&
+            personAlerts &&
+            workOrder && (
+              <WorkOrderDetails
+                propertyReference={property.propertyReference}
+                workOrder={workOrder}
+                address={property.address}
+                tenure={tenure}
+                subTypeDescription={property.hierarchyType.subTypeDescription}
+                locationAlerts={locationAlerts}
+                personAlerts={personAlerts}
+                canRaiseRepair={property.canRaiseRepair}
+              />
+            )}
+          {error && <ErrorMessage label={error} />}
+        </>
+      )}
+    </>
+  )
+}
+
+WorkOrderView.propTypes = {
+  workOrderReference: PropTypes.string.isRequired,
+}
+
+export default WorkOrderView

--- a/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
@@ -38,23 +38,19 @@ exports[`WorkOrderDetails component should render properly 1`] = `
                 href="/properties/00012345"
               >
                 16 Pitcairn House
+                <br />
+                <span
+                  class="govuk-!-font-weight-bold text-green"
+                >
+                  St Thomass Square
+                </span>
+                <br />
+                <span
+                  class="govuk-body-xs text-green"
+                >
+                  E9 6PT
+                </span>
               </a>
-            </span>
-            <br />
-            <span
-              class="govuk-!-font-weight-bold text-green"
-            >
-              <a
-                href="/properties/00012345"
-              >
-                St Thomass Square
-              </a>
-            </span>
-            <br />
-            <span
-              class="govuk-body-xs text-green"
-            >
-              E9 6PT
             </span>
           </div>
           <ul

--- a/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WorkOrderDetails component should render properly 1`] = `
+<DocumentFragment>
+  <div>
+    <h1
+      class="govuk-heading-l"
+    >
+      Works order: 10000012
+    </h1>
+    <p
+      class="govuk-body-m"
+    >
+      This is an urgent repair description
+    </p>
+    <div
+      class="govuk-grid-row"
+    >
+      <div
+        class="govuk-grid-column-one-half"
+      >
+        <div
+          class="govuk-body-s"
+        >
+          <div
+            class="property-details-main-section"
+          >
+            <span
+              class="govuk-body-xs"
+            >
+              Dwelling
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-weight-bold text-green"
+            >
+              <a
+                href="/properties/00012345"
+              >
+                16 Pitcairn House
+              </a>
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-weight-bold text-green"
+            >
+              <a
+                href="/properties/00012345"
+              >
+                St Thomass Square
+              </a>
+            </span>
+            <br />
+            <span
+              class="govuk-body-xs text-green"
+            >
+              E9 6PT
+            </span>
+          </div>
+          <ul
+            class="hackney-property-alerts"
+          >
+            <li
+              class="bg-turquoise"
+            >
+              Tenure: Secure
+            </li>
+            <li
+              class="bg-orange"
+            >
+              Address Alert:  (
+              <strong />
+              )
+            </li>
+            <li
+              class="bg-orange"
+            >
+              Contact Alert:  (
+              <strong />
+              )
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/pages/work-orders/[id].js
+++ b/src/pages/work-orders/[id].js
@@ -1,0 +1,17 @@
+import WorkOrderView from '../../components/WorkOrder/WorkOrderView'
+
+const WorkOrderPage = ({ query }) => {
+  return <WorkOrderView workOrderReference={query.id} />
+}
+
+export const getServerSideProps = async (ctx) => {
+  const { query } = ctx
+
+  return {
+    props: {
+      query,
+    },
+  }
+}
+
+export default WorkOrderPage

--- a/src/utils/frontend-api-client/repairs.js
+++ b/src/utils/frontend-api-client/repairs.js
@@ -11,3 +11,9 @@ export const getRepairs = async () => {
 
   return data
 }
+
+export const getRepair = async (workOrderReference) => {
+  const { data } = await axios.get(`/api/repairs/${workOrderReference}`)
+
+  return data
+}

--- a/src/utils/frontend-api-client/repairs.test.js
+++ b/src/utils/frontend-api-client/repairs.test.js
@@ -1,4 +1,4 @@
-import { postRepair, getRepair } from './repairs'
+import { postRepair, getRepair, getRepairs } from './repairs'
 import mockAxios from '../__mocks__/axios'
 
 describe('postRepair', () => {
@@ -31,5 +31,23 @@ describe('getRepair', () => {
     expect(response).toEqual(responseData)
     expect(mockAxios.get).toHaveBeenCalledTimes(1)
     expect(mockAxios.get).toHaveBeenCalledWith('/api/repairs/10000012')
+  })
+})
+
+describe('getRepairs', () => {
+  it('calls the Next JS API', async () => {
+    const responseData = { data: 'test' }
+
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: responseData,
+      })
+    )
+
+    const response = await getRepairs()
+
+    expect(response).toEqual(responseData)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith('/api/repairs')
   })
 })

--- a/src/utils/frontend-api-client/repairs.test.js
+++ b/src/utils/frontend-api-client/repairs.test.js
@@ -1,4 +1,4 @@
-import { postRepair } from './repairs'
+import { postRepair, getRepair } from './repairs'
 import mockAxios from '../__mocks__/axios'
 
 describe('postRepair', () => {
@@ -13,5 +13,23 @@ describe('postRepair', () => {
       foo: 'bar',
     })
     expect(formData).toEqual('foobar')
+  })
+})
+
+describe('getRepair', () => {
+  it('calls the Next JS API', async () => {
+    const responseData = { data: 'test' }
+
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: responseData,
+      })
+    )
+
+    const response = await getRepair('10000012')
+
+    expect(response).toEqual(responseData)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith('/api/repairs/10000012')
   })
 })

--- a/src/utils/hact/raise-repair-form.js
+++ b/src/utils/hact/raise-repair-form.js
@@ -13,6 +13,7 @@ export const buildRaiseRepairFormData = (formData) => {
       requiredCompletionDateTime: calculateRequiredCompletionDateTime(
         mapPriorityCodeToHact[formData.priorityCode].numberOfHours
       ),
+      numberOfDays: mapPriorityCodeToHact[formData.priorityCode].numberOfDays,
     },
     workClass: {
       workClassCode: 0,
@@ -26,6 +27,18 @@ export const buildRaiseRepairFormData = (formData) => {
             quantity: {
               amount: [Number.parseInt(formData.quantity)],
             },
+          },
+        ],
+      },
+    ],
+    sitePropertyUnit: [
+      {
+        address: {
+          addressLine: [formData.shortAddress],
+        },
+        reference: [
+          {
+            id: formData.propertyReference,
           },
         ],
       },

--- a/src/utils/hact/raise-repair-form.test.js
+++ b/src/utils/hact/raise-repair-form.test.js
@@ -13,6 +13,8 @@ describe('buildRaiseRepairFormData', () => {
       priorityDescription: 'U - Urgent (5 Working days)',
       priorityCode: '3',
       descriptionOfWork: 'This is an urgent test description',
+      propertyReference: '00001234',
+      shortAddress: '12 Pitcairn House',
     }
 
     const raiseRepairFormData = {
@@ -21,6 +23,7 @@ describe('buildRaiseRepairFormData', () => {
         priorityCode: 2,
         priorityDescription: 'U - Urgent (5 Working days)',
         requiredCompletionDateTime: new Date('2021-01-21T18:16:20.986Z'),
+        numberOfDays: 7,
       },
       workClass: {
         workClassCode: 0,
@@ -32,6 +35,18 @@ describe('buildRaiseRepairFormData', () => {
               customCode: 'DES5R006',
               customName: 'Urgent call outs',
               quantity: { amount: [1] },
+            },
+          ],
+        },
+      ],
+      sitePropertyUnit: [
+        {
+          address: {
+            addressLine: ['12 Pitcairn House'],
+          },
+          reference: [
+            {
+              id: '00001234',
             },
           ],
         },


### PR DESCRIPTION
### **Description of change**
- Display work order show page
- Shows repair description
- Shows property/tenure/alert details
- Adds link from raise repair success screen to "View work order"

### **Link to trello**
https://trello.com/c/KzfYg9zi/100-as-a-repairs-hub-user-i-can-select-and-view-the-work-order-so-that-i-can-view-the-details-of-the-job
https://trello.com/c/e5yVhXHL/315-as-a-repairs-hub-user-i-can-select-and-view-the-work-order-property-information-so-that-i-can-view-the-details-of-the-job

### **Link to view work order after raising a repair**
![Screenshot 2021-01-22 at 11 50 06](https://user-images.githubusercontent.com/34001723/105489325-f46e5800-5caa-11eb-92fa-d197536e51c1.png)

### **Work order view page with property details**
![Screenshot 2021-01-22 at 11 53 19](https://user-images.githubusercontent.com/34001723/105489335-f9330c00-5caa-11eb-9f45-cdc539431d42.png)

