### PR TITLE
Pass the user JWT back to the API

### DIFF
--- a/src/pages/api/[...path].js
+++ b/src/pages/api/[...path].js
@@ -1,7 +1,10 @@
+import cookie from 'cookie'
 import * as HttpStatus from 'http-status-codes'
 
 import { serviceAPIRequest } from '../../utils/service-api-client'
 import { isAuthorised } from '../../utils/GoogleAuth'
+
+const { GSSO_TOKEN_NAME } = process.env
 
 // Catch-all endpoint. Assumes incoming requests have paths and params
 // matching those on the service API endpoint so it can forward them
@@ -23,11 +26,15 @@ export default async (req, res) => {
       }
     }
 
+    const cookies = cookie.parse(req.headers.cookie ?? '')
+    const token = cookies[GSSO_TOKEN_NAME]
+
     const data = await serviceAPIRequest(
       req.method,
       path.join('/'),
       queryParams,
-      req.body
+      req.body,
+      token
     )
 
     res.status(HttpStatus.OK).json(data)

--- a/src/pages/api/[...path].test.js
+++ b/src/pages/api/[...path].test.js
@@ -16,8 +16,6 @@ const {
   CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
 } = process.env
 
-const headers = { 'x-api-key': REPAIRS_SERVICE_API_KEY }
-
 describe('/api/[...path]', () => {
   test('returns a not authorised error when there is no auth cookie', async () => {
     const req = createRequest()
@@ -65,6 +63,11 @@ describe('/api/[...path]', () => {
       },
       HACKNEY_JWT_SECRET
     )
+
+    const headers = {
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+    }
 
     describe('reflects errors from the service API', () => {
       test('when it returns a 404 not found', async () => {
@@ -212,6 +215,11 @@ describe('GET /api/repairs', () => {
       },
       HACKNEY_JWT_SECRET
     )
+
+    const headers = {
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+    }
 
     test('retrieves and sends the ref as a query parameter even if the user has forced a different param into the request', async () => {
       const req = createRequest({

--- a/src/utils/service-api-client.js
+++ b/src/utils/service-api-client.js
@@ -2,9 +2,18 @@ import axios from 'axios'
 
 const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_KEY } = process.env
 
-const headers = { 'x-api-key': REPAIRS_SERVICE_API_KEY }
+export const serviceAPIRequest = async (
+  method,
+  path,
+  queryParams,
+  body,
+  token
+) => {
+  const headers = {
+    'x-api-key': REPAIRS_SERVICE_API_KEY,
+    'x-hackney-user': token,
+  }
 
-export const serviceAPIRequest = async (method, path, queryParams, body) => {
   const { data } = await axios({
     method,
     headers,


### PR DESCRIPTION
This is so that it can log who performed what actions.
