### PR TITLE
Allow adding multiple SOR codes to raise a repair

### DIFF
--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -2,16 +2,13 @@
 
 import 'cypress-audit/commands'
 
-beforeEach(() => {
-  cy.loginWithAgentRole()
-
-  cy.server()
-  // Stub request for raise a repair form page
-  cy.fixture('schedule-of-rates/codes.json').as('sorCodes')
-})
-
-describe('Raise repair form on property with tenure', () => {
+describe('Raise repair form', () => {
   beforeEach(() => {
+    cy.loginWithAgentRole()
+
+    cy.server()
+    // Stub request for raise a repair form page
+    cy.fixture('schedule-of-rates/codes.json').as('sorCodes')
     cy.fixture('properties/property.json').as('property')
     cy.route('GET', 'api/properties/00012345', '@property')
     cy.route('GET', 'api/schedule-of-rates/codes', '@property')
@@ -23,415 +20,366 @@ describe('Raise repair form on property with tenure', () => {
     }).as('apiCheck')
   })
 
-  context('Fill out repair task details form to raise a repair', () => {
-    beforeEach(() => {
-      // Click link to raise a repair
-      cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+  it('Fill out repair task details form to raise a repair', () => {
+    // Click link to raise a repair
+    cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
 
-      cy.get('.govuk-heading-m')
-        .contains('Raise a repair on this dwelling')
-        .click()
-      cy.url().should('contains', 'properties/00012345/raise-repair/new')
+    cy.get('.govuk-heading-m')
+      .contains('Raise a repair on this dwelling')
+      .click()
+    cy.url().should('contains', 'properties/00012345/raise-repair/new')
+
+    // Property address details with tenure and alerts information
+    cy.get('.govuk-caption-l').contains('New repair')
+    cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
+
+    cy.checkForTenureAlertDetails(
+      'Tenure: Secure',
+      ['Address Alert: Property Under Disrepair (DIS)'],
+      [
+        'Contact Alert: No Lone Visits (CV)',
+        'Contact Alert: Verbal Abuse or Threat of (VA)',
+      ]
+    )
+
+    cy.get('.govuk-heading-m').contains('Repair task details')
+
+    // Form section
+    // Try to submit form without entering required fields
+    cy.get('[type="submit"]').contains('Create works order').click()
+    cy.get(
+      'div[id="sorCodesCollection[0][code]-form-group"] .govuk-error-message'
+    ).within(() => {
+      cy.contains('Please select an SOR code')
+    })
+    cy.get(
+      'div[id="sorCodesCollection[0][quantity]-form-group"] .govuk-error-message'
+    ).within(() => {
+      cy.contains('Please enter a quantity')
+    })
+    cy.get('#priorityDescription-form-group .govuk-error-message').within(
+      () => {
+        cy.contains('Please select a priority')
+      }
+    )
+    cy.get('#descriptionOfWork-form-group .govuk-error-message').within(() => {
+      cy.contains('Please enter a repair description')
     })
 
-    it('shows New repair title', () => {
-      cy.get('.govuk-caption-l').contains('New repair')
+    // Fill out form
+    cy.get('#repair-request-form').within(() => {
+      // Select SOR Code from dropdown
+      cy.get('select[id="sorCodesCollection[0][code]"]').select(
+        'DES5R004 - Emergency call out'
+      )
+      // Assigns description and contractor ref to hidden field
+      cy.get('input[id="sorCodesCollection[0][description]"]').should(
+        'have.value',
+        'Emergency call out'
+      )
+      cy.get('input[id="sorCodesCollection[0][contractorRef]"]').should(
+        'have.value',
+        'H01'
+      )
+      // Removes SOR Code validation errors
+      cy.get(
+        'div[id="sorCodesCollection[0][code]-form-group"] .govuk-error-message'
+      ).should('not.exist')
+
+      // Select blank SOR Code
+      cy.get('select[id="sorCodesCollection[0][code]"]').select('')
+      cy.get(
+        'div[id="sorCodesCollection[0][code]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Please select an SOR code')
+      })
+      cy.get('select[id="sorCodesCollection[0][code]"]').select(
+        'DES5R004 - Emergency call out'
+      )
+
+      // Enter a blank quantity
+      cy.get('input[id="sorCodesCollection[0][quantity]"]').clear()
+      cy.get(
+        'div[id="sorCodesCollection[0][quantity]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Please enter a quantity')
+      })
+
+      // Enter a non-number quantity
+      cy.get('input[id="sorCodesCollection[0][quantity]"]').clear().type('x')
+      cy.get(
+        'div[id="sorCodesCollection[0][quantity]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Quantity must be a whole number')
+      })
+
+      // Enter a non-integer quantity
+      cy.get('input[id="sorCodesCollection[0][quantity]"]').clear().type('1.5')
+      cy.get(
+        'div[id="sorCodesCollection[0][quantity]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Quantity must be a whole number')
+      })
+
+      // Enter a quantity less than the minimum
+      cy.get('input[id="sorCodesCollection[0][quantity]"]').clear().type('0')
+      cy.get(
+        'div[id="sorCodesCollection[0][quantity]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Quantity must be 1 or more')
+      })
+
+      // Enter a quantity more than the maximum
+      cy.get('input[id="sorCodesCollection[0][quantity]"]').clear().type('51')
+      cy.get(
+        'div[id="sorCodesCollection[0][quantity]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Quantity must be 50 or less')
+      })
+
+      // Enter a valid quantity
+      cy.get('input[id="sorCodesCollection[0][quantity]"]').clear().type('1')
+
+      // Adding multiple SOR codes
+      // Remove link does not exist when just one SOR code selector component
+      cy.get('.remove-sor-code').should('not.exist')
+      cy.contains('+ Add another SOR code').click()
+      // Remove link now exists for additional SOR code selector component
+      cy.get('.remove-sor-code').contains('-')
+      // Select SOR Code from dropdown
+      cy.get('select[id="sorCodesCollection[1][code]"]').select(
+        'DES5R005 - Normal call outs'
+      )
+      // Try to submit form without quantity for this SOR code at index 1
+      cy.get('[type="submit"]').contains('Create works order').click()
+      cy.get(
+        'div[id="sorCodesCollection[1][quantity]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Please enter a quantity')
+      })
+      // Remove SOR code at index 1
+      cy.get('select[id="sorCodesCollection[1][code]"]').select('')
+      cy.get(
+        'div[id="sorCodesCollection[1][code]-form-group"] .govuk-error-message'
+      ).within(() => {
+        cy.contains('Please select an SOR code')
+      })
+      // Enter SOR code and quantity
+      cy.get('select[id="sorCodesCollection[1][code]"]').select(
+        'DES5R005 - Normal call outs'
+      )
+      cy.get(
+        'div[id="sorCodesCollection[1][code]-form-group"] .govuk-error-message'
+      ).should('not.exist')
+      cy.get('input[id="sorCodesCollection[1][quantity]"]').clear().type('3')
+      cy.get(
+        'div[id="sorCodesCollection[1][quantity]-form-group"] .govuk-error-message'
+      ).should('not.exist')
+      // Add another SOR code
+      cy.contains('+ Add another SOR code').click()
+      cy.get('select[id="sorCodesCollection[2][code]"]').select(
+        'DES5R006 - Urgent call outs'
+      )
+      cy.get('input[id="sorCodesCollection[2][quantity]"]').clear().type('2')
+      // Delete the SOR code at the targeted index
+      cy.get('button[id="remove-sor-code-1"]').click()
+      cy.get('select[id="sorCodesCollection[1][code]"]').should('not.exist')
+      cy.get('input[id="sorCodesCollection[1][quantity]"]').should('not.exist')
+      cy.get('input[id="sorCodesCollection[1][description]"]').should(
+        'not.exist'
+      )
+      cy.get('input[id="sorCodesCollection[1][contractorRef]"]').should(
+        'not.exist'
+      )
+      // Remaining SOR codes
+      cy.get('button[id="remove-sor-code-1"]').should('not.exist')
+      cy.get('select[id="sorCodesCollection[0][code]"]').contains(
+        'DES5R004 - Emergency call out'
+      )
+      cy.get('input[id="sorCodesCollection[0][quantity]"]').should(
+        'have.value',
+        '1'
+      )
+      cy.get('button[id="remove-sor-code-0"]').should('not.exist')
+      cy.get('select[id="sorCodesCollection[2][code]"]').contains(
+        'DES5R006 - Urgent call outs'
+      )
+      cy.get('input[id="sorCodesCollection[2][quantity]"]').should(
+        'have.value',
+        '2'
+      )
+      cy.get('button[id="remove-sor-code-2"]').contains('-')
+
+      // Select Task Priority
+      cy.get('#priorityDescription').select('E - Emergency (24 hours)')
+      // Removes Task Priority validation errors
+      cy.get('#priorityDescription-form-group .govuk-error-message').should(
+        'not.exist'
+      )
+      // Select blank Task Priority
+      cy.get('#priorityDescription').select('')
+      cy.get('#priorityDescription-form-group .govuk-error-message').within(
+        () => {
+          cy.contains('Please select a priority')
+        }
+      )
+      cy.get('#priorityDescription').select('E - Emergency (24 hours)')
+
+      // Go over the Repair description character limit
+      cy.get('#descriptionOfWork').get('.govuk-textarea').type('x'.repeat(251))
+      cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
+        () => {
+          cy.contains('You have exceeded the maximum amount of characters')
+        }
+      )
+      // Delete all Repair Description text
+      cy.get('#descriptionOfWork').get('.govuk-textarea').clear()
+      cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
+        () => {
+          cy.contains('Please enter a repair description')
+        }
+      )
+      // Fill in Repair Description within character limit
+      cy.get('#descriptionOfWork').get('.govuk-textarea').type('A problem')
+      cy.get('.govuk-hint').within(() => {
+        cy.contains('You have 241 characters remaining.')
+      })
+      // Removes Repair Description validation errors
+      cy.get('#descriptionOfWork-form-group .govuk-error-message').should(
+        'not.exist'
+      )
+
+      // Fill in contact details
+      cy.get('#callerName').type('Bob Leek')
+      cy.get('#contactNumber').type('a')
+      // Enter invalid contact number
+      cy.get('#contactNumber-form-group .govuk-error-message').within(() => {
+        cy.contains('Contact number is not valid')
+      })
+      // Enter a valid contact number
+      cy.get('#contactNumber').clear().type('07788659111')
     })
 
-    it('shows property address in the heading', () => {
-      cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
+    // Submit form
+    cy.get('[type="submit"]').contains('Create works order').click()
+    // Check body of post request
+    cy.get('@apiCheck')
+      .its('request.body')
+      .then((body) => {
+        const referenceIdUuid = body.reference[0].id
+        const requiredCompletionDateTime =
+          body.priority.requiredCompletionDateTime
+        cy.get('@apiCheck')
+          .its('request.body')
+          .should('deep.equal', {
+            reference: [{ id: referenceIdUuid }],
+            descriptionOfWork: 'A problem',
+            priority: {
+              priorityCode: 1,
+              priorityDescription: 'E - Emergency (24 hours)',
+              requiredCompletionDateTime: requiredCompletionDateTime,
+              numberOfDays: 1,
+            },
+            workClass: { workClassCode: 0 },
+            workElement: [
+              {
+                rateScheduleItem: [
+                  {
+                    customCode: 'DES5R004',
+                    customName: 'Emergency call out',
+                    quantity: { amount: [1] },
+                  },
+                ],
+              },
+              {
+                rateScheduleItem: [
+                  {
+                    customCode: 'DES5R006',
+                    customName: 'Urgent call outs',
+                    quantity: { amount: [2] },
+                  },
+                ],
+              },
+            ],
+            site: {
+              property: [
+                {
+                  propertyReference: '00012345',
+                  address: {
+                    addressLine: ['16 Pitcairn House  St Thomass Square'],
+                  },
+                  reference: [
+                    {
+                      id: '00012345',
+                    },
+                  ],
+                },
+              ],
+            },
+            instructedBy: { name: 'Hackney Housing' },
+            assignedToPrimary: {
+              name: 'Contractor H01',
+              organization: {
+                reference: [
+                  {
+                    id: 'H01',
+                  },
+                ],
+              },
+            },
+            customer: {
+              name: 'Bob Leek',
+              person: {
+                name: {
+                  full: 'Bob Leek',
+                },
+                contact: [
+                  {
+                    name: {
+                      full: 'Bob Leek',
+                    },
+                    communication: [
+                      {
+                        channel: {
+                          medium: '20',
+                          code: '60',
+                        },
+                        value: '07788659111',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          })
+      })
+
+    // Confirmation screen
+    cy.get('.govuk-panel--confirmation').within(() => {
+      cy.get('h1.govuk-heading-xl').contains('Repair work order created')
+
+      cy.get('.govuk-panel__body').within(() => {
+        cy.contains('Work order number')
+        cy.contains('10102030')
+      })
     })
 
-    it('shows Tenure and Alerts section', () => {
-      cy.checkForTenureAlertDetails(
-        'Tenure: Secure',
-        ['Address Alert: Property Under Disrepair (DIS)'],
-        [
-          'Contact Alert: No Lone Visits (CV)',
-          'Contact Alert: Verbal Abuse or Threat of (VA)',
-        ]
+    // Actions to see relevant pages
+    cy.get('.govuk-list li').within(() => {
+      cy.contains('Back to 16 Pitcairn House St Thomass Square').should(
+        'have.attr',
+        'href',
+        '/properties/00012345'
+      )
+      cy.contains('Start a new search').should('have.attr', 'href', '/')
+      cy.contains('View work order').should(
+        'have.attr',
+        'href',
+        '/work-orders/10102030'
       )
     })
 
-    it('shows form title', () => {
-      cy.get('.govuk-heading-m').contains('Repair task details')
-    })
-
-    // Form section
-    context('submit the form without fields', () => {
-      beforeEach(() => {
-        // Try to submit form without entering required fields
-        cy.get('[type="submit"]').contains('Create works order').click()
-      })
-
-      it('shows an error', () => {
-        cy.get('#sorCode-form-group .govuk-error-message').within(() => {
-          cy.contains('Please select an SOR code')
-        })
-        cy.get('#priorityDescription-form-group .govuk-error-message').within(
-          () => {
-            cy.contains('Please select a priority')
-          }
-        )
-        cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
-          () => {
-            cy.contains('Please enter a repair description')
-          }
-        )
-      })
-    })
-
-    context('submit the form with fields', () => {
-      beforeEach(() => {
-        // Fill out form
-        cy.get('#repair-request-form').within(() => {
-          // Select SOR Code from dropdown
-          cy.get('#sorCode').select('DES5R004')
-          // Autofills SOR Code summary and populates Task Priority dropdown
-          cy.get('.sor-code-summary').contains(
-            'SOR code summary: Emergency call out'
-          )
-          cy.get('#priorityDescription').should(
-            'have.value',
-            'E - Emergency (24 hours)'
-          )
-          // Removes SOR Code & Task priority validation errors
-          cy.get('#sorCode-form-group .govuk-error-message').should('not.exist')
-          cy.get('#priorityDescription-form-group .govuk-error-message').should(
-            'not.exist'
-          )
-
-          // Select blank SOR Code
-          cy.get('#sorCode').select('')
-          // Submit form
-          cy.get('[type="submit"]').contains('Create works order').click()
-          cy.get('#sorCode-form-group .govuk-error-message').within(() => {
-            cy.contains('Please select an SOR code')
-          })
-          cy.get('#priorityDescription').should(
-            'have.value',
-            'E - Emergency (24 hours)'
-          )
-          // Select blank Task Priority
-          cy.get('#priorityDescription').select('')
-          cy.get('#priorityDescription-form-group .govuk-error-message').within(
-            () => {
-              cy.contains('Please select a priority')
-            }
-          )
-
-          cy.get('#sorCode').select('DES5R004')
-
-          // Enter a blank quantity
-          cy.get('#quantity').clear()
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Please enter a quantity')
-          })
-
-          // Enter a non-number quantity
-          cy.get('#quantity').clear().type('x')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be a whole number')
-          })
-
-          // Enter a non-integer quantity
-          cy.get('#quantity').clear().type('1.5')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be a whole number')
-          })
-
-          // Enter a quantity less than the minimum
-          cy.get('#quantity').clear().type('0')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be 1 or more')
-          })
-
-          // Enter a quantity more than the maximum
-          cy.get('#quantity').clear().type('51')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be 50 or less')
-          })
-
-          // Enter a valid quantity
-          cy.get('#quantity').clear().type('1')
-
-          // Go over the Repair description character limit
-          cy.get('#descriptionOfWork')
-            .get('.govuk-textarea')
-            .type('x'.repeat(251))
-          cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
-            () => {
-              cy.contains('You have exceeded the maximum amount of characters')
-            }
-          )
-          // Delete all Repair Description text
-          cy.get('#descriptionOfWork').get('.govuk-textarea').clear()
-          cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
-            () => {
-              cy.contains('Please enter a repair description')
-            }
-          )
-          // Fill in Repair Description within character limit
-          cy.get('#descriptionOfWork').get('.govuk-textarea').type('A problem')
-          cy.get('.govuk-hint').within(() => {
-            cy.contains('You have 241 characters remaining.')
-          })
-          // Removes Repair Description validation errors
-          cy.get('#descriptionOfWork-form-group .govuk-error-message').should(
-            'not.exist'
-          )
-
-          // Fill in contact details
-          cy.get('#callerName').type('Bob Leek')
-          cy.get('#contactNumber').type('a')
-          // Enter invalid contact number
-          cy.get('#contactNumber-form-group .govuk-error-message').within(
-            () => {
-              cy.contains('Contact number is not valid')
-            }
-          )
-          // Enter a valid contact number
-          cy.get('#contactNumber').clear().type('07788659111')
-        })
-
-        // Submit form
-        cy.get('[type="submit"]').contains('Create works order').click()
-      })
-
-      it('submit the form correct', () => {
-        // Submit form
-        cy.get('.govuk-panel--confirmation').within(() => {
-          cy.get('h1.govuk-heading-xl').contains('Repair work order created')
-
-          cy.get('.govuk-panel__body').within(() => {
-            cy.contains('Work order number')
-            cy.contains('10102030')
-          })
-        })
-
-        cy.get('.govuk-list li').within(() => {
-          cy.contains('Back to 16 Pitcairn House St Thomass Square').should(
-            'have.attr',
-            'href',
-            '/properties/00012345'
-          )
-          cy.contains('Start a new search').should('have.attr', 'href', '/')
-          cy.contains('View work order').should(
-            'have.attr',
-            'href',
-            '/work-orders/10102030'
-          )
-        })
-
-        // Run lighthouse audit for accessibility report
-        cy.audit()
-      })
-    })
-  })
-})
-
-describe('Raise repair form on property without tenure code', () => {
-  beforeEach(() => {
-    cy.fixture('properties/property_no_tenure.json').as('property_no_tenure')
-    cy.route('GET', 'api/properties/00012345', '@property_no_tenure')
-    cy.route('GET', 'api/schedule-of-rates/codes', '@property_no_tenure')
-    cy.route('GET', 'api/schedule-of-rates/codes', '@sorCodes')
-    cy.route({
-      method: 'POST',
-      url: '/api/repairs/schedule',
-      response: '10102030',
-    }).as('apiCheck')
-  })
-
-  context('Fill out repair task details form to raise a repair', () => {
-    beforeEach(() => {
-      // Click link to raise a repair
-      cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
-
-      cy.get('.govuk-heading-m')
-        .contains('Raise a repair on this dwelling')
-        .click()
-      cy.url().should('contains', 'properties/00012345/raise-repair/new')
-    })
-
-    it('shows New repair title', () => {
-      cy.get('.govuk-caption-l').contains('New repair')
-    })
-
-    it('shows property address in the heading', () => {
-      cy.get('.govuk-heading-l').contains('Dwelling: 16 Pitcairn House')
-    })
-
-    it('does not show property alerts', () => {
-      cy.get('.hackney-property-alerts').should('not.exist')
-    })
-
-    it('does not show Tenure', () => {
-      cy.get('.hackney-property-alerts').should('not.exist')
-      cy.contains('Tenure').should('not.exist')
-    })
-
-    it('shows form title', () => {
-      cy.get('.govuk-heading-m').contains('Repair task details')
-    })
-
-    // Form section
-    context('submit the form without fields', () => {
-      beforeEach(() => {
-        // Try to submit form without entering required fields
-        cy.get('[type="submit"]').contains('Create works order').click()
-      })
-
-      it('shows an error', () => {
-        cy.get('#sorCode-form-group .govuk-error-message').within(() => {
-          cy.contains('Please select an SOR code')
-        })
-        cy.get('#priorityDescription-form-group .govuk-error-message').within(
-          () => {
-            cy.contains('Please select a priority')
-          }
-        )
-        cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
-          () => {
-            cy.contains('Please enter a repair description')
-          }
-        )
-      })
-    })
-
-    context('submit the form with fields', () => {
-      beforeEach(() => {
-        // Fill out form
-        cy.get('#repair-request-form').within(() => {
-          // Select SOR Code from dropdown
-          cy.get('#sorCode').select('DES5R004')
-          // Autofills SOR Code summary and populates Task Priority dropdown
-          cy.get('.sor-code-summary').contains(
-            'SOR code summary: Emergency call out'
-          )
-          cy.get('#priorityDescription').should(
-            'have.value',
-            'E - Emergency (24 hours)'
-          )
-          // Removes SOR Code & Task priority validation errors
-          cy.get('#sorCode-form-group .govuk-error-message').should('not.exist')
-          cy.get('#priorityDescription-form-group .govuk-error-message').should(
-            'not.exist'
-          )
-
-          // Select blank SOR Code
-          cy.get('#sorCode').select('')
-          // Submit form
-          cy.get('[type="submit"]').contains('Create works order').click()
-          cy.get('#sorCode-form-group .govuk-error-message').within(() => {
-            cy.contains('Please select an SOR code')
-          })
-          cy.get('#priorityDescription').should(
-            'have.value',
-            'E - Emergency (24 hours)'
-          )
-          // Select blank Task Priority
-          cy.get('#priorityDescription').select('')
-          cy.get('#priorityDescription-form-group .govuk-error-message').within(
-            () => {
-              cy.contains('Please select a priority')
-            }
-          )
-
-          cy.get('#sorCode').select('DES5R004')
-
-          // Enter a blank quantity
-          cy.get('#quantity').clear()
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Please enter a quantity')
-          })
-
-          // Enter a non-number quantity
-          cy.get('#quantity').clear().type('x')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be a whole number')
-          })
-
-          // Enter a non-integer quantity
-          cy.get('#quantity').clear().type('1.5')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be a whole number')
-          })
-
-          // Enter a quantity less than the minimum
-          cy.get('#quantity').clear().type('0')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be 1 or more')
-          })
-
-          // Enter a quantity more than the maximum
-          cy.get('#quantity').clear().type('51')
-          cy.get('#quantity-form-group .govuk-error-message').within(() => {
-            cy.contains('Quantity must be 50 or less')
-          })
-
-          // Enter a valid quantity
-          cy.get('#quantity').clear().type('1')
-
-          // Go over the Repair description character limit
-          cy.get('#descriptionOfWork')
-            .get('.govuk-textarea')
-            .type('x'.repeat(251))
-          cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
-            () => {
-              cy.contains('You have exceeded the maximum amount of characters')
-            }
-          )
-          // Delete all Repair Description text
-          cy.get('#descriptionOfWork').get('.govuk-textarea').clear()
-          cy.get('#descriptionOfWork-form-group .govuk-error-message').within(
-            () => {
-              cy.contains('Please enter a repair description')
-            }
-          )
-          // Fill in Repair Description within character limit
-          cy.get('#descriptionOfWork').get('.govuk-textarea').type('A problem')
-          cy.get('.govuk-hint').within(() => {
-            cy.contains('You have 241 characters remaining.')
-          })
-          // Removes Repair Description validation errors
-          cy.get('#descriptionOfWork-form-group .govuk-error-message').should(
-            'not.exist'
-          )
-        })
-
-        // Submit form
-        cy.get('[type="submit"]').contains('Create works order').click()
-      })
-
-      it('submit the form correct', () => {
-        // Submit form
-        cy.get('.govuk-panel--confirmation').within(() => {
-          cy.get('h1.govuk-heading-xl').contains('Repair work order created')
-
-          cy.get('.govuk-panel__body').within(() => {
-            cy.contains('Work order number')
-            cy.contains('10102030')
-          })
-        })
-
-        cy.get('.govuk-list li').within(() => {
-          cy.contains('Back to 16 Pitcairn House St Thomass Square').should(
-            'have.attr',
-            'href',
-            '/properties/00012345'
-          )
-          cy.contains('Start a new search').should('have.attr', 'href', '/')
-          cy.contains('View work order').should(
-            'have.attr',
-            'href',
-            '/work-orders/10102030'
-          )
-        })
-
-        // Run lighthouse audit for accessibility report
-        cy.audit()
-      })
-    })
+    // Run lighthouse audit for accessibility report
+    cy.audit()
   })
 })

--- a/src/components/Form/Button/Button.js
+++ b/src/components/Form/Button/Button.js
@@ -1,9 +1,23 @@
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
-const Button = ({ onClick, label, type, ...otherProps }) => (
+const Button = ({
+  onClick,
+  label,
+  type,
+  isSecondary,
+  className,
+  ...otherProps
+}) => (
   <div className="govuk-form-group">
     <button
-      className="govuk-button"
+      className={cx(
+        'govuk-button',
+        {
+          'govuk-button--secondary': isSecondary,
+        },
+        className
+      )}
       data-module="govuk-button"
       onClick={onClick}
       type={type}
@@ -18,6 +32,8 @@ Button.propTypes = {
   onClick: PropTypes.func,
   label: PropTypes.node.isRequired,
   type: PropTypes.string,
+  isSecondary: PropTypes.bool,
+  className: PropTypes.string,
 }
 
 export default Button

--- a/src/components/Form/Select/Select.js
+++ b/src/components/Form/Select/Select.js
@@ -41,7 +41,7 @@ const Select = ({
       data-testid={name}
       ref={register}
       aria-describedby={hint && `${name}-hint`}
-      onChange={(e) => onChange && onChange(e.target.value)}
+      onChange={(e) => onChange && onChange(e)}
       value={ignoreValue ? undefined : value}
       disabled={disabled}
     >

--- a/src/components/Layout/Grid/GridRow.js
+++ b/src/components/Layout/Grid/GridRow.js
@@ -1,5 +1,7 @@
 const GridRow = (props) => (
-  <div className="govuk-grid-row">{props.children}</div>
+  <div className={`govuk-grid-row ${props.className}`} id={props.id}>
+    {props.children}
+  </div>
 )
 
 export default GridRow

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -5,7 +5,7 @@ import TenureAlertDetails from '../TenureAlertDetails'
 import BackButton from '../../Layout/BackButton/BackButton'
 import { Select, Button, TextArea, TextInput } from '../../Form'
 import { buildScheduleRepairFormData } from '../../../utils/hact/raise-repair-form'
-import { GridRow, GridColumn } from '../../Layout/Grid'
+import SorCodeSelectView from './SorCodeSelectView'
 
 const RaiseRepairForm = ({
   propertyReference,
@@ -20,9 +20,6 @@ const RaiseRepairForm = ({
 }) => {
   const { register, handleSubmit, errors } = useForm()
   const [priorityCode, setPriorityCode] = useState('')
-  const [sorCodeDescription, setSorCodeDescription] = useState('')
-  const [sorCodeContractorRef, setSorCodeContractorRef] = useState('')
-  const sorCodesList = sorCodes.map((code) => code.customCode)
   const priorityList = [
     ...new Set(sorCodes.map((code) => code.priority.description)),
   ]
@@ -33,51 +30,12 @@ const RaiseRepairForm = ({
     onFormSubmit(scheduleRepairFormData)
   }
 
-  const onPrioritySelect = (priority) => {
+  const onPrioritySelect = (event) => {
     const sorCodeObject = sorCodes.filter(
-      (a) => a.priority.description == priority
+      (a) => a.priority.description == event.target.value
     )[0]
 
     setPriorityCode(sorCodeObject?.priority.priorityCode || '')
-  }
-  const onSorCodeSelect = (code) => {
-    const sorCodeObject = sorCodes.filter((a) => a.customCode == code)[0]
-    const sorCodeDescription = sorCodeObject?.customName || ''
-
-    if (code) {
-      document.getElementById('priorityDescription').value =
-        sorCodeObject?.priority.description
-
-      if (errors?.priorityDescription) {
-        delete errors.priorityDescription
-      }
-    }
-
-    setPriorityCode(sorCodeObject?.priority.priorityCode || '')
-    setSorCodeDescription(sorCodeDescription)
-    setSorCodeContractorRef(sorCodeObject?.sorContractor.reference || '')
-    addSorCodeSummaryHtml(sorCodeDescription)
-  }
-
-  const addSorCodeSummaryHtml = (sorCodeName) => {
-    const sorCodeSummaryHtml = `<p class='govuk-body-s'>SOR code summary: ${sorCodeName}</p>`
-    const targetNextSibling = event.target.nextSibling
-
-    if (!targetNextSibling) {
-      const sorCodeSummaryDiv = [
-        '<div class="sor-code-summary govuk-!-margin-top-2">',
-        `${sorCodeSummaryHtml}`,
-        '</div>',
-      ].join('\n')
-
-      return event.target.insertAdjacentHTML('afterend', sorCodeSummaryDiv)
-    }
-
-    if (sorCodeName) {
-      targetNextSibling.innerHTML = sorCodeSummaryHtml
-    } else {
-      targetNextSibling.remove()
-    }
   }
 
   const characterCount = () => {
@@ -115,63 +73,12 @@ const RaiseRepairForm = ({
             id="repair-request-form"
             onSubmit={handleSubmit(onSubmit)}
           >
-            <GridRow>
-              <GridColumn width="two-thirds">
-                <Select
-                  name="sorCode"
-                  label="SOR Code"
-                  options={sorCodesList}
-                  onChange={onSorCodeSelect}
-                  required={true}
-                  register={register({
-                    required: 'Please select an SOR code',
-                    validate: (value) =>
-                      sorCodesList.includes(value) || 'SOR code is not valid',
-                  })}
-                  error={errors && errors.sorCode}
-                  widthClass="govuk-!-width-full"
-                />
-                <input
-                  id="sorCodeDescription"
-                  name="sorCodeDescription"
-                  type="hidden"
-                  value={sorCodeDescription}
-                  ref={register}
-                />
-                <input
-                  id="sorCodeContractorRef"
-                  name="sorCodeContractorRef"
-                  type="hidden"
-                  value={sorCodeContractorRef}
-                  ref={register}
-                />
-              </GridColumn>
-              <GridColumn width="one-third">
-                <TextInput
-                  name="quantity"
-                  label="Quantity"
-                  error={errors && errors.quantity}
-                  widthClass="govuk-!-width-full"
-                  required={true}
-                  register={register({
-                    required: 'Please enter a quantity',
-                    valueAsNumber: true,
-                    validate: (value) => {
-                      if (!Number.isInteger(value)) {
-                        return 'Quantity must be a whole number'
-                      }
-                      if (value < 1) {
-                        return 'Quantity must be 1 or more'
-                      } else if (value > 50) {
-                        return 'Quantity must be 50 or less'
-                      } else {
-                        return true
-                      }
-                    },
-                  })}
-                />
-              </GridColumn>
-            </GridRow>
+            <SorCodeSelectView
+              sorCodes={sorCodes}
+              register={register}
+              errors={errors}
+            />
+
             <Select
               name="priorityDescription"
               label="Task priority"

--- a/src/components/Property/RaiseRepair/SorCodeSelect.js
+++ b/src/components/Property/RaiseRepair/SorCodeSelect.js
@@ -1,0 +1,99 @@
+import PropTypes from 'prop-types'
+import { GridRow, GridColumn } from '../../Layout/Grid'
+import { Select, TextInput } from '../../Form'
+
+const SorCodeSelect = ({
+  onSorCodeSelect,
+  sorCodesList,
+  register,
+  errors,
+  index,
+  showRemoveSorCodeSelect,
+  removeSorCodeSelect,
+}) => {
+  return (
+    <GridRow
+      className="sor-code-select display-flex align-items-center position-relative"
+      id={`sor-code-select-${index}`}
+    >
+      <GridColumn width="two-thirds">
+        <Select
+          name={`sorCodesCollection[${index}][code]`}
+          label="SOR Code"
+          options={sorCodesList}
+          onChange={(event) => onSorCodeSelect(index, event)}
+          required={true}
+          register={register({
+            required: 'Please select an SOR code',
+            validate: (value) =>
+              sorCodesList.includes(value) || 'SOR code is not valid',
+          })}
+          error={errors && errors.sorCodesCollection?.[`${index}`]?.code}
+          widthClass="govuk-!-width-full"
+        />
+        <input
+          id={`sorCodesCollection[${index}][description]`}
+          name={`sorCodesCollection[${index}][description]`}
+          type="hidden"
+          ref={register}
+        />
+        <input
+          id={`sorCodesCollection[${index}][contractorRef]`}
+          name={`sorCodesCollection[${index}][contractorRef]`}
+          type="hidden"
+          ref={register}
+        />
+      </GridColumn>
+      <GridColumn width="one-third">
+        <TextInput
+          name={`sorCodesCollection[${index}][quantity]`}
+          label="Quantity"
+          error={errors && errors.sorCodesCollection?.[`${index}`]?.quantity}
+          widthClass="govuk-!-width-full"
+          required={true}
+          register={register({
+            required: 'Please enter a quantity',
+            valueAsNumber: true,
+            validate: (value) => {
+              if (!Number.isInteger(value)) {
+                return 'Quantity must be a whole number'
+              }
+              if (value < 1) {
+                return 'Quantity must be 1 or more'
+              } else if (value > 50) {
+                return 'Quantity must be 50 or less'
+              } else {
+                return true
+              }
+            },
+          })}
+        />
+      </GridColumn>
+
+      {showRemoveSorCodeSelect && (
+        <div className="remove-sor-code position-absolute right-negative-3">
+          <button
+            id={`remove-sor-code-${index}`}
+            className="cursor-pointer"
+            type="button"
+            onClick={() => removeSorCodeSelect(index)}
+          >
+            -
+          </button>
+        </div>
+      )}
+    </GridRow>
+  )
+}
+
+SorCodeSelect.propTypes = {
+  onSorCodeSelect: PropTypes.func.isRequired,
+  sorCodesList: PropTypes.array.isRequired,
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  showRemoveSorCodeSelect: PropTypes.bool.isRequired,
+  removeSorCodeSelect: PropTypes.func.isRequired,
+}
+
+export default SorCodeSelect

--- a/src/components/Property/RaiseRepair/SorCodeSelectView.js
+++ b/src/components/Property/RaiseRepair/SorCodeSelectView.js
@@ -1,0 +1,84 @@
+import PropTypes from 'prop-types'
+import { useState, Fragment } from 'react'
+import SorCodeSelect from './SorCodeSelect'
+
+const SorCodeSelectView = ({ sorCodes, register, errors }) => {
+  const sorCodesList = sorCodes.map(
+    (code) => `${code.customCode} - ${code.customName}`
+  )
+  const [
+    arrayOfSorCodeSelectComponentIndexes,
+    setArrayOfSorCodeSelectComponentIndexes,
+  ] = useState([0])
+
+  const onSorCodeSelect = (index, event) => {
+    const value = event.target.value.split(' - ')[0]
+    const sorCodeObject = sorCodes.filter((a) => a.customCode == value)[0]
+    const sorCodeDescription = sorCodeObject?.customName || ''
+    const sorCodeContractorRef = sorCodeObject?.sorContractor.reference || ''
+
+    document.getElementById(
+      `sorCodesCollection[${index}][description]`
+    ).value = sorCodeDescription
+    document.getElementById(
+      `sorCodesCollection[${index}][contractorRef]`
+    ).value = sorCodeContractorRef
+  }
+
+  const addSorCodeSelect = () => {
+    setArrayOfSorCodeSelectComponentIndexes(
+      (arrayOfSorCodeSelectComponentIndexes) => [
+        ...arrayOfSorCodeSelectComponentIndexes,
+        arrayOfSorCodeSelectComponentIndexes.slice(-1)[0] + 1,
+      ]
+    )
+  }
+
+  const removeSorCodeSelect = (index) => {
+    setArrayOfSorCodeSelectComponentIndexes(
+      (arrayOfSorCodeSelectComponentIndexes) =>
+        arrayOfSorCodeSelectComponentIndexes.filter((i) => i !== index)
+    )
+  }
+
+  const sorCodeSelectCollection = () => {
+    return arrayOfSorCodeSelectComponentIndexes.map((i) => {
+      return (
+        <Fragment key={`sorCodeCollection~${i}`}>
+          <SorCodeSelect
+            sorCodesList={sorCodesList}
+            register={register}
+            errors={errors}
+            key={i}
+            index={i}
+            onSorCodeSelect={onSorCodeSelect}
+            showRemoveSorCodeSelect={i > 0}
+            removeSorCodeSelect={removeSorCodeSelect}
+          />
+        </Fragment>
+      )
+    })
+  }
+
+  return (
+    <div className="govuk-!-padding-bottom-5">
+      {sorCodeSelectCollection()}
+
+      <a
+        onClick={addSorCodeSelect}
+        href="#"
+        className="repairs-hub-link govuk-body-s"
+      >
+        + Add another SOR code
+      </a>
+    </div>
+  )
+}
+
+SorCodeSelectView.propTypes = {
+  sorCodes: PropTypes.array.isRequired,
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+}
+
+export default SorCodeSelectView

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -64,86 +64,95 @@ exports[`RaiseRepairForm component should render properly 1`] = `
           role="form"
         >
           <div
-            class="govuk-grid-row"
+            class="govuk-!-padding-bottom-5"
           >
             <div
-              class="govuk-grid-column-two-thirds"
+              class="govuk-grid-row sor-code-select display-flex align-items-center position-relative"
+              id="sor-code-select-0"
             >
               <div
-                class="govuk-form-group"
-                id="sorCode-form-group"
+                class="govuk-grid-column-two-thirds"
               >
-                <label
-                  class="govuk-label"
-                  for="sorCode"
+                <div
+                  class="govuk-form-group"
+                  id="sorCodesCollection[0][code]-form-group"
                 >
-                  SOR Code 
-                  <span
-                    class="govuk-required"
+                  <label
+                    class="govuk-label"
+                    for="sorCodesCollection[0][code]"
                   >
-                    *
-                  </span>
-                </label>
-                <select
-                  class="govuk-select govuk-!-width-full"
-                  data-testid="sorCode"
-                  id="sorCode"
-                  name="sorCode"
-                >
-                  <option
-                    value=""
-                  />
-                  <option
-                    value="DES5R003"
+                    SOR Code 
+                    <span
+                      class="govuk-required"
+                    >
+                      *
+                    </span>
+                  </label>
+                  <select
+                    class="govuk-select govuk-!-width-full"
+                    data-testid="sorCodesCollection[0][code]"
+                    id="sorCodesCollection[0][code]"
+                    name="sorCodesCollection[0][code]"
                   >
-                    DES5R003
-                  </option>
-                  <option
-                    value="DES5R004"
-                  >
-                    DES5R004
-                  </option>
-                </select>
-              </div>
-              <input
-                id="sorCodeDescription"
-                name="sorCodeDescription"
-                type="hidden"
-                value=""
-              />
-              <input
-                id="sorCodeContractorRef"
-                name="sorCodeContractorRef"
-                type="hidden"
-                value=""
-              />
-            </div>
-            <div
-              class="govuk-grid-column-one-third"
-            >
-              <div
-                class="govuk-form-group"
-                id="quantity-form-group"
-              >
-                <label
-                  class="govuk-label"
-                  for="quantity"
-                >
-                  Quantity 
-                  <span
-                    class="govuk-required"
-                  >
-                    *
-                  </span>
-                </label>
+                    <option
+                      value=""
+                    />
+                    <option
+                      value="DES5R003 - Immediate call outs"
+                    >
+                      DES5R003 - Immediate call outs
+                    </option>
+                    <option
+                      value="DES5R004 - Emergency call outs"
+                    >
+                      DES5R004 - Emergency call outs
+                    </option>
+                  </select>
+                </div>
                 <input
-                  class="govuk-input govuk-!-width-full"
-                  id="quantity"
-                  name="quantity"
-                  type="text"
+                  id="sorCodesCollection[0][description]"
+                  name="sorCodesCollection[0][description]"
+                  type="hidden"
+                />
+                <input
+                  id="sorCodesCollection[0][contractorRef]"
+                  name="sorCodesCollection[0][contractorRef]"
+                  type="hidden"
                 />
               </div>
+              <div
+                class="govuk-grid-column-one-third"
+              >
+                <div
+                  class="govuk-form-group"
+                  id="sorCodesCollection[0][quantity]-form-group"
+                >
+                  <label
+                    class="govuk-label"
+                    for="sorCodesCollection[0][quantity]"
+                  >
+                    Quantity 
+                    <span
+                      class="govuk-required"
+                    >
+                      *
+                    </span>
+                  </label>
+                  <input
+                    class="govuk-input govuk-!-width-full"
+                    id="sorCodesCollection[0][quantity]"
+                    name="sorCodesCollection[0][quantity]"
+                    type="text"
+                  />
+                </div>
+              </div>
             </div>
+            <a
+              class="repairs-hub-link govuk-body-s"
+              href="#"
+            >
+              + Add another SOR code
+            </a>
           </div>
           <div
             class="govuk-form-group"

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -4,6 +4,7 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
 
 @import 'colours';
 @import 'links';
+@import 'layout';
 
 @import 'components/button';
 @import 'components/header';

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,0 +1,15 @@
+.display-flex {
+  display: flex;
+  &.align-items-center {
+    align-items: center;
+  }
+  &.position-relative {
+    position: relative;
+  }
+}
+.position-absolute {
+  position: absolute;
+  &.right-negative-3 {
+    right: -3%;
+  }
+}

--- a/src/styles/links.scss
+++ b/src/styles/links.scss
@@ -25,3 +25,7 @@
     @extend %repairs-hub-link;
   }
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/src/utils/hact/raise-repair-form.js
+++ b/src/utils/hact/raise-repair-form.js
@@ -24,19 +24,23 @@ export const buildScheduleRepairFormData = (formData) => {
     workClass: {
       workClassCode: 0,
     },
-    workElement: [
-      {
-        rateScheduleItem: [
+    workElement: formData.sorCodesCollection
+      .map((item) => {
+        return [
           {
-            customCode: formData.sorCode,
-            customName: formData.sorCodeDescription,
-            quantity: {
-              amount: [Number.parseInt(formData.quantity)],
-            },
+            rateScheduleItem: [
+              {
+                customCode: item.code.split(' - ')[0],
+                customName: item.description,
+                quantity: {
+                  amount: [Number.parseInt(item.quantity)],
+                },
+              },
+            ],
           },
-        ],
-      },
-    ],
+        ]
+      })
+      .flat(),
     site: {
       property: [
         {
@@ -56,11 +60,11 @@ export const buildScheduleRepairFormData = (formData) => {
       name: 'Hackney Housing',
     },
     assignedToPrimary: {
-      name: `Contractor ${formData.sorCodeContractorRef}`,
+      name: `Contractor ${formData.sorCodesCollection[0].contractorRef}`,
       organization: {
         reference: [
           {
-            id: formData.sorCodeContractorRef,
+            id: formData.sorCodesCollection[0].contractorRef,
           },
         ],
       },

--- a/src/utils/hact/raise-repair-form.test.js
+++ b/src/utils/hact/raise-repair-form.test.js
@@ -9,8 +9,20 @@ jest.mock('uuid', () => {
 
 describe('buildRaiseRepairFormData', () => {
   const formData = {
-    sorCode: 'DES5R006',
-    sorCodeDescription: 'Urgent call outs',
+    sorCodesCollection: [
+      {
+        code: 'DES5R006 - Urgent call outs',
+        description: 'Urgent call outs',
+        quantity: '1',
+        contractorRef: 'H01',
+      },
+      {
+        code: 'DES5R005 - Normal call outs',
+        description: 'Normal call outs',
+        quantity: '3',
+        contractorRef: 'H01',
+      },
+    ],
     quantity: '1',
     priorityDescription: 'U - Urgent (5 Working days)',
     priorityCode: '3',
@@ -19,7 +31,6 @@ describe('buildRaiseRepairFormData', () => {
     shortAddress: '12 Pitcairn House',
     callerName: 'John Smith',
     contactNumber: '07788777888',
-    sorCodeContractorRef: 'H01',
   }
 
   it('builds the ScheduleRepair form data to post to the Repairs API', async () => {
@@ -49,6 +60,15 @@ describe('buildRaiseRepairFormData', () => {
               customCode: 'DES5R006',
               customName: 'Urgent call outs',
               quantity: { amount: [1] },
+            },
+          ],
+        },
+        {
+          rateScheduleItem: [
+            {
+              customCode: 'DES5R005',
+              customName: 'Normal call outs',
+              quantity: { amount: [3] },
             },
           ],
         },


### PR DESCRIPTION
### Description of change
- Permit to add multiple SOR code select components (code and quantity) and enable deletion if there is more than one of these components
- Adds error validation to targeted components based on index
- Populate hidden fields of description and contractor ref once SOR code is selected
- Return array of RateScheduleItems on HACT raise repair form
- Show sor code description next to code in dropdown select (remove SOR code summary auto populate feature)

### Story Link

https://trello.com/c/fLciBa9w/263-as-an-agent-i-can-add-multiple-sor-codes-to-a-work-order-so-that-i-can-raise-all-the-repairs-required

### **Single SOR code**
![Screenshot 2021-02-01 at 15 28 36](https://user-images.githubusercontent.com/34001723/106490005-47b38800-64ad-11eb-83a6-ce186c50e554.png)

### **Multiple SOR code**
![Screenshot 2021-02-01 at 15 27 35](https://user-images.githubusercontent.com/34001723/106489990-44b89780-64ad-11eb-98d9-a3d3c45b9832.png)

### **Error validations targeting SOR component at right index**
![Screenshot 2021-02-01 at 15 28 23](https://user-images.githubusercontent.com/34001723/106489998-45e9c480-64ad-11eb-8fc8-1e99d2d1ee27.png)

### **Mobile view**
![Screenshot 2021-02-01 at 14 31 34](https://user-images.githubusercontent.com/34001723/106491701-0a4ffa00-64af-11eb-8744-3290ba96ad2e.png)
