### PR TITLE
Add repairs history table for a property

### DIFF
--- a/cypress/fixtures/repairs/work-orders.json
+++ b/cypress/fixtures/repairs/work-orders.json
@@ -1,0 +1,46 @@
+[
+  {
+    "reference": 10000040,
+    "dateRaised": "2021-01-22T11:02:00.334849",
+    "lastUpdated": null,
+    "priority": "E - Emergency (24 hours)",
+    "property": "315 Banister House  Homerton High Street",
+    "owner": "",
+    "description": "An emergency repair",
+    "propertyReference": "00012345",
+    "status": "In progress"
+  },
+  {
+    "reference": 10000037,
+    "dateRaised": "2021-01-21T16:46:35.960727",
+    "lastUpdated": null,
+    "priority": "U - Urgent 7 days (5 Working days)",
+    "property": "315 Banister House  Homerton High Street",
+    "owner": "",
+    "description": "A very urgent repair",
+    "propertyReference": "00012345",
+    "status": "Work complete"
+  },
+  {
+    "reference": 10000036,
+    "dateRaised": "2021-01-21T16:41:07.417519",
+    "lastUpdated": null,
+    "priority": "I - Immediate (2 hours)",
+    "property": "315 Banister House  Homerton High Street",
+    "owner": "",
+    "description": "An immediate repair",
+    "propertyReference": "00012345",
+    "status": "Work complete"
+  },
+  {
+    "reference": 10000035,
+    "dateRaised": "2021-01-21T15:03:09.432105",
+    "lastUpdated": null,
+    "priority": "N - Normal 28 days (21 working days)",
+    "property": "315 Banister House  Homerton High Street",
+    "owner": "",
+    "description": "A normal repair",
+    "propertyReference": "00012345",
+    "status": "In progress"
+  }
+]

--- a/cypress/integration/show_property.spec.js
+++ b/cypress/integration/show_property.spec.js
@@ -15,6 +15,12 @@ describe('Show property', () => {
         // Stub request with property response
         cy.fixture('properties/property.json').as('property')
         cy.route('GET', 'api/properties/00012345', '@property')
+        cy.fixture('repairs/work-orders.json').as('workOrders')
+        cy.route(
+          'GET',
+          'api/repairs/?propertyReference=00012345',
+          '@workOrders'
+        )
         cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
       })
 
@@ -46,9 +52,61 @@ describe('Show property', () => {
             'Contact Alert: Verbal Abuse or Threat of (VA)',
           ]
         )
+      })
+
+      it('Display the repairs history for the property', () => {
+        cy.get('.govuk-tabs').within(() => {
+          cy.get('.govuk-tabs__tab').contains('Repairs history')
+          cy.get('.govuk-heading-l').contains('Repairs history')
+
+          // Repairs history table headers
+          cy.get('.govuk-table').within(() => {
+            cy.contains('th', 'Reference')
+            cy.contains('th', 'Date raised')
+            cy.contains('th', 'Status')
+            cy.contains('th', 'Description')
+          })
+          // Repairs history table rows
+          cy.get('[data-ref=10000040]').within(() => {
+            cy.contains('10000040')
+            cy.contains('22 Jan 2021')
+            cy.contains('11:02 am')
+            cy.contains('In progress')
+            cy.contains('An emergency repair')
+          })
+          cy.get('[data-ref=10000037]').within(() => {
+            cy.contains('10000037')
+            cy.contains('21 Jan 2021')
+            cy.contains('4:46 pm')
+            cy.contains('Work complete')
+            cy.contains('A very urgent repair')
+          })
+          cy.get('[data-ref=10000036]').within(() => {
+            cy.contains('10000036')
+            cy.contains('21 Jan 2021')
+            cy.contains('4:41 pm')
+            cy.contains('Work complete')
+            cy.contains('An immediate repair')
+          })
+          cy.get('[data-ref=10000035]').within(() => {
+            cy.contains('10000035')
+            cy.contains('21 Jan 2021')
+            cy.contains('3:03 pm')
+            cy.contains('In progress')
+            cy.contains('A normal repair')
+          })
+        })
 
         // Run lighthouse audit for accessibility report
         cy.audit()
+      })
+
+      it('Display no repairs text when records do not exist', () => {
+        cy.route('GET', 'api/repairs/?propertyReference=00012345', '[]')
+
+        cy.get('.govuk-tabs__tab').contains('Repairs history')
+        cy.get('.govuk-heading-l').contains('Repairs history')
+        cy.get('.govuk-heading-s').contains('There are no historical repairs')
       })
     }
   )
@@ -85,6 +143,11 @@ describe('Show property', () => {
 
       it('does not show Alerts section', () => {
         cy.get('.hackney-property-alerts').should('not.exist')
+      })
+
+      it('does not show the Repairs history tab', () => {
+        // No repairs history
+        cy.contains('Repairs history').should('not.exist')
 
         // Run lighthouse audit for accessibility report
         cy.audit()
@@ -111,6 +174,11 @@ describe('Show property', () => {
     it('does not show Tenure', () => {
       cy.get('.hackney-property-alerts').should('not.exist')
       cy.contains('Tenure').should('not.exist')
+    })
+
+    it('does not show the Repairs history tab', () => {
+      // No repairs history
+      cy.contains('Repairs history').should('not.exist')
 
       // Run lighthouse audit for accessibility report
       cy.audit()

--- a/cypress/integration/show_work_order.spec.js
+++ b/cypress/integration/show_work_order.spec.js
@@ -2,7 +2,7 @@
 
 import 'cypress-audit/commands'
 
-describe('Search for property', () => {
+describe('Show work order', () => {
   beforeEach(() => {
     cy.login()
     cy.server()

--- a/src/components/Property/PropertyDetails.js
+++ b/src/components/Property/PropertyDetails.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import RaiseRepairStatus from './RaiseRepairStatus'
 import PropertyDetailsGrid from './PropertyDetailsGrid'
+import RepairsHistoryView from './RepairsHistory/RepairsHistoryView'
 import BackButton from '../Layout/BackButton/BackButton'
 
 const PropertyDetails = ({
@@ -33,6 +34,9 @@ const PropertyDetails = ({
         tenure={tenure}
         canRaiseRepair={canRaiseRepair}
       />
+      {canRaiseRepair && (
+        <RepairsHistoryView propertyReference={propertyReference} />
+      )}
     </div>
   )
 }

--- a/src/components/Property/PropertyDetails.test.js
+++ b/src/components/Property/PropertyDetails.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import PropertyDetails from './PropertyDetails'
 
 describe('PropertyDetails component', () => {
@@ -21,16 +21,16 @@ describe('PropertyDetails component', () => {
     alerts: {
       locationAlert: [
         {
-          alertCode: 'DIS',
-          description: 'Property Under Disrepair',
+          type: 'DIS',
+          comments: 'Property Under Disrepair',
           startDate: '2011-02-16',
           endDate: null,
         },
       ],
       personAlert: [
         {
-          alertCode: 'DIS',
-          description: 'Property Under Disrepair',
+          type: 'DIS',
+          comments: 'Property Under Disrepair',
           startDate: '2011-08-16',
           endDate: null,
         },
@@ -42,18 +42,20 @@ describe('PropertyDetails component', () => {
     },
   }
 
-  it('should render properly', () => {
-    const { asFragment } = render(
-      <PropertyDetails
-        propertyReference={props.property.propertyReference}
-        address={props.property.address}
-        hierarchyType={props.property.hierarchyType}
-        canRaiseRepair={props.property.canRaiseRepair}
-        tenure={props.tenure}
-        locationAlerts={props.alerts.locationAlert}
-        personAlerts={props.alerts.personAlert}
-      />
-    )
-    expect(asFragment()).toMatchSnapshot()
+  it('should render properly', async () => {
+    await act(async () => {
+      const { asFragment } = render(
+        <PropertyDetails
+          propertyReference={props.property.propertyReference}
+          address={props.property.address}
+          hierarchyType={props.property.hierarchyType}
+          canRaiseRepair={props.property.canRaiseRepair}
+          tenure={props.tenure}
+          locationAlerts={props.alerts.locationAlert}
+          personAlerts={props.alerts.personAlert}
+        />
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
   })
 })

--- a/src/components/Property/RepairsHistory/RepairsHistoryRow.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryRow.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import { dateToStr } from '../../../utils/date'
+import { extractTimeFromDate } from '../../../utils/time'
+
+const RepairsHistoryRow = ({ reference, dateRaised, description, status }) => (
+  <tr
+    className="govuk-table__row govuk-table__row--clickable govuk-body-s"
+    data-ref={reference}
+  >
+    <td className="govuk-table__cell">
+      <Link href={`/work-orders/${reference}`}>
+        <a>{reference}</a>
+      </Link>
+    </td>
+    <td className="govuk-table__cell">
+      {dateRaised ? dateToStr(dateRaised) : '—'}
+      <div className="work-order-hours">
+        {dateRaised ? extractTimeFromDate(dateRaised) : ''}
+      </div>
+    </td>
+    <td className="govuk-table__cell">
+      <span
+        className={`status status-${status.replace(/\s+/g, '-').toLowerCase()}`}
+      >
+        {status}
+      </span>
+    </td>
+    <td className="govuk-table__cell description">{description}</td>
+  </tr>
+)
+
+RepairsHistoryRow.propTypes = {
+  reference: PropTypes.number.isRequired,
+  dateRaised: PropTypes.instanceOf(Date),
+  description: PropTypes.string.isRequired,
+  status: PropTypes.string.isRequired,
+}
+
+export default RepairsHistoryRow

--- a/src/components/Property/RepairsHistory/RepairsHistoryTable.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryTable.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types'
+import RepairsHistoryRow from './RepairsHistoryRow'
+
+const RepairsHistoryTable = ({ workOrders }) => (
+  <table className="govuk-table govuk-!-margin-top-5 repairs-history-table">
+    <thead className="govuk-table__head">
+      <tr className="govuk-table__row govuk-body">
+        <th scope="col" className="govuk-table__header">
+          Reference
+        </th>
+        <th scope="col" className="govuk-table__header">
+          Date raised
+        </th>
+        <th scope="col" className="govuk-table__header">
+          Status
+        </th>
+        <th scope="col" className="govuk-table__header">
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody className="govuk-table__body">
+      {workOrders.map((workOrder, index) => (
+        <RepairsHistoryRow key={index} {...workOrder} />
+      ))}
+    </tbody>
+  </table>
+)
+
+RepairsHistoryTable.propTypes = {
+  workOrders: PropTypes.arrayOf(
+    PropTypes.shape({
+      reference: PropTypes.number,
+      dateRaised: PropTypes.instanceOf(Date),
+      status: PropTypes.string,
+      description: PropTypes.string,
+    })
+  ).isRequired,
+}
+
+export default RepairsHistoryTable

--- a/src/components/Property/RepairsHistory/RepairsHistoryTable.test.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryTable.test.js
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react'
+import RepairsHistoryTable from './RepairsHistoryTable'
+
+describe('RepairsHistoryTable component', () => {
+  const props = {
+    workOrders: [
+      {
+        reference: 10000012,
+        dateRaised: new Date('2021-01-18T15:28:57.17811'),
+        lastUpdated: null,
+        priority: 'I - Immediate (2 hours)',
+        property: '16 Pitcairn House  St Thomass Square',
+        owner: '',
+        description: 'This is an immediate repair description',
+        propertyReference: '00012345',
+        status: 'In progress',
+      },
+      {
+        reference: 10000013,
+        dateRaised: new Date('2021-01-23T16:28:57.17811'),
+        lastUpdated: null,
+        priority: 'U - Urgent (5 Working days)',
+        property: '16 Pitcairn House  St Thomass Square',
+        owner: '',
+        description: 'This is an urgent repair description',
+        propertyReference: '00012345',
+        status: 'In progress',
+      },
+    ],
+  }
+
+  it('should render properly', () => {
+    const { asFragment } = render(
+      <RepairsHistoryTable workOrders={props.workOrders} />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/components/Property/RepairsHistory/RepairsHistoryView.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryView.js
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types'
+import { useState, useEffect } from 'react'
+import RepairsHistoryTable from './RepairsHistoryTable'
+import Spinner from '../../Spinner/Spinner'
+import ErrorMessage from '../../Errors/ErrorMessage/ErrorMessage'
+import { getRepairs } from '../../../utils/frontend-api-client/repairs'
+import { sortedByDate } from '../../../utils/date'
+
+const RepairsHistoryView = ({ propertyReference }) => {
+  const [workOrders, setWorkOrders] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState()
+
+  const getRepairsHistoryView = async (propertyReference) => {
+    setError(null)
+
+    try {
+      const data = await getRepairs(propertyReference)
+
+      setWorkOrders(sortedByDate(data))
+    } catch (e) {
+      setWorkOrders(null)
+      console.log('An error has occured:', e.response)
+      setError(
+        `Oops an error occurred with error status: ${e.response?.status}`
+      )
+    }
+
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    setLoading(true)
+
+    getRepairsHistoryView(propertyReference)
+  }, [])
+
+  const renderRepairsHistoryTable = () => {
+    if (workOrders?.length > 0) {
+      return <RepairsHistoryTable workOrders={workOrders} />
+    }
+
+    if (!error) {
+      return (
+        <>
+          <div>
+            <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+            <p className="govuk-heading-s">There are no historical repairs</p>
+          </div>
+        </>
+      )
+    }
+  }
+
+  return (
+    <div>
+      <div className="govuk-tabs" data-module="tabs">
+        <h2 className="govuk-tabs__title">Contents</h2>
+
+        <ul className="govuk-tabs__list hackney-tabs-list">
+          <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
+            <a className="govuk-tabs__tab" href="#repairs-history-tab">
+              Repairs history
+            </a>
+          </li>
+        </ul>
+
+        <div
+          className="govuk-tabs__panel hackney-tabs-panel"
+          id="repairs-history-tab"
+        >
+          <h2 className="govuk-heading-l">Repairs history</h2>
+          {loading ? (
+            <Spinner />
+          ) : (
+            <>
+              {workOrders && renderRepairsHistoryTable()}
+              {error && <ErrorMessage label={error} />}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+RepairsHistoryView.propTypes = {
+  propertyReference: PropTypes.string.isRequired,
+}
+
+export default RepairsHistoryView

--- a/src/components/Property/RepairsHistory/__snapshots__/RepairsHistoryTable.test.js.snap
+++ b/src/components/Property/RepairsHistory/__snapshots__/RepairsHistoryTable.test.js.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RepairsHistoryTable component should render properly 1`] = `
+<DocumentFragment>
+  <table
+    class="govuk-table govuk-!-margin-top-5 repairs-history-table"
+  >
+    <thead
+      class="govuk-table__head"
+    >
+      <tr
+        class="govuk-table__row govuk-body"
+      >
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Reference
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Date raised
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Status
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="govuk-table__body"
+    >
+      <tr
+        class="govuk-table__row govuk-table__row--clickable govuk-body-s"
+        data-ref="10000012"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            href="/work-orders/10000012"
+          >
+            10000012
+          </a>
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          18 Jan 2021
+          <div
+            class="work-order-hours"
+          >
+            3:28 pm
+          </div>
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          <span
+            class="status status-in-progress"
+          >
+            In progress
+          </span>
+        </td>
+        <td
+          class="govuk-table__cell description"
+        >
+          This is an immediate repair description
+        </td>
+      </tr>
+      <tr
+        class="govuk-table__row govuk-table__row--clickable govuk-body-s"
+        data-ref="10000013"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            href="/work-orders/10000013"
+          >
+            10000013
+          </a>
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          23 Jan 2021
+          <div
+            class="work-order-hours"
+          >
+            4:28 pm
+          </div>
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          <span
+            class="status status-in-progress"
+          >
+            In progress
+          </span>
+        </td>
+        <td
+          class="govuk-table__cell description"
+        >
+          This is an urgent repair description
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;

--- a/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
+++ b/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
@@ -74,18 +74,68 @@ exports[`PropertyDetails component should render properly 1`] = `
             <li
               class="bg-orange"
             >
-              Address Alert:  (
-              <strong />
+              Address Alert: Property Under Disrepair (
+              <strong>
+                DIS
+              </strong>
               )
             </li>
             <li
               class="bg-orange"
             >
-              Contact Alert:  (
-              <strong />
+              Contact Alert: Property Under Disrepair (
+              <strong>
+                DIS
+              </strong>
               )
             </li>
           </ul>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        class="govuk-tabs"
+        data-module="tabs"
+      >
+        <h2
+          class="govuk-tabs__title"
+        >
+          Contents
+        </h2>
+        <ul
+          class="govuk-tabs__list hackney-tabs-list"
+        >
+          <li
+            class="govuk-tabs__list-item govuk-tabs__list-item--selected"
+          >
+            <a
+              class="govuk-tabs__tab"
+              href="#repairs-history-tab"
+            >
+              Repairs history
+            </a>
+          </li>
+        </ul>
+        <div
+          class="govuk-tabs__panel hackney-tabs-panel"
+          id="repairs-history-tab"
+        >
+          <h2
+            class="govuk-heading-l"
+          >
+            Repairs history
+          </h2>
+          <div>
+            <hr
+              class="govuk-section-break govuk-section-break--l govuk-section-break--visible"
+            />
+            <p
+              class="govuk-heading-s"
+            >
+              There are no historical repairs
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -10,3 +10,4 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
 @import 'components/property-details';
 @import 'components/form';
 @import 'components/work-orders';
+@import 'components/tabs';

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -4,7 +4,10 @@ $repairs-hub-colours: (
   'housing-3': #2dccd3,
   'warning': #ffa300,
   'white': govuk-colour('white'),
+  'black': govuk-colour('black'),
   'grey': grey,
+  'light-grey': #bfc1c3,
+  'status-planned': #009ca6,
 );
 
 @function repairs-hub-colour($colour) {

--- a/src/styles/components/tabs.scss
+++ b/src/styles/components/tabs.scss
@@ -1,0 +1,16 @@
+.hackney-tabs-list > li {
+  &:focus {
+    outline: 3px solid repairs-hub-colour('housing-2');
+  }
+  a:focus {
+    background-color: repairs-hub-colour('housing-2');
+    box-shadow: 0 -2px repairs-hub-colour('housing-2'),
+      0 4px repairs-hub-colour('black');
+  }
+}
+
+.hackney-tabs-panel {
+  border: none !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}

--- a/src/styles/components/work-orders.scss
+++ b/src/styles/components/work-orders.scss
@@ -14,3 +14,31 @@
     margin: 0;
   }
 }
+
+.repairs-history-table {
+  tbody {
+    vertical-align: top;
+  }
+
+  td {
+    white-space: nowrap;
+    &.description {
+      white-space: normal;
+      max-width: 400px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .status {
+      color: govuk-colour('white');
+      padding: 4px 10px;
+      font-weight: bold;
+      display: inline-block;
+      width: 90%;
+      max-width: 150px;
+      text-align: center;
+    }
+    .status-in-progress {
+      background-color: repairs-hub-colour('status-planned');
+    }
+  }
+}

--- a/src/utils/frontend-api-client/repairs.js
+++ b/src/utils/frontend-api-client/repairs.js
@@ -6,7 +6,14 @@ export const postRepair = async (formData) => {
   return data
 }
 
-export const getRepairs = async () => {
+export const getRepairs = async (propertyReference = null) => {
+  if (propertyReference) {
+    const { data } = await axios.get(
+      `/api/repairs/?propertyReference=${propertyReference}`
+    )
+
+    return data
+  }
   const { data } = await axios.get('/api/repairs')
 
   return data


### PR DESCRIPTION
### Description of change

- Render work orders within table inside Repairs history tab with columns: Reference, Date raised, Status, Trade, Description
- Search for these work orders using propRef parameter on /repairs/?propertyReference=${ref} endpoint
- Add snapshot and integration tests
- Don't render repairs history component if canRaiseRepair is false on property

### Story Link

https://trello.com/c/KDGxtwH2/107-as-an-agent-i-can-view-repairs-history-on-a-dwelling-so-that-i-dont-raise-duplicate-repairs

![Screenshot 2021-01-28 at 11 58 46](https://user-images.githubusercontent.com/34001723/106135773-49edad80-6160-11eb-9404-cd7f1a7131b9.png)
