### PR TITLE
Update multiple sor code selection / priority auto population

### DIFF
--- a/cypress/fixtures/schedule-of-rates/codes.json
+++ b/cypress/fixtures/schedule-of-rates/codes.json
@@ -53,5 +53,13 @@
     "sorContractor": {
       "reference": "H01"
     }
+  },
+  {
+    "customCode": "INP5R001",
+    "customName": "Pre insp of wrks by Constructr",
+    "priority": null,
+    "sorContractor": {
+      "reference": "G16-PCL-PGBR"
+    }
   }
 ]

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -70,10 +70,37 @@ describe('Raise repair form', () => {
 
     // Fill out form
     cy.get('#repair-request-form').within(() => {
-      // Select SOR Code from dropdown
+      // Select SOR code with no priority attached
+      cy.get('select[id="sorCodesCollection[0][code]"]').select(
+        'INP5R001 - Pre insp of wrks by Constructr'
+      )
+      // Does not autopopulate priority description
+      cy.get('#priorityDescription').should('have.value', '')
+
+      // Select SOR code with priority attached
+      cy.get('select[id="sorCodesCollection[0][code]"]').select(
+        'DES5R003 - Immediate call outs'
+      )
+      // Autopopulates priority description
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'I - Immediate (2 hours)'
+      )
+      // Removes Task Priority validation errors
+      cy.get('#priorityDescription-form-group .govuk-error-message').should(
+        'not.exist'
+      )
+
+      // Select another SOR code
       cy.get('select[id="sorCodesCollection[0][code]"]').select(
         'DES5R004 - Emergency call out'
       )
+      // Autopopulates priority description
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'E - Emergency (24 hours)'
+      )
+
       // Assigns description and contractor ref to hidden field
       cy.get('input[id="sorCodesCollection[0][description]"]').should(
         'have.value',
@@ -96,7 +123,7 @@ describe('Raise repair form', () => {
         cy.contains('Please select an SOR code')
       })
       cy.get('select[id="sorCodesCollection[0][code]"]').select(
-        'DES5R004 - Emergency call out'
+        'DES5R005 - Normal call outs'
       )
 
       // Enter a blank quantity
@@ -148,10 +175,57 @@ describe('Raise repair form', () => {
       cy.contains('+ Add another SOR code').click()
       // Remove link now exists for additional SOR code selector component
       cy.get('.remove-sor-code').contains('-')
+
       // Select SOR Code from dropdown
       cy.get('select[id="sorCodesCollection[1][code]"]').select(
-        'DES5R005 - Normal call outs'
+        'DES5R013 - Inspect additional sec entrance'
       )
+      // Priority description should remain same because inspection is a lower priority than normal
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'N - Normal 28 days (21 working days)'
+      )
+      // Add another SOR code with higher priority
+      cy.contains('+ Add another SOR code').click()
+      cy.get('select[id="sorCodesCollection[2][code]"]').select(
+        'DES5R003 - Immediate call outs'
+      )
+      // Autopopulates priority description with the highest priority
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'I - Immediate (2 hours)'
+      )
+      // Add another SOR code with an emergency priority
+      cy.contains('+ Add another SOR code').click()
+      cy.get('select[id="sorCodesCollection[3][code]"]').select(
+        'DES5R004 - Emergency call out'
+      )
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'I - Immediate (2 hours)'
+      )
+      // Remove SOR code at index 2
+      cy.get('button[id="remove-sor-code-2"]').click()
+      // Autopopulates priority description with the remaining highest priority
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'E - Emergency (24 hours)'
+      )
+      cy.get('button[id="remove-sor-code-3"]').click()
+      // Autopopulates priority description with the remaining highest priority
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'N - Normal 28 days (21 working days)'
+      )
+      // Select SOR code with emergency priority at index 1
+      cy.get('select[id="sorCodesCollection[1][code]"]').select(
+        'DES5R004 - Emergency call out'
+      )
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'E - Emergency (24 hours)'
+      )
+
       // Try to submit form without quantity for this SOR code at index 1
       cy.get('[type="submit"]').contains('Create works order').click()
       cy.get(
@@ -195,7 +269,11 @@ describe('Raise repair form', () => {
       )
       // Remaining SOR codes
       cy.get('button[id="remove-sor-code-1"]').should('not.exist')
-      cy.get('select[id="sorCodesCollection[0][code]"]').contains(
+      cy.get('select[id="sorCodesCollection[0][code]"]').select(
+        'DES5R004 - Emergency call out'
+      )
+      cy.get('select[id="sorCodesCollection[0][code]"]').should(
+        'have.value',
         'DES5R004 - Emergency call out'
       )
       cy.get('input[id="sorCodesCollection[0][quantity]"]').should(
@@ -203,29 +281,19 @@ describe('Raise repair form', () => {
         '1'
       )
       cy.get('button[id="remove-sor-code-0"]').should('not.exist')
-      cy.get('select[id="sorCodesCollection[2][code]"]').contains(
+      cy.get('select[id="sorCodesCollection[2][code]"]').should(
+        'have.value',
         'DES5R006 - Urgent call outs'
       )
       cy.get('input[id="sorCodesCollection[2][quantity]"]').should(
         'have.value',
         '2'
       )
+      cy.get('#priorityDescription').should(
+        'have.value',
+        'E - Emergency (24 hours)'
+      )
       cy.get('button[id="remove-sor-code-2"]').contains('-')
-
-      // Select Task Priority
-      cy.get('#priorityDescription').select('E - Emergency (24 hours)')
-      // Removes Task Priority validation errors
-      cy.get('#priorityDescription-form-group .govuk-error-message').should(
-        'not.exist'
-      )
-      // Select blank Task Priority
-      cy.get('#priorityDescription').select('')
-      cy.get('#priorityDescription-form-group .govuk-error-message').within(
-        () => {
-          cy.contains('Please select a priority')
-        }
-      )
-      cy.get('#priorityDescription').select('E - Emergency (24 hours)')
 
       // Go over the Repair description character limit
       cy.get('#descriptionOfWork').get('.govuk-textarea').type('x'.repeat(251))

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -34,12 +34,62 @@ const RaiseRepairForm = ({
     onFormSubmit(scheduleRepairFormData)
   }
 
-  const onPrioritySelect = (event) => {
-    const priorityObject = priorities.filter(
-      (priority) => priority.description == event.target.value
+  const getPriorityObjectByDescription = (description) => {
+    return priorities.filter(
+      (priority) => priority.description == description
     )[0]
+  }
+  const getPriorityObjectByCode = (code) => {
+    return priorities.filter((priority) => priority.priorityCode == code)[0]
+  }
+
+  const onPrioritySelect = (event) => {
+    const priorityObject = getPriorityObjectByDescription(event.target.value)
 
     setPriorityCode(priorityObject?.priorityCode)
+  }
+
+  const updatePriority = (
+    description,
+    code,
+    sorCodesCollectionLength,
+    existingHigherPriorityCode
+  ) => {
+    if (existingHigherPriorityCode) {
+      description = getPriorityObjectByCode(existingHigherPriorityCode)
+        ?.description
+    }
+
+    if (priorityList.includes(description)) {
+      const existingCode = parseInt(
+        document.getElementById('priorityCode').value
+      )
+      // Update priority when SOR code has priority attached if:
+      // Priority description is blank, or there's only one sor code entry, or
+      // when removing an SOR there's an existing entry with higher priority, or
+      // the selected priority code is less than existing priority codes
+      // (Higher priority as code gets lower)
+      if (
+        !existingCode ||
+        sorCodesCollectionLength <= 1 ||
+        existingHigherPriorityCode ||
+        code < existingCode
+      ) {
+        if (errors?.priorityDescription) {
+          delete errors.priorityDescription
+        }
+
+        document.getElementById('priorityDescription').value = description
+
+        setPriorityCode(
+          getPriorityObjectByDescription(description)?.priorityCode
+        )
+      }
+    } else {
+      console.error(
+        `Priority: "${description}" is not included in the available priorities list`
+      )
+    }
   }
 
   return (
@@ -75,6 +125,8 @@ const RaiseRepairForm = ({
               register={register}
               errors={errors}
               isContractorUpdatePage={false}
+              updatePriority={updatePriority}
+              getPriorityObjectByCode={getPriorityObjectByCode}
             />
 
             <Select


### PR DESCRIPTION
### Description of change

- If an SOR code has a priority attached, upon selection this will autopopulate the priority description
- If multiple SOR codes are added, and more than one has a priority attached, the highest priority (lowest code) will be reflected in the priority description
- If an SOR code is removed, the highest priority of the remaining SOR code objects will be calculated and then reflected in the priority description
- No auto population when an SOR code with no priority attached is added
- When changing an existing SOR code select option, it will calculate the highest out of all SOR code priorities and reflect this in the priority description
- Allow user to still manually edit the priority description

### Story Link

https://trello.com/c/fLciBa9w/263-as-an-agent-i-can-add-multiple-sor-codes-to-a-work-order-so-that-i-can-raise-all-the-repairs-required
