### PR TITLE
Enable manual production deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,13 +72,13 @@ jobs:
           name: deploy
           command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
 
-  # build-deploy-production:
-  #   executor: aws-cli/default
-  #   steps:
-  #     - *attach_workspace
-  #     - run:
-  #         name: deploy
-  #         command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy -s production
+  build-deploy-production:
+    executor: aws-cli/default
+    steps:
+      - *attach_workspace
+      - run:
+          name: deploy
+          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production
 
   assume-role-staging:
     executor: docker-python
@@ -93,18 +93,18 @@ jobs:
           paths:
             - .aws
 
-  # assume-role-production:
-  #   executor: docker-python
-  #   steps:
-  #     - checkout
-  #     - aws_assume_role/assume_role:
-  #         account: $AWS_ACCOUNT_PRODUCTION
-  #         profile_name: default
-  #         role: 'LBH_Circle_CI_Deployment_Role'
-  #     - persist_to_workspace:
-  #         root: *workspace_root
-  #         paths:
-  #           - .aws
+  assume-role-production:
+    executor: docker-python
+    steps:
+      - checkout
+      - aws_assume_role/assume_role:
+          account: $AWS_ACCOUNT_PRODUCTION
+          profile_name: default
+          role: 'LBH_Circle_CI_Deployment_Role'
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
 
 workflows:
   version: 2
@@ -131,20 +131,23 @@ workflows:
           filters:
             branches:
               only: main
-      # - permit-deploy-production:
-      #     type: approval
-      #     requires:
-      #       - build-deploy-staging
-      #     filters:
-      #       branches:
-      #         only: main
-      # - assume-role-production:
-      #     context: api-assume-role-production-context
-      #     requires:
-      #       - permit-deploy-production
-      #     filters:
-      #       branches:
-      #         only: main
-      # - build-deploy-production:
-      #     requires:
-      #       - assume-role-production
+      - permit-deploy-production:
+          type: approval
+          requires:
+            - build-deploy-staging
+          filters:
+            branches:
+              only: main
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+            - permit-deploy-production
+          filters:
+            branches:
+              only: main
+      - build-deploy-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: main

--- a/serverless.yml
+++ b/serverless.yml
@@ -98,16 +98,16 @@ custom:
     production: repairs-hub.hackney.gov.uk
   certificate-arn:
     staging: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
-    production: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
+    production: arn:aws:acm:us-east-1:282997303675:certificate/a43b1303-83ff-496e-b7a2-a75fa3ebfe87
   securityGroups:
     staging:
       - sg-0166cbf56b7e77af0
     production:
-      - sg-04b71cc889c5790e7
+      - sg-0c40b8cfd2d03c359
   subnets:
     staging:
       - subnet-06d3de1bd9181b0d7
       - subnet-0ed7d7713d1127656
     production:
-      - subnet-0b7b8fea07efabf34
-      - subnet-01d3657f97a243261
+      - subnet-0beb266003a56ca82
+      - subnet-06a697d86a9b6ed01


### PR DESCRIPTION
### Description of change

Enable **manual** production deployments.

This will enable anyone with push access to the repo to approve a production deployment for up to 15 days after the job is run.

Here is an [example CI workflow](https://app.circleci.com/pipelines/github/LBHackney-IT/repairs-hub-frontend/565/workflows/1a946369-ec54-424b-906f-3cab285f84d4) using this new configuration showing an approved step (temporarily set to this current branch). The real workflow will be a bit different because there will be staging deploy steps not included in the above.

### Story Link

https://trello.com/c/adDtZ5Uo/389-deploy-frontend-to-production-under-hackney-domain

### Circle CI screenshots

<img width="1015" alt="Screenshot 2021-02-19 at 14 13 48" src="https://user-images.githubusercontent.com/1370570/108532724-0bb35c00-72d0-11eb-84f8-99ad839a0a0e.png">

<img width="842" alt="Screenshot 2021-02-19 at 14 13 52" src="https://user-images.githubusercontent.com/1370570/108532739-10781000-72d0-11eb-94f0-24bb2d59c660.png">

![image](https://user-images.githubusercontent.com/1370570/108532974-5cc35000-72d0-11eb-8e59-603154dc368c.png)


### Before Merge

- [x] Remove temporary commit to deploy this branch
- [x] Check if this is pointed at the correct AWS Account
- [x] Add required vars to Circle CI
