### PR TITLE
Update serverless timeout to 10

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '2'
 provider:
   name: aws
   runtime: nodejs12.x
+  timeout: 10
   region: eu-west-2
   stage: ${opt:stage}
   apiGateway:


### PR DESCRIPTION
### Description of change

- A default of 6 exists so any change to the timeout in aws is overriden upon deployment
- https://www.serverless.com/framework/docs/providers/aws/guide/functions/