### PR TITLE
Display work order information panel on work order page

### DIFF
--- a/cypress/fixtures/repairs/work-order.json
+++ b/cypress/fixtures/repairs/work-order.json
@@ -6,5 +6,11 @@
   "property": "16 Pitcairn House  St Thomass Square",
   "owner": "",
   "description": "This is an urgent repair description",
-  "propertyReference": "00012345"
+  "propertyReference": "00012345",
+  "status": "In Progress",
+  "priorityCode": 2,
+  "raisedBy": "Dummy Agent",
+  "target": "2021-01-23T18:30:00.00000",
+  "callerName": "Jill Smith",
+  "callerNumber": "07700 900999"
 }

--- a/cypress/integration/show_work_order.spec.js
+++ b/cypress/integration/show_work_order.spec.js
@@ -31,7 +31,7 @@ describe('Show work order', () => {
     })
 
     it('Property details', () => {
-      cy.get('.govuk-grid-row').within(() => {
+      cy.get('.property-details-main-section').within(() => {
         cy.contains('Dwelling')
         cy.contains('16 Pitcairn House').should(
           'have.attr',
@@ -54,6 +54,21 @@ describe('Show work order', () => {
           'Contact Alert: Verbal Abuse or Threat of (VA)',
         ]
       )
+
+      // Run lighthouse audit for accessibility report
+      cy.audit()
+    })
+
+    it('Work order details', () => {
+      cy.get('.work-order-info').within(() => {
+        cy.contains('Status: In Progress')
+        cy.contains('Priority: U - Urgent (5 Working days)')
+        cy.contains('Raised by Dummy Agent')
+        cy.contains('18 Jan 2021, 3:28 pm')
+        cy.contains('Target: 23 Jan 2021, 6:30 pm')
+        cy.contains('Caller: Jill Smith')
+        cy.contains('07700 900999')
+      })
 
       // Run lighthouse audit for accessibility report
       cy.audit()

--- a/src/components/Property/PropertyDetails.js
+++ b/src/components/Property/PropertyDetails.js
@@ -27,12 +27,14 @@ const PropertyDetails = ({
         />
       </div>
       <PropertyDetailsGrid
+        propertyReference={propertyReference}
         address={address}
         locationAlerts={locationAlerts}
         personAlerts={personAlerts}
         subTypeDescription="Property details"
         tenure={tenure}
         canRaiseRepair={canRaiseRepair}
+        hasLinkToProperty={false}
       />
       {canRaiseRepair && (
         <RepairsHistoryView propertyReference={propertyReference} />

--- a/src/components/Property/PropertyDetailsAddress.js
+++ b/src/components/Property/PropertyDetailsAddress.js
@@ -1,26 +1,50 @@
 import PropTypes from 'prop-types'
+import Link from 'next/link'
 
-const PropertyDetailsAddress = ({ address }) => {
+const Address = ({ address }) => {
   return (
-    <>
+    <div className="text-!-green govuk-!-font-weight-bold">
       {address.addressLine}
       <br></br>
       {address.streetSuffix && (
         <>
-          <span className="govuk-!-font-weight-bold text-green">
-            {address.streetSuffix}
-          </span>
+          {address.streetSuffix}
           <br></br>
         </>
       )}
+      <span className="govuk-!-font-size-14">{address.postalCode}</span>
+    </div>
+  )
+}
 
-      <span className="govuk-body-xs text-green">{address.postalCode}</span>
-    </>
+const PropertyDetailsAddress = ({
+  address,
+  propertyReference,
+  subTypeDescription,
+  hasLinkToProperty,
+}) => {
+  return (
+    <div className="property-details-main-section">
+      <span className="govuk-!-font-size-14">{subTypeDescription}</span>
+      <br></br>
+      {hasLinkToProperty ? (
+        <Link href={`/properties/${propertyReference}`}>
+          <a>
+            <Address address={address} />
+          </a>
+        </Link>
+      ) : (
+        <Address address={address} />
+      )}
+    </div>
   )
 }
 
 PropertyDetailsAddress.propTypes = {
   address: PropTypes.object.isRequired,
+  propertyReference: PropTypes.string.isRequired,
+  subTypeDescription: PropTypes.string.isRequired,
+  hasLinkToProperty: PropTypes.bool.isRequired,
 }
 
 export default PropertyDetailsAddress

--- a/src/components/Property/PropertyDetailsGrid.js
+++ b/src/components/Property/PropertyDetailsGrid.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import PropertyDetailsAddress from './PropertyDetailsAddress'
 import TenureAlertDetails from './TenureAlertDetails'
-import Link from 'next/link'
 
 const PropertyDetailsGrid = ({
   propertyReference,
@@ -17,21 +16,12 @@ const PropertyDetailsGrid = ({
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-one-half">
         <div className="govuk-body-s">
-          <div className="property-details-main-section">
-            <span className="govuk-body-xs">{subTypeDescription}</span>
-            <br></br>
-            <span className="govuk-!-font-weight-bold text-green">
-              {hasLinkToProperty ? (
-                <Link href={`/properties/${propertyReference}`}>
-                  <a>
-                    <PropertyDetailsAddress address={address} />
-                  </a>
-                </Link>
-              ) : (
-                <PropertyDetailsAddress address={address} />
-              )}
-            </span>
-          </div>
+          <PropertyDetailsAddress
+            address={address}
+            propertyReference={propertyReference}
+            subTypeDescription={subTypeDescription}
+            hasLinkToProperty={hasLinkToProperty}
+          />
 
           <TenureAlertDetails
             tenure={tenure}

--- a/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
+++ b/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
@@ -40,28 +40,24 @@ exports[`PropertyDetails component should render properly 1`] = `
             class="property-details-main-section"
           >
             <span
-              class="govuk-body-xs"
+              class="govuk-!-font-size-14"
             >
               Property details
             </span>
             <br />
-            <span
-              class="govuk-!-font-weight-bold text-green"
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
             >
               16 Pitcairn House
               <br />
-              <span
-                class="govuk-!-font-weight-bold text-green"
-              >
-                St Thomass Square
-              </span>
+              St Thomass Square
               <br />
               <span
-                class="govuk-body-xs text-green"
+                class="govuk-!-font-size-14"
               >
                 E9 6PT
               </span>
-            </span>
+            </div>
           </div>
           <ul
             class="hackney-property-alerts"

--- a/src/components/WorkOrder/AppointmentDetails.js
+++ b/src/components/WorkOrder/AppointmentDetails.js
@@ -1,0 +1,10 @@
+const AppointmentDetails = () => {
+  return (
+    <div className="appointment-details">
+      <span className="govuk-!-font-size-14">Appointment details</span>
+      <br></br>
+    </div>
+  )
+}
+
+export default AppointmentDetails

--- a/src/components/WorkOrder/WorkOrderDetails.js
+++ b/src/components/WorkOrder/WorkOrderDetails.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import PropertyDetailsGrid from '../Property/PropertyDetailsGrid'
+import WorkOrderHeader from './WorkOrderHeader'
 
 const WorkOrderDetails = ({
   propertyReference,
@@ -16,8 +16,9 @@ const WorkOrderDetails = ({
       <h1 className="govuk-heading-l">Works order: {workOrder.reference}</h1>
       <p className="govuk-body-m">{workOrder.description}</p>
 
-      <PropertyDetailsGrid
+      <WorkOrderHeader
         propertyReference={propertyReference}
+        workOrder={workOrder}
         address={address}
         locationAlerts={locationAlerts}
         personAlerts={personAlerts}

--- a/src/components/WorkOrder/WorkOrderDetails.test.js
+++ b/src/components/WorkOrder/WorkOrderDetails.test.js
@@ -12,6 +12,12 @@ describe('WorkOrderDetails component', () => {
       owner: '',
       description: 'This is an urgent repair description',
       propertyReference: '00014888',
+      status: 'In Progress',
+      priorityCode: 2,
+      raisedBy: 'Dummy Agent',
+      target: '2021-01-23T18:30:00.00000',
+      callerName: 'Jill Smith',
+      callerNumber: '07700 900999',
     },
     property: {
       propertyReference: '00012345',

--- a/src/components/WorkOrder/WorkOrderHeader.js
+++ b/src/components/WorkOrder/WorkOrderHeader.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types'
+import PropertyDetailsAddress from '../Property/PropertyDetailsAddress'
+import TenureAlertDetails from '../Property/TenureAlertDetails'
+import WorkOrderInfo from './WorkOrderInfo'
+import AppointmentDetails from './AppointmentDetails'
+
+const WorkOrderHeader = ({
+  propertyReference,
+  workOrder,
+  address,
+  subTypeDescription,
+  locationAlerts,
+  personAlerts,
+  tenure,
+  canRaiseRepair,
+}) => {
+  console.log(workOrder)
+  return (
+    <div className="govuk-body-s govuk-grid-row">
+      <div className="govuk-grid-column-one-third">
+        <PropertyDetailsAddress
+          address={address}
+          propertyReference={propertyReference}
+          subTypeDescription={subTypeDescription}
+          hasLinkToProperty={true}
+        />
+
+        <TenureAlertDetails
+          tenure={tenure}
+          locationAlerts={locationAlerts}
+          personAlerts={personAlerts}
+          canRaiseRepair={canRaiseRepair}
+        />
+      </div>
+      <div className="govuk-grid-column-one-third">
+        <WorkOrderInfo workOrder={workOrder} />
+      </div>
+      <div className="govuk-grid-column-one-third">
+        <AppointmentDetails />
+      </div>
+    </div>
+  )
+}
+
+WorkOrderHeader.propTypes = {
+  propertyReference: PropTypes.string.isRequired,
+  workOrder: PropTypes.object.isRequired,
+  address: PropTypes.object.isRequired,
+  subTypeDescription: PropTypes.string.isRequired,
+  locationAlerts: PropTypes.array.isRequired,
+  personAlerts: PropTypes.array.isRequired,
+  tenure: PropTypes.object.isRequired,
+  canRaiseRepair: PropTypes.bool.isRequired,
+}
+
+export default WorkOrderHeader

--- a/src/components/WorkOrder/WorkOrderInfo.js
+++ b/src/components/WorkOrder/WorkOrderInfo.js
@@ -4,7 +4,7 @@ import { formatDateTime } from '../../utils/time'
 const WorkOrderInfo = ({ workOrder }) => {
   return (
     <div className="work-order-info">
-      <span className="govuk-!-font-size-14">Works Order</span>
+      <span className="govuk-!-font-size-14">Works order</span>
 
       <div className="govuk-body-s govuk-!-margin-bottom-2">
         <span className="govuk-!-font-weight-bold">

--- a/src/components/WorkOrder/WorkOrderInfo.js
+++ b/src/components/WorkOrder/WorkOrderInfo.js
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types'
+import { formatDateTime } from '../../utils/time'
+
+const WorkOrderInfo = ({ workOrder }) => {
+  return (
+    <div className="work-order-info">
+      <span className="govuk-!-font-size-14">Works Order</span>
+
+      <div className="govuk-body-s govuk-!-margin-bottom-2">
+        <span className="govuk-!-font-weight-bold">
+          Status: {workOrder.status}
+        </span>
+        <br></br>
+        {workOrder.priorityCode == 1 ? (
+          <span className="text-danger govuk-!-font-size-14">
+            Priority: {workOrder.priority}
+          </span>
+        ) : (
+          <span className="govuk-!-font-size-14">
+            Priority: {workOrder.priority}
+          </span>
+        )}
+      </div>
+
+      <div className="govuk-body-xs govuk-!-margin-bottom-2">
+        <span>Raised by {workOrder.raisedBy}</span>
+        {workOrder.dateRaised && (
+          <>
+            <br></br>
+            <span>{formatDateTime(workOrder.dateRaised)}</span>
+          </>
+        )}
+      </div>
+
+      {workOrder.target && (
+        <div className="govuk-body-xs govuk-!-margin-bottom-2">
+          <span className="govuk-!-font-weight-bold">
+            Target: {formatDateTime(workOrder.target)}
+          </span>
+        </div>
+      )}
+
+      {workOrder.callerName && (
+        <div className="govuk-body-xs govuk-!-margin-bottom-2">
+          <span>Caller: {workOrder.callerName}</span>
+          {workOrder.callerNumber && (
+            <>
+              <br></br>
+              <span>{workOrder.callerNumber}</span>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+WorkOrderInfo.propTypes = {
+  workOrder: PropTypes.object.isRequired,
+}
+
+export default WorkOrderInfo

--- a/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
@@ -26,32 +26,28 @@ exports[`WorkOrderDetails component should render properly 1`] = `
             class="property-details-main-section"
           >
             <span
-              class="govuk-body-xs"
+              class="govuk-!-font-size-14"
             >
               Dwelling
             </span>
             <br />
-            <span
-              class="govuk-!-font-weight-bold text-green"
+            <a
+              href="/properties/00012345"
             >
-              <a
-                href="/properties/00012345"
+              <div
+                class="text-!-green govuk-!-font-weight-bold"
               >
                 16 Pitcairn House
                 <br />
-                <span
-                  class="govuk-!-font-weight-bold text-green"
-                >
-                  St Thomass Square
-                </span>
+                St Thomass Square
                 <br />
                 <span
-                  class="govuk-body-xs text-green"
+                  class="govuk-!-font-size-14"
                 >
                   E9 6PT
                 </span>
-              </a>
-            </span>
+              </div>
+            </a>
           </div>
           <ul
             class="hackney-property-alerts"

--- a/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
@@ -79,7 +79,7 @@ exports[`WorkOrderDetails component should render properly 1`] = `
           <span
             class="govuk-!-font-size-14"
           >
-            Works Order
+            Works order
           </span>
           <div
             class="govuk-body-s govuk-!-margin-bottom-2"

--- a/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
@@ -14,64 +14,133 @@ exports[`WorkOrderDetails component should render properly 1`] = `
       This is an urgent repair description
     </p>
     <div
-      class="govuk-grid-row"
+      class="govuk-body-s govuk-grid-row"
     >
       <div
-        class="govuk-grid-column-one-half"
+        class="govuk-grid-column-one-third"
       >
         <div
-          class="govuk-body-s"
+          class="property-details-main-section"
         >
-          <div
-            class="property-details-main-section"
+          <span
+            class="govuk-!-font-size-14"
           >
+            Dwelling
+          </span>
+          <br />
+          <a
+            href="/properties/00012345"
+          >
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
+            >
+              16 Pitcairn House
+              <br />
+              St Thomass Square
+              <br />
+              <span
+                class="govuk-!-font-size-14"
+              >
+                E9 6PT
+              </span>
+            </div>
+          </a>
+        </div>
+        <ul
+          class="hackney-property-alerts"
+        >
+          <li
+            class="bg-turquoise"
+          >
+            Tenure: Secure
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Address Alert:  (
+            <strong />
+            )
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Contact Alert:  (
+            <strong />
+            )
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="work-order-info"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Works Order
+          </span>
+          <div
+            class="govuk-body-s govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Status: In Progress
+            </span>
+            <br />
             <span
               class="govuk-!-font-size-14"
             >
-              Dwelling
+              Priority: U - Urgent (5 Working days)
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Raised by Dummy Agent
             </span>
             <br />
-            <a
-              href="/properties/00012345"
-            >
-              <div
-                class="text-!-green govuk-!-font-weight-bold"
-              >
-                16 Pitcairn House
-                <br />
-                St Thomass Square
-                <br />
-                <span
-                  class="govuk-!-font-size-14"
-                >
-                  E9 6PT
-                </span>
-              </div>
-            </a>
+            <span>
+              18 Jan 2021, 3:28 pm
+            </span>
           </div>
-          <ul
-            class="hackney-property-alerts"
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
           >
-            <li
-              class="bg-turquoise"
+            <span
+              class="govuk-!-font-weight-bold"
             >
-              Tenure: Secure
-            </li>
-            <li
-              class="bg-orange"
-            >
-              Address Alert:  (
-              <strong />
-              )
-            </li>
-            <li
-              class="bg-orange"
-            >
-              Contact Alert:  (
-              <strong />
-              )
-            </li>
-          </ul>
+              Target: 23 Jan 2021, 6:30 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Caller: Jill Smith
+            </span>
+            <br />
+            <span>
+              07700 900999
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="appointment-details"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Appointment details
+          </span>
+          <br />
         </div>
       </div>
     </div>

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -22,8 +22,17 @@ $repairs-hub-colours: (
 .text-green {
   color: repairs-hub-colour('housing-2');
 }
+
 .text-white {
   color: repairs-hub-colour('white');
+}
+
+.text-\!-green {
+  color: repairs-hub-colour('housing-2') !important;
+}
+
+.text-\!-white {
+  color: repairs-hub-colour('white') !important;
 }
 
 .background-green {

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -3,6 +3,7 @@ $repairs-hub-colours: (
   'housing-2': #009ca6,
   'housing-3': #2dccd3,
   'warning': #ffa300,
+  'danger': #be3a34,
   'white': govuk-colour('white'),
   'black': govuk-colour('black'),
   'grey': grey,
@@ -25,6 +26,14 @@ $repairs-hub-colours: (
 
 .text-white {
   color: repairs-hub-colour('white');
+}
+
+.text-warning {
+  color: repairs-hub-colour('warning');
+}
+
+.text-danger {
+  color: repairs-hub-colour('danger');
 }
 
 .text-\!-green {

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -4,3 +4,17 @@ export const extractTimeFromDate = (date) =>
     minute: 'numeric',
     hour12: true,
   })
+
+export const formatDateTime = (datetime) => {
+  if (typeof datetime === 'string') {
+    datetime = new Date(datetime)
+  }
+  return datetime.toLocaleString('en-GB', {
+    hour12: true,
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}

--- a/src/utils/time.test.js
+++ b/src/utils/time.test.js
@@ -1,4 +1,4 @@
-import { extractTimeFromDate } from './time'
+import { extractTimeFromDate, formatDateTime } from './time'
 
 describe('time', () => {
   describe('extractTimeFromDate', () => {
@@ -8,6 +8,18 @@ describe('time', () => {
       )
 
       expect(extractTimeFromDate(date)).toEqual('3:46 pm')
+    })
+  })
+
+  describe('formatDateTime', () => {
+    it('formats date/time passed as a Date object', () => {
+      const datetime = new Date('2021-01-20T15:16:57Z')
+      expect(formatDateTime(datetime)).toEqual('20 Jan 2021, 3:16 pm')
+    })
+
+    it('formats date/time passed as a String object', () => {
+      const datetime = '2021-01-20T15:16:57Z'
+      expect(formatDateTime(datetime)).toEqual('20 Jan 2021, 3:16 pm')
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,10 +2819,10 @@ cypress-dotenv@^1.2.2:
     dotenv-parse-variables "^0.2.3"
     lodash.clonedeep "^2.0.0"
 
-cypress@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.1.0.tgz#af2596cb110aa98eaf75fef3d8ab379ca0ff2413"
-  integrity sha512-uQnSxRcZ6hkf9R5cr8KpRBTzN88QZwLIImbf5DWa5RIxH6o5Gpff58EcjiYhAR8/8p9SGv7O6SRygq4H+k0Qpw==
+cypress@^6.3.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.4.0.tgz#432c516bf4f1a0f042a6aa1f2c3a4278fa35a8b2"
+  integrity sha512-SrsPsZ4IBterudkoFYBvkQmXOVxclh1/+ytbzpV8AH/D2FA+s2Qy5ISsaRzOFsbQa4KZWoi3AKwREmF1HucYkg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
@@ -2838,6 +2838,7 @@ cypress@^6.1.0:
     cli-table3 "~0.6.0"
     commander "^5.1.0"
     common-tags "^1.8.0"
+    dayjs "^1.9.3"
     debug "^4.1.1"
     eventemitter2 "^6.4.2"
     execa "^4.0.2"
@@ -2852,7 +2853,7 @@ cypress@^6.1.0:
     lodash "^4.17.19"
     log-symbols "^4.0.0"
     minimist "^1.2.5"
-    moment "^2.27.0"
+    moment "^2.29.1"
     ospath "^1.2.2"
     pretty-bytes "^5.4.1"
     ramda "~0.26.1"
@@ -2903,6 +2904,11 @@ date-fns@^2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
+dayjs@^1.9.3:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
+  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -6591,7 +6597,7 @@ mockdate@^3.0.2:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
   integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
 
-moment@^2.27.0:
+moment@^2.27.0, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
### Trello Card

https://trello.com/c/hDl1Z4Yc/316-as-a-repairs-hub-user-i-can-select-and-view-the-work-order-with-the-work-order-details-so-that-i-can-view-the-details-of-the-job

### Description

Displays the information returned by the API for the WorkOrder entity.

![image](https://user-images.githubusercontent.com/6321/106618390-51012b00-6567-11eb-880a-aa7db3bd5f8d.png)

### Notes

The API is currently returning some dummy information as it's not clear where some of it should come from, however this shouldn't affect merging of this story since it will just display whatever is returned by the API.