### PR TITLE
Show last 50 records in repairs history, changed from a default of 10

### DIFF
--- a/cypress/integration/show_property.spec.js
+++ b/cypress/integration/show_property.spec.js
@@ -18,7 +18,7 @@ describe('Show property', () => {
         cy.fixture('repairs/work-orders.json').as('workOrders')
         cy.route(
           'GET',
-          'api/repairs/?propertyReference=00012345',
+          'api/repairs/?propertyReference=00012345&PageSize=50',
           '@workOrders'
         )
         cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
@@ -105,7 +105,11 @@ describe('Show property', () => {
       })
 
       it('Display no repairs text when records do not exist', () => {
-        cy.route('GET', 'api/repairs/?propertyReference=00012345', '[]')
+        cy.route(
+          'GET',
+          'api/repairs/?propertyReference=00012345&PageSize=50',
+          '[]'
+        )
 
         cy.get('.govuk-tabs__tab').contains('Repairs history').click()
         cy.get('.govuk-heading-l').contains('Repairs history')

--- a/src/utils/frontend-api-client/repairs.js
+++ b/src/utils/frontend-api-client/repairs.js
@@ -1,11 +1,12 @@
 import axios from 'axios'
 
-const PAGE_SIZE = 10
+const PAGE_SIZE_CONTRACTORS = 10
+const PAGE_SIZE_AGENTS = 50
 
 export const getRepairs = async (pageNumber = 1) => {
-  const { data } = await await axios.get('/api/repairs/', {
+  const { data } = await axios.get('/api/repairs/', {
     params: {
-      PageSize: PAGE_SIZE,
+      PageSize: PAGE_SIZE_CONTRACTORS,
       PageNumber: pageNumber,
     },
   })
@@ -13,14 +14,15 @@ export const getRepairs = async (pageNumber = 1) => {
   return data
 }
 
-export const getRepairsForProperty = async (propertyReference = null) => {
-  if (propertyReference) {
-    const { data } = await axios.get(
-      `/api/repairs/?propertyReference=${propertyReference}`
-    )
+export const getRepairsForProperty = async (propertyReference) => {
+  const { data } = await axios.get('/api/repairs/', {
+    params: {
+      propertyReference: propertyReference,
+      PageSize: PAGE_SIZE_AGENTS,
+    },
+  })
 
-    return data
-  }
+  return data
 }
 
 export const getRepair = async (workOrderReference) => {

--- a/src/utils/frontend-api-client/repairs.test.js
+++ b/src/utils/frontend-api-client/repairs.test.js
@@ -53,8 +53,8 @@ describe('getRepairsForProperty', () => {
 
     expect(response).toEqual(responseData)
     expect(mockAxios.get).toHaveBeenCalledTimes(1)
-    expect(mockAxios.get).toHaveBeenCalledWith(
-      '/api/repairs/?propertyReference=1'
-    )
+    expect(mockAxios.get).toHaveBeenCalledWith('/api/repairs/', {
+      params: { propertyReference: '1', PageSize: 50 },
+    })
   })
 })


### PR DESCRIPTION
### Description of change

- Repairs endpoint only returns a default of 10. Until we decide on pagination / display a link to load more repairs - this is a temporary fix to load 50 of the last records