### PR TITLE
Reduce amount of memory used for Jest unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prestart": "next build",
     "start": "next start -p $PORT",
     "tests": "jest && yarn test:e2e",
-    "test:unit": "jest",
+    "test:unit": "node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx && echo 'Lint complete.'",
     "test:e2e": "PORT=5001 start-test 5001 cy:run",
     "e2e:audit": "PORT=5001 start-test 5001 cy:run:audit",

--- a/src/components/Property/PropertyDetails.test.js
+++ b/src/components/Property/PropertyDetails.test.js
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import PropertyDetails from './PropertyDetails'
 
 describe('PropertyDetails component', () => {
@@ -43,19 +43,17 @@ describe('PropertyDetails component', () => {
   }
 
   it('should render properly', async () => {
-    await act(async () => {
-      const { asFragment } = render(
-        <PropertyDetails
-          propertyReference={props.property.propertyReference}
-          address={props.property.address}
-          hierarchyType={props.property.hierarchyType}
-          canRaiseRepair={props.property.canRaiseRepair}
-          tenure={props.tenure}
-          locationAlerts={props.alerts.locationAlert}
-          personAlerts={props.alerts.personAlert}
-        />
-      )
-      expect(asFragment()).toMatchSnapshot()
-    })
+    const { asFragment } = render(
+      <PropertyDetails
+        propertyReference={props.property.propertyReference}
+        address={props.property.address}
+        hierarchyType={props.property.hierarchyType}
+        canRaiseRepair={props.property.canRaiseRepair}
+        tenure={props.tenure}
+        locationAlerts={props.alerts.locationAlert}
+        personAlerts={props.alerts.personAlert}
+      />
+    )
+    expect(asFragment()).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
- Update jest script (with heap usage log)
- Failure message: ENOMEM: not enough memory