### PR TITLE
Update to use hourCycle for 12 hour time formatting

### DIFF
--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -2,7 +2,7 @@ export const extractTimeFromDate = (date) =>
   date.toLocaleString('en-GB', {
     hour: 'numeric',
     minute: 'numeric',
-    hour12: true,
+    hourCycle: 'h12',
   })
 
 export const formatDateTime = (datetime) => {
@@ -10,7 +10,7 @@ export const formatDateTime = (datetime) => {
     datetime = new Date(datetime)
   }
   return datetime.toLocaleString('en-GB', {
-    hour12: true,
+    hourCycle: 'h12',
     day: 'numeric',
     month: 'short',
     year: 'numeric',

--- a/src/utils/time.test.js
+++ b/src/utils/time.test.js
@@ -9,6 +9,22 @@ describe('time', () => {
 
       expect(extractTimeFromDate(date)).toEqual('3:46 pm')
     })
+
+    it('extracts time at 12pm from a date', () => {
+      const date = new Date(
+        'Wed Jan 20 2021 12:46:57 GMT+0000 (Greenwich Mean Time)'
+      )
+
+      expect(extractTimeFromDate(date)).toEqual('12:46 pm')
+    })
+
+    it('extracts time at 12am from a date', () => {
+      const date = new Date(
+        'Wed Jan 20 2021 00:46:57 GMT+0000 (Greenwich Mean Time)'
+      )
+
+      expect(extractTimeFromDate(date)).toEqual('12:46 am')
+    })
   })
 
   describe('formatDateTime', () => {
@@ -20,6 +36,16 @@ describe('time', () => {
     it('formats date/time passed as a String object', () => {
       const datetime = '2021-01-20T15:16:57Z'
       expect(formatDateTime(datetime)).toEqual('20 Jan 2021, 3:16 pm')
+    })
+
+    it('formats 12pm date/time', () => {
+      const datetime = new Date('2021-01-20T12:16:57Z')
+      expect(formatDateTime(datetime)).toEqual('20 Jan 2021, 12:16 pm')
+    })
+
+    it('formats 12am date/time', () => {
+      const datetime = '2021-01-20T00:16:57Z'
+      expect(formatDateTime(datetime)).toEqual('20 Jan 2021, 12:16 am')
     })
   })
 })


### PR DESCRIPTION
- 'hour12: true' would yield 0:30pm for a 12:30pm time which looked a bit strange. This new option now returns 12:30pm which makes more sense.

**Previously:**
![Screenshot 2021-02-17 at 13 10 29](https://user-images.githubusercontent.com/34001723/108208909-8a1dcb80-7121-11eb-8590-e9bcf7af3dd2.png)

**Now:**
![Screenshot 2021-02-17 at 13 10 35](https://user-images.githubusercontent.com/34001723/108208930-9144d980-7121-11eb-9256-aa83bc512f92.png)
