### PR TITLE
Add per-resource user authorisation

### DIFF
--- a/__test__/_app.test.js
+++ b/__test__/_app.test.js
@@ -1,0 +1,109 @@
+import MyApp from '../src/pages/_app'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../src/utils/user'
+
+import { createRequest, createResponse } from 'node-mocks-http'
+import jsonwebtoken from 'jsonwebtoken'
+import * as HttpStatus from 'http-status-codes'
+
+const {
+  REPAIRS_AGENTS_GOOGLE_GROUPNAME,
+  HACKNEY_JWT_SECRET,
+  GSSO_TOKEN_NAME,
+} = process.env
+
+describe('MyApp.getInitialProps', () => {
+  describe('when the context contains a valid user token', () => {
+    const signedCookie = jsonwebtoken.sign(
+      {
+        name: 'name',
+        email: 'name@example.com',
+        groups: [REPAIRS_AGENTS_GOOGLE_GROUPNAME],
+      },
+      HACKNEY_JWT_SECRET
+    )
+
+    const headers = { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` }
+
+    describe('when the component permittedRoles contains a role matching the user role', () => {
+      const req = createRequest({ headers })
+      const res = createResponse()
+
+      const context = {
+        req,
+        res,
+        pathname: '',
+      }
+
+      const component = {
+        permittedRoles: [AGENT_ROLE], // matches the detected user role from their token
+      }
+
+      it('returns an object representing the user', async () => {
+        const { userDetails } = await MyApp.getInitialProps({
+          ctx: context,
+          Component: component,
+        })
+
+        expect(userDetails).toMatchObject({
+          name: 'name',
+          email: 'name@example.com',
+          hasAgentPermissions: true,
+          hasContractorPermissions: false,
+          hasAnyPermissions: true,
+        })
+      })
+    })
+
+    describe('when the component permittedRoles does not contain a role matching the user role', () => {
+      const req = createRequest({ headers })
+      const res = createResponse()
+
+      const context = {
+        req,
+        res,
+        pathname: '',
+      }
+
+      const component = {
+        permittedRoles: [CONTRACTOR_ROLE], // does not match the user role from their token
+      }
+
+      it('returns an empty object and writes a redirect to the access denied page', async () => {
+        const result = await MyApp.getInitialProps({
+          ctx: context,
+          Component: component,
+        })
+
+        expect(result).toEqual({})
+
+        expect(res._getStatusCode()).toBe(HttpStatus.MOVED_TEMPORARILY)
+        expect(res._getHeaders()).toEqual({ location: '/access-denied' })
+      })
+    })
+
+    describe('when the component contains no permittedRoles', () => {
+      const req = createRequest({ headers })
+      const res = createResponse()
+
+      const context = {
+        req,
+        res,
+        pathname: '',
+      }
+
+      const component = {}
+
+      it('returns an empty object and writes a redirect to the access denied page', async () => {
+        const result = await MyApp.getInitialProps({
+          ctx: context,
+          Component: component,
+        })
+
+        expect(result).toEqual({})
+
+        expect(res._getStatusCode()).toBe(HttpStatus.MOVED_TEMPORARILY)
+        expect(res._getHeaders()).toEqual({ location: '/access-denied' })
+      })
+    })
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,8 @@ module.exports = {
     '/node_modules/',
     '^.+\\.module\\.(css|sass|scss)$',
   ],
-  moduleNameMapper: {
-    '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
-  },
   moduleDirectories: ['node_modules', '.'],
+  moduleNameMapper: {
+    '^.+\\.(css|scss)$': '<rootDir>/src/styles/__mocks__/styleMock.js',
+  },
 }

--- a/src/components/AccessDenied.js
+++ b/src/components/AccessDenied.js
@@ -1,0 +1,7 @@
+const AccessDenied = () => (
+  <div>
+    <h1>Access denied</h1>
+  </div>
+)
+
+export default AccessDenied

--- a/src/pages/access-denied.js
+++ b/src/pages/access-denied.js
@@ -1,10 +1,7 @@
 import { redirectToHome, isAuthorised } from '../utils/GoogleAuth'
+import AccessDenied from '../components/AccessDenied'
 
-const AccessDenied = () => (
-  <div>
-    <h1>Access denied</h1>
-  </div>
-)
+const AccessDeniedPage = () => <AccessDenied></AccessDenied>
 
 export const getServerSideProps = async (ctx) => {
   const user = isAuthorised(ctx)
@@ -16,4 +13,4 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-export default AccessDenied
+export default AccessDeniedPage

--- a/src/pages/access-denied.js
+++ b/src/pages/access-denied.js
@@ -3,15 +3,12 @@ import { redirectToHome, isAuthorised } from '../utils/GoogleAuth'
 const AccessDenied = () => (
   <div>
     <h1>Access denied</h1>
-    <p className="govuk-body">
-      Sorry, but access to that page is for administrators only.
-    </p>
   </div>
 )
 
 export const getServerSideProps = async (ctx) => {
   const user = isAuthorised(ctx)
-  if (user && user.hasAnyPermissions) {
+  if (!user || !user.hasAnyPermissions) {
     redirectToHome(ctx.res)
   }
   return {

--- a/src/pages/api/[...path].js
+++ b/src/pages/api/[...path].js
@@ -1,4 +1,3 @@
-import cookie from 'cookie'
 import * as HttpStatus from 'http-status-codes'
 
 import {
@@ -6,16 +5,11 @@ import {
   authoriseServiceAPIRequest,
 } from '../../utils/service-api-client'
 
-const { GSSO_TOKEN_NAME } = process.env
-
 // Catch-all endpoint. Assumes incoming requests have paths and params
 // matching those on the service API endpoint so it can forward them
 // without any additional knowledge.
 export default authoriseServiceAPIRequest(async (req, res) => {
-  const cookies = cookie.parse(req.headers.cookie ?? '')
-  const token = cookies[GSSO_TOKEN_NAME]
-
-  const data = await serviceAPIRequest(req, token)
+  const data = await serviceAPIRequest(req)
 
   res.status(HttpStatus.OK).json(data)
 })

--- a/src/pages/api/[...path].test.js
+++ b/src/pages/api/[...path].test.js
@@ -13,7 +13,6 @@ const {
   HACKNEY_JWT_SECRET,
   REPAIRS_AGENTS_GOOGLE_GROUPNAME,
   GSSO_TOKEN_NAME,
-  CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
 } = process.env
 
 describe('/api/[...path]', () => {
@@ -199,55 +198,6 @@ describe('/api/[...path]', () => {
 
         // Expect the Node API response to reflect the service API response
         expect(res._getStatusCode()).toBe(200)
-      })
-    })
-  })
-})
-
-// Special case for scoping jobs to contractors
-describe('GET /api/repairs', () => {
-  describe('when called by a contractor with a contractorRef', () => {
-    const signedCookie = jsonwebtoken.sign(
-      {
-        name: 'name',
-        email: 'name@example.com',
-        groups: [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME], // mapped internally to the 'H01' contractor Ref
-      },
-      HACKNEY_JWT_SECRET
-    )
-
-    const headers = {
-      'x-api-key': REPAIRS_SERVICE_API_KEY,
-      'x-hackney-user': signedCookie,
-    }
-
-    test('retrieves and sends the ref as a query parameter even if the user has forced a different param into the request', async () => {
-      const req = createRequest({
-        method: 'get',
-        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
-        query: {
-          path: ['repairs'],
-          ContractorReference: 'give-me-unauthorised-results', // simulate a user forcing another ref
-        },
-      })
-
-      axios.mockImplementationOnce(() =>
-        Promise.resolve({
-          status: 200,
-        })
-      )
-
-      const res = createResponse()
-
-      await catchAllEndpoint(req, res)
-
-      expect(axios).toHaveBeenCalledTimes(1)
-      expect(axios).toHaveBeenCalledWith({
-        method: 'get',
-        headers,
-        url: `${REPAIRS_SERVICE_API_URL}/repairs`,
-        params: { ContractorReference: 'H01' }, // request to service API made with user's contractor ref from cookie
-        data: {},
       })
     })
   })

--- a/src/pages/api/repairs.js
+++ b/src/pages/api/repairs.js
@@ -1,5 +1,4 @@
 import * as HttpStatus from 'http-status-codes'
-import cookie from 'cookie'
 
 import { CONTRACTOR_ROLE } from '../../utils/user'
 import {
@@ -7,12 +6,7 @@ import {
   authoriseServiceAPIRequest,
 } from '../../utils/service-api-client'
 
-const { GSSO_TOKEN_NAME } = process.env
-
 export default authoriseServiceAPIRequest(async (req, res, user) => {
-  const cookies = cookie.parse(req.headers.cookie ?? '')
-  const token = cookies[GSSO_TOKEN_NAME]
-
   // Inject contractor query param for repair index requests
   if (req.method.toLowerCase() === 'get' && user.hasRole(CONTRACTOR_ROLE)) {
     req.query = {
@@ -23,7 +17,7 @@ export default authoriseServiceAPIRequest(async (req, res, user) => {
 
   req.query = { ...req.query, path: ['repairs'] }
 
-  const data = await serviceAPIRequest(req, token)
+  const data = await serviceAPIRequest(req)
 
   res.status(HttpStatus.OK).json(data)
 })

--- a/src/pages/api/repairs.js
+++ b/src/pages/api/repairs.js
@@ -1,0 +1,29 @@
+import * as HttpStatus from 'http-status-codes'
+import cookie from 'cookie'
+
+import { CONTRACTOR_ROLE } from '../../utils/user'
+import {
+  serviceAPIRequest,
+  authoriseServiceAPIRequest,
+} from '../../utils/service-api-client'
+
+const { GSSO_TOKEN_NAME } = process.env
+
+export default authoriseServiceAPIRequest(async (req, res, user) => {
+  const cookies = cookie.parse(req.headers.cookie ?? '')
+  const token = cookies[GSSO_TOKEN_NAME]
+
+  // Inject contractor query param for repair index requests
+  if (req.method.toLowerCase() === 'get' && user.hasRole(CONTRACTOR_ROLE)) {
+    req.query = {
+      ...req.query,
+      ContractorReference: user.contractorReference,
+    }
+  }
+
+  req.query = { ...req.query, path: ['repairs'] }
+
+  const data = await serviceAPIRequest(req, token)
+
+  res.status(HttpStatus.OK).json(data)
+})

--- a/src/pages/api/repairs.test.js
+++ b/src/pages/api/repairs.test.js
@@ -1,0 +1,63 @@
+import axios from 'axios'
+import jsonwebtoken from 'jsonwebtoken'
+import { createRequest, createResponse } from 'node-mocks-http'
+
+import repairsEndpoint from './repairs.js'
+
+jest.mock('axios', () => jest.fn())
+
+const {
+  REPAIRS_SERVICE_API_URL,
+  REPAIRS_SERVICE_API_KEY,
+  HACKNEY_JWT_SECRET,
+  GSSO_TOKEN_NAME,
+  CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
+} = process.env
+
+describe('GET /api/repairs', () => {
+  const signedCookie = jsonwebtoken.sign(
+    {
+      name: 'name',
+      email: 'name@example.com',
+      groups: [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME], // mapped internally to the 'H01' contractor Ref
+    },
+    HACKNEY_JWT_SECRET
+  )
+
+  const headers = {
+    'x-api-key': REPAIRS_SERVICE_API_KEY,
+    'x-hackney-user': signedCookie,
+  }
+
+  describe("when called from a contractor's browser with a reference that doesn't apply to me", () => {
+    test('it always applies my contratorReference mapped from the user token', async () => {
+      const req = createRequest({
+        method: 'get',
+        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
+        query: {
+          path: ['repairs'],
+          ContractorReference: 'give-me-unauthorised-results', // simulate a user forcing another ref
+        },
+      })
+
+      axios.mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+        })
+      )
+
+      const res = createResponse()
+
+      await repairsEndpoint(req, res)
+
+      expect(axios).toHaveBeenCalledTimes(1)
+      expect(axios).toHaveBeenCalledWith({
+        method: 'get',
+        headers,
+        url: `${REPAIRS_SERVICE_API_URL}/repairs`,
+        params: { ContractorReference: 'H01' }, // request to service API made with user's contractor ref from cookie
+        data: {},
+      })
+    })
+  })
+})

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import Search from '../components/Search/Search'
 import JobView from '../components/WorkOrders/JobView'
 import UserContext from '../components/UserContext/UserContext'
 import { useContext } from 'react'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../utils/user'
 
 const Home = ({ query }) => {
   const { user } = useContext(UserContext)
@@ -30,5 +31,7 @@ export const getServerSideProps = async (ctx) => {
     },
   }
 }
+
+Home.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default Home

--- a/src/pages/logout.js
+++ b/src/pages/logout.js
@@ -1,4 +1,5 @@
 import { deleteSession } from '../utils/GoogleAuth'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../utils/user'
 
 const Logout = () => null
 
@@ -6,5 +7,7 @@ export const getServerSideProps = async ({ res }) => {
   deleteSession(res)
   return { props: {} }
 }
+
+Logout.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default Logout

--- a/src/pages/properties/[id]/index.js
+++ b/src/pages/properties/[id]/index.js
@@ -1,4 +1,5 @@
 import PropertyView from '../../../components/Property/PropertyView'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../../../utils/user'
 
 const PropertyPage = ({ query }) => {
   return <PropertyView propertyReference={query.id} />
@@ -13,5 +14,7 @@ export const getServerSideProps = async (ctx) => {
     },
   }
 }
+
+PropertyPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default PropertyPage

--- a/src/pages/properties/[id]/raise-repair/new.js
+++ b/src/pages/properties/[id]/raise-repair/new.js
@@ -1,4 +1,5 @@
 import RaiseRepairFormView from '../../../../components/Property/RaiseRepair/RaiseRepairFormView'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../../../../utils/user'
 
 const RaiseRepairPage = ({ query }) => {
   return <RaiseRepairFormView propertyReference={query.id} />
@@ -13,5 +14,7 @@ export const getServerSideProps = async (ctx) => {
     },
   }
 }
+
+RaiseRepairPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default RaiseRepairPage

--- a/src/pages/properties/search.js
+++ b/src/pages/properties/search.js
@@ -1,4 +1,5 @@
 import Search from '../../components/Search/Search'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../../utils/user'
 
 const SearchPage = ({ query }) => {
   return <Search query={query} />
@@ -13,5 +14,7 @@ export const getServerSideProps = async (ctx) => {
     },
   }
 }
+
+SearchPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default SearchPage

--- a/src/pages/repairs/jobs/[id]/choose-option.js
+++ b/src/pages/repairs/jobs/[id]/choose-option.js
@@ -1,4 +1,5 @@
 import ChooseOption from '../../../../components/WorkOrders/ChooseOption'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../../../../utils/user'
 
 const JobPage = ({ query }) => {
   return <ChooseOption reference={query.id} />
@@ -12,5 +13,7 @@ export const getServerSideProps = async (ctx) => {
     },
   }
 }
+
+JobPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default JobPage

--- a/src/pages/repairs/jobs/[id]/close-job.js
+++ b/src/pages/repairs/jobs/[id]/close-job.js
@@ -1,4 +1,5 @@
 import CloseJob from '../../../../components/WorkOrders/CloseJob'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../../../../utils/user'
 
 const JobPage = ({ query }) => {
   return <CloseJob reference={query.id} />
@@ -12,5 +13,7 @@ export const getServerSideProps = async (ctx) => {
     },
   }
 }
+
+JobPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default JobPage

--- a/src/pages/work-orders/[id].js
+++ b/src/pages/work-orders/[id].js
@@ -1,4 +1,5 @@
 import WorkOrderView from '../../components/WorkOrder/WorkOrderView'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../../utils/user'
 
 const WorkOrderPage = ({ query }) => {
   return <WorkOrderView workOrderReference={query.id} />
@@ -13,5 +14,7 @@ export const getServerSideProps = async (ctx) => {
     },
   }
 }
+
+WorkOrderPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default WorkOrderPage

--- a/src/styles/__mocks__/styleMock.js
+++ b/src/styles/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/src/utils/GoogleAuth.js
+++ b/src/utils/GoogleAuth.js
@@ -63,6 +63,7 @@ export const isAuthorised = ({ req, res }, withRedirect = false) => {
     if (!user.hasAnyPermissions) {
       return withRedirect && redirectToAcessDenied(res)
     }
+
     return user
   } catch (err) {
     if (err instanceof jsonwebtoken.JsonWebTokenError) {

--- a/src/utils/service-api-client.js
+++ b/src/utils/service-api-client.js
@@ -1,11 +1,19 @@
+import cookie from 'cookie'
 import axios from 'axios'
 import * as HttpStatus from 'http-status-codes'
 
 import { isAuthorised } from './GoogleAuth'
 
-const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_KEY } = process.env
+const {
+  REPAIRS_SERVICE_API_URL,
+  REPAIRS_SERVICE_API_KEY,
+  GSSO_TOKEN_NAME,
+} = process.env
 
-export const serviceAPIRequest = async (request, token) => {
+export const serviceAPIRequest = async (request) => {
+  const cookies = cookie.parse(request.headers.cookie ?? '')
+  const token = cookies[GSSO_TOKEN_NAME]
+
   const headers = {
     'x-api-key': REPAIRS_SERVICE_API_KEY,
     'x-hackney-user': token,

--- a/src/utils/service-api-client.js
+++ b/src/utils/service-api-client.js
@@ -1,26 +1,50 @@
 import axios from 'axios'
+import * as HttpStatus from 'http-status-codes'
+
+import { isAuthorised } from './GoogleAuth'
 
 const { REPAIRS_SERVICE_API_URL, REPAIRS_SERVICE_API_KEY } = process.env
 
-export const serviceAPIRequest = async (
-  method,
-  path,
-  queryParams,
-  body,
-  token
-) => {
+export const serviceAPIRequest = async (request, token) => {
   const headers = {
     'x-api-key': REPAIRS_SERVICE_API_KEY,
     'x-hackney-user': token,
   }
 
+  let { path, ...queryParams } = request.query
+
   const { data } = await axios({
-    method,
+    method: request.method,
     headers,
-    url: `${REPAIRS_SERVICE_API_URL}/${path}`,
+    url: `${REPAIRS_SERVICE_API_URL}/${path?.join('/')}`,
     params: queryParams,
-    data: body,
+    data: request.body,
   })
 
   return data
+}
+
+export const authoriseServiceAPIRequest = (callBack) => {
+  return async (req, res) => {
+    const user = isAuthorised({ req })
+    if (!user) {
+      return res
+        .status(HttpStatus.UNAUTHORIZED)
+        .json({ message: 'Auth cookie missing.' })
+    }
+    try {
+      // Call the function defined in the API route
+      return await callBack(req, res, user)
+    } catch (err) {
+      console.log(`Service API ${req.method} error:`, err)
+
+      err?.response?.status === HttpStatus.NOT_FOUND
+        ? res
+            .status(HttpStatus.NOT_FOUND)
+            .json({ message: `Resource not found` })
+        : res
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .json({ message: 'Service API server error' })
+    }
+  }
 }


### PR DESCRIPTION
### Description of change

This PR adds a way for us to control who can access individual pages.

Configuration for exactly which roles can access which resources has not been added yet but this work should make that trivial to implement.

It does this making use of a new `permittedRoles` property on each page component, which is required in most cases.

This is an example of the use of this new key in a component:

```
// close-jobs.js

//..

JobPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]

//..
```

This PR also refactors our API routes so that individual routes can add filtering and inject parameters before forwarding the request on to the service API.

We used to do that in a single catch all endpoint but that is going to become difficult to work with if I continue to add special cases to it.

See individual commit messages for more details.

#### Before Merge

 - [x] Tell devs about updates to current work which will need page permissions added