### PR TITLE
Use priorities endpoint to populate priority list

### DIFF
--- a/cypress/fixtures/schedule-of-rates/priorities.json
+++ b/cypress/fixtures/schedule-of-rates/priorities.json
@@ -1,0 +1,22 @@
+[
+  {
+    "priorityCode": 1,
+    "description": "I - Immediate (2 hours)"
+  },
+  {
+    "priorityCode": 2,
+    "description": "E - Emergency (24 hours)"
+  },
+  {
+    "priorityCode": 3,
+    "description": "U - Urgent 7 days (5 Working days)"
+  },
+  {
+    "priorityCode": 4,
+    "description": "N - Normal 28 days (21 working days)"
+  },
+  {
+    "priorityCode": 5,
+    "description": "Inspection"
+  }
+]

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -9,10 +9,12 @@ describe('Raise repair form', () => {
     cy.server()
     // Stub request for raise a repair form page
     cy.fixture('schedule-of-rates/codes.json').as('sorCodes')
+    cy.fixture('schedule-of-rates/priorities.json').as('priorities')
     cy.fixture('properties/property.json').as('property')
     cy.route('GET', 'api/properties/00012345', '@property')
     cy.route('GET', 'api/schedule-of-rates/codes', '@property')
     cy.route('GET', 'api/schedule-of-rates/codes', '@sorCodes')
+    cy.route('GET', 'api/schedule-of-rates/priorities', '@priorities')
     cy.route({
       method: 'POST',
       url: '/api/repairs/schedule',

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -16,22 +16,12 @@ const RaiseRepairForm = ({
   personAlerts,
   tenure,
   sorCodes,
+  priorities,
   onFormSubmit,
 }) => {
   const { register, handleSubmit, errors } = useForm()
   const [priorityCode, setPriorityCode] = useState('')
-
-  const priorityList = [
-    ...new Set(
-      sorCodes
-        .map((code) => {
-          if (code.priority) {
-            return code.priority.description
-          }
-        })
-        .filter(Boolean)
-    ),
-  ]
+  const priorityList = priorities.map((priority) => priority.description)
 
   const onSubmit = async (formData) => {
     const scheduleRepairFormData = buildScheduleRepairFormData(formData)
@@ -40,11 +30,11 @@ const RaiseRepairForm = ({
   }
 
   const onPrioritySelect = (event) => {
-    const sorCodeObject = sorCodes.filter(
-      (a) => a.priority.description == event.target.value
+    const priorityObject = priorities.filter(
+      (priority) => priority.description == event.target.value
     )[0]
 
-    setPriorityCode(sorCodeObject?.priority.priorityCode || '')
+    setPriorityCode(priorityObject?.priorityCode)
   }
 
   const characterCount = () => {
@@ -189,6 +179,7 @@ RaiseRepairForm.propTypes = {
   personAlerts: PropTypes.array.isRequired,
   tenure: PropTypes.object,
   sorCodes: PropTypes.array.isRequired,
+  priorities: PropTypes.array.isRequired,
   onFormSubmit: PropTypes.func.isRequired,
 }
 

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.test.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.test.js
@@ -64,6 +64,28 @@ describe('RaiseRepairForm component', () => {
         },
       },
     ],
+    priorities: [
+      {
+        priorityCode: 1,
+        description: 'I - Immediate (2 hours)',
+      },
+      {
+        priorityCode: 2,
+        description: 'E - Emergency (24 hours)',
+      },
+      {
+        priorityCode: 3,
+        description: 'U - Urgent 7 days (5 Working days)',
+      },
+      {
+        priorityCode: 4,
+        description: 'N - Normal 28 days (21 working days)',
+      },
+      {
+        priorityCode: 5,
+        description: 'Inspection',
+      },
+    ],
     onFormSubmit: jest.fn(),
   }
 
@@ -78,6 +100,7 @@ describe('RaiseRepairForm component', () => {
         locationAlerts={props.alerts.locationAlert}
         personAlerts={props.alerts.personAlert}
         sorCodes={props.sorCodes}
+        priorities={props.priorities}
         onFormSubmit={props.onFormSubmit}
       />
     )

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -6,6 +6,7 @@ import Spinner from '../../Spinner/Spinner'
 import ErrorMessage from '../../Errors/ErrorMessage/ErrorMessage'
 import { getProperty } from '../../../utils/frontend-api-client/properties'
 import { getSorCodes } from '../../../utils/frontend-api-client/schedule-of-rates/codes'
+import { getPriorities } from '../../../utils/frontend-api-client/schedule-of-rates/priorities'
 import { postRepair } from '../../../utils/frontend-api-client/repairs/schedule'
 
 const RaiseRepairFormView = ({ propertyReference }) => {
@@ -14,6 +15,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
   const [personAlerts, setPersonAlerts] = useState([])
   const [tenure, setTenure] = useState({})
   const [sorCodes, setSorCodes] = useState([])
+  const [priorities, setPriorities] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
   const [formSuccess, setFormSuccess] = useState(false)
@@ -43,15 +45,18 @@ const RaiseRepairFormView = ({ propertyReference }) => {
     try {
       const data = await getProperty(propertyReference)
       const sorCodes = await getSorCodes()
+      const priorities = await getPriorities()
 
       setTenure(data.tenure)
       setProperty(data.property)
       setLocationAlerts(data.alerts.locationAlert)
       setPersonAlerts(data.alerts.personAlert)
       setSorCodes(sorCodes)
+      setPriorities(priorities)
     } catch (e) {
       setProperty(null)
       setSorCodes(null)
+      setPriorities(null)
       console.log('An error has occured:', e.response)
       setError(
         `Oops an error occurred with error status: ${e.response?.status}`
@@ -87,7 +92,8 @@ const RaiseRepairFormView = ({ propertyReference }) => {
             property.canRaiseRepair &&
             locationAlerts &&
             personAlerts &&
-            sorCodes && (
+            sorCodes &&
+            priorities && (
               <RaiseRepairForm
                 propertyReference={propertyReference}
                 address={property.address}
@@ -97,6 +103,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
                 locationAlerts={locationAlerts}
                 personAlerts={personAlerts}
                 sorCodes={sorCodes}
+                priorities={priorities}
                 onFormSubmit={onFormSubmit}
               />
             )}

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -188,6 +188,21 @@ exports[`RaiseRepairForm component should render properly 1`] = `
               >
                 E - Emergency (24 hours)
               </option>
+              <option
+                value="U - Urgent 7 days (5 Working days)"
+              >
+                U - Urgent 7 days (5 Working days)
+              </option>
+              <option
+                value="N - Normal 28 days (21 working days)"
+              >
+                N - Normal 28 days (21 working days)
+              </option>
+              <option
+                value="Inspection"
+              >
+                Inspection
+              </option>
             </select>
           </div>
           <input

--- a/src/utils/frontend-api-client/schedule-of-rates/priorities.js
+++ b/src/utils/frontend-api-client/schedule-of-rates/priorities.js
@@ -1,0 +1,7 @@
+import axios from 'axios'
+
+export const getPriorities = async () => {
+  const { data } = await axios.get('/api/schedule-of-rates/priorities')
+
+  return data
+}

--- a/src/utils/frontend-api-client/schedule-of-rates/priorities.test.js
+++ b/src/utils/frontend-api-client/schedule-of-rates/priorities.test.js
@@ -1,0 +1,22 @@
+import { getPriorities } from './priorities'
+import mockAxios from '../../__mocks__/axios'
+
+describe('getPriorities`', () => {
+  it('calls the Next JS API', async () => {
+    const responseData = { data: 'test' }
+
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: responseData,
+      })
+    )
+
+    const response = await getPriorities()
+
+    expect(response).toEqual(responseData)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      '/api/schedule-of-rates/priorities'
+    )
+  })
+})


### PR DESCRIPTION
### Description of change

Update to retrieve priorities from endpoint. Fixed breaking api change with the addition of new sor codes that do not have priority attached to them