### PR TITLE
Send up caller name correctly

### DIFF
--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -333,20 +333,13 @@ describe('Raise repair form', () => {
                 name: {
                   full: 'Bob Leek',
                 },
-                contact: [
+                communication: [
                   {
-                    name: {
-                      full: 'Bob Leek',
+                    channel: {
+                      medium: '20',
+                      code: '60',
                     },
-                    communication: [
-                      {
-                        channel: {
-                          medium: '20',
-                          code: '60',
-                        },
-                        value: '07788659111',
-                      },
-                    ],
+                    value: '07788659111',
                   },
                 ],
               },

--- a/src/utils/hact/raise-repair-form.js
+++ b/src/utils/hact/raise-repair-form.js
@@ -75,22 +75,15 @@ export const buildScheduleRepairFormData = (formData) => {
         name: {
           full: formData.callerName,
         },
-        contact: [
+        communication: [
           {
-            name: {
-              full: formData.callerName,
+            channel: {
+              // Audio
+              medium: '20',
+              // Mobile Phone
+              code: '60',
             },
-            communication: [
-              {
-                channel: {
-                  // Audio
-                  medium: '20',
-                  // Mobile Phone
-                  code: '60',
-                },
-                value: formData.contactNumber,
-              },
-            ],
+            value: formData.contactNumber,
           },
         ],
       },

--- a/src/utils/hact/raise-repair-form.test.js
+++ b/src/utils/hact/raise-repair-form.test.js
@@ -107,20 +107,13 @@ describe('buildRaiseRepairFormData', () => {
           name: {
             full: 'John Smith',
           },
-          contact: [
+          communication: [
             {
-              name: {
-                full: 'John Smith',
+              channel: {
+                medium: '20',
+                code: '60',
               },
-              communication: [
-                {
-                  channel: {
-                    medium: '20',
-                    code: '60',
-                  },
-                  value: '07788777888',
-                },
-              ],
+              value: '07788777888',
             },
           ],
         },


### PR DESCRIPTION
### Description of change

Originally sent up in wrong place - this should solve it
.NET repairs api code:
```CallerNumber = workOrder.Customer?.Person?.Communication?.Where(cc => cc.Channel?.Medium == Generated.CommunicationMediumCode._20 /* Audio */).FirstOrDefault()```

