### PR TITLE
Show contacts on raise repair form

### DIFF
--- a/cypress/fixtures/properties/property.json
+++ b/cypress/fixtures/properties/property.json
@@ -42,18 +42,16 @@
     "typeCode": "SEC",
     "typeDescription": "Secure"
   },
-  "contacts": {
-    "contacts": [
-      {
-        "firstName": "Mark",
-        "lastName": "Gardner",
-        "phoneNumbers": ["00000111111", "00000222222"]
-      },
-      {
-        "firstName": "Luam",
-        "lastName": "Berhane",
-        "phoneNumbers": ["00000666666"]
-      }
-    ]
-  }
+  "contacts": [
+    {
+      "firstName": "Mark",
+      "lastName": "Gardner",
+      "phoneNumbers": ["00000111111", "00000222222"]
+    },
+    {
+      "firstName": "Luam",
+      "lastName": "Berhane",
+      "phoneNumbers": ["00000666666"]
+    }
+  ]
 }

--- a/cypress/fixtures/properties/property.json
+++ b/cypress/fixtures/properties/property.json
@@ -41,5 +41,19 @@
   "tenure": {
     "typeCode": "SEC",
     "typeDescription": "Secure"
+  },
+  "contacts": {
+    "contacts": [
+      {
+        "firstName": "Mark",
+        "lastName": "Gardner",
+        "phoneNumbers": ["00000111111", "00000222222"]
+      },
+      {
+        "firstName": "Luam",
+        "lastName": "Berhane",
+        "phoneNumbers": ["00000666666"]
+      }
+    ]
   }
 }

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -13,6 +13,7 @@ describe('Raise repair form', () => {
     cy.fixture('schedule-of-rates/trades.json').as('trades')
     cy.fixture('contractors/contractors.json').as('contractors')
     cy.fixture('properties/property.json').as('property')
+
     cy.route('GET', 'api/properties/00012345', '@property')
     cy.route(
       'GET',
@@ -54,6 +55,14 @@ describe('Raise repair form', () => {
         'Contact Alert: Verbal Abuse or Threat of (VA)',
       ]
     )
+
+    // Property contact information table
+    cy.get('.govuk-table__caption').contains('Contacts')
+    cy.get('.govuk-table__row .govuk-table__cell').contains('Mark Gardner')
+    cy.get('.govuk-table__row .govuk-table__cell').contains('00000111111')
+    cy.get('.govuk-table__row .govuk-table__cell').contains('00000222222')
+    cy.get('.govuk-table__row .govuk-table__cell').contains('Luam Berhane')
+    cy.get('.govuk-table__row .govuk-table__cell').contains('00000666666')
 
     cy.get('.govuk-heading-m').contains('Repair task details')
 

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -57,12 +57,17 @@ describe('Raise repair form', () => {
     )
 
     // Property contact information table
-    cy.get('.govuk-table__caption').contains('Contacts')
-    cy.get('.govuk-table__row .govuk-table__cell').contains('Mark Gardner')
-    cy.get('.govuk-table__row .govuk-table__cell').contains('00000111111')
-    cy.get('.govuk-table__row .govuk-table__cell').contains('00000222222')
-    cy.get('.govuk-table__row .govuk-table__cell').contains('Luam Berhane')
-    cy.get('.govuk-table__row .govuk-table__cell').contains('00000666666')
+    cy.get('.govuk-table')
+      .contains('Contacts')
+      .parent()
+      .within(() => {
+        cy.get('tbody>tr').eq(0).contains('Mark Gardner')
+        cy.get('tbody>tr').eq(0).contains('00000111111')
+        cy.get('tbody>tr').eq(0).contains('00000222222')
+
+        cy.get('tbody>tr').eq(1).contains('Luam Berhane')
+        cy.get('tbody>tr').eq(1).contains('00000666666')
+      })
 
     cy.get('.govuk-heading-m').contains('Repair task details')
 

--- a/src/components/Property/Contacts/Contacts.js
+++ b/src/components/Property/Contacts/Contacts.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types'
-import ContactsNoneAvailable from './ContactsNoneAvailable'
+import WarningText from '../../WarningText'
 import ContactsTable from './ContactsTable'
 
 const Contacts = ({ contacts }) => {
   return contacts.length < 1 ? (
-    <ContactsNoneAvailable />
+    <WarningText text="No contact details available for this property" />
   ) : (
     <ContactsTable contacts={contacts} />
   )

--- a/src/components/Property/Contacts/Contacts.js
+++ b/src/components/Property/Contacts/Contacts.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types'
+import ContactsNoneAvailable from './ContactsNoneAvailable'
+import ContactsTable from './ContactsTable'
+
+const Contacts = ({ contacts }) => {
+  return contacts.length < 1 ? (
+    <ContactsNoneAvailable />
+  ) : (
+    <ContactsTable contacts={contacts} />
+  )
+}
+
+Contacts.propTypes = {
+  contacts: PropTypes.arrayOf(PropTypes.object).isRequired,
+}
+
+export default Contacts

--- a/src/components/Property/Contacts/Contacts.test.js
+++ b/src/components/Property/Contacts/Contacts.test.js
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react'
+import Contacts from './Contacts'
+
+describe('Contacts component', () => {
+  describe('when supplied with an empty contacts list', () => {
+    const contacts = []
+
+    it('renders text indicating that no contacts are available', () => {
+      const { asFragment } = render(<Contacts contacts={contacts} />)
+
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when supplied with a list of contacts', () => {
+    const contacts = [
+      {
+        firstName: 'Mark',
+        lastName: 'Gardner',
+        phoneNumbers: ['00000111111', '00000222222', '00000333333'],
+      },
+      {
+        firstName: 'Luam',
+        lastName: 'Berhane',
+        phoneNumbers: ['', '', '00000333333'],
+      },
+    ]
+
+    it('renders a table with a row for each contact', () => {
+      const { asFragment } = render(<Contacts contacts={contacts} />)
+
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/Property/Contacts/ContactsNoneAvailable.js
+++ b/src/components/Property/Contacts/ContactsNoneAvailable.js
@@ -1,0 +1,15 @@
+const ContactsNoneAvailable = () => {
+  return (
+    <div className="govuk-warning-text">
+      <span className="govuk-warning-text__icon" aria-hidden="true">
+        !
+      </span>
+      <strong className="govuk-warning-text__text">
+        <span className="govuk-warning-text__assistive">Warning</span>
+        No contact details available for this property
+      </strong>
+    </div>
+  )
+}
+
+export default ContactsNoneAvailable

--- a/src/components/Property/Contacts/ContactsRow.js
+++ b/src/components/Property/Contacts/ContactsRow.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types'
+
+const Row = ({ contact }) => {
+  return (
+    <tr className="govuk-table__row">
+      <td className="govuk-table__cell">
+        {[contact?.firstName, contact?.lastName].join(' ')}
+      </td>
+      <td className="govuk-table__cell">{contact.phoneNumbers[0]}</td>
+      <td className="govuk-table__cell">{contact.phoneNumbers[1]}</td>
+      <td className="govuk-table__cell">{contact.phoneNumbers[2]}</td>
+    </tr>
+  )
+}
+
+Row.propTypes = {
+  contact: PropTypes.shape({
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    phoneNumbers: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+}
+
+export default Row

--- a/src/components/Property/Contacts/ContactsRow.test.js
+++ b/src/components/Property/Contacts/ContactsRow.test.js
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react'
+import ContactsRow from './ContactsRow'
+
+describe('ContactsRow component', () => {
+  const contact = {
+    firstName: 'Hugo Neves',
+    lastName: 'Ferreira',
+    phoneNumbers: ['00000111111', '', '00000333333'],
+  }
+
+  it('renders the name and available phone numbers in a row', async () => {
+    const table = document.createElement('table')
+    const tbody = document.createElement('tbody')
+
+    table.appendChild(tbody)
+
+    render(<ContactsRow contact={contact} />, {
+      container: document.body.appendChild(tbody),
+    })
+
+    expect(tbody).toMatchInlineSnapshot(`
+      <tbody>
+        <tr
+          class="govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            Hugo Neves Ferreira
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            00000111111
+          </td>
+          <td
+            class="govuk-table__cell"
+          />
+          <td
+            class="govuk-table__cell"
+          >
+            00000333333
+          </td>
+        </tr>
+      </tbody>
+    `)
+  })
+})

--- a/src/components/Property/Contacts/ContactsTable.js
+++ b/src/components/Property/Contacts/ContactsTable.js
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types'
+import ContactsRow from './ContactsRow'
+
+const ContactsTable = ({ contacts }) => {
+  return (
+    <table className="govuk-table">
+      <caption className="govuk-table__caption">Contacts</caption>
+      <thead className="govuk-table__head">
+        <tr className="govuk-table__row">
+          <th className="govuk-table__header" scope="col">
+            Name
+          </th>
+          <th className="govuk-table__header" scope="col">
+            Telephone 1
+          </th>
+          <th className="govuk-table__header" scope="col">
+            Telephone 2
+          </th>
+          <th className="govuk-table__header" scope="col">
+            Telephone 3
+          </th>
+        </tr>
+      </thead>
+      <tbody className="govuk-table__body">
+        {contacts.map((contact, index) => (
+          <ContactsRow key={index} contact={contact} />
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+ContactsTable.propTypes = {
+  contacts: PropTypes.arrayOf(PropTypes.object).isRequired,
+}
+
+export default ContactsTable

--- a/src/components/Property/Contacts/__snapshots__/Contacts.test.js.snap
+++ b/src/components/Property/Contacts/__snapshots__/Contacts.test.js.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Contacts component when supplied with a list of contacts renders a table with a row for each contact 1`] = `
+<DocumentFragment>
+  <table
+    class="govuk-table"
+  >
+    <caption
+      class="govuk-table__caption"
+    >
+      Contacts
+    </caption>
+    <thead
+      class="govuk-table__head"
+    >
+      <tr
+        class="govuk-table__row"
+      >
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Name
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Telephone 1
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Telephone 2
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Telephone 3
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="govuk-table__body"
+    >
+      <tr
+        class="govuk-table__row"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          Mark Gardner
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          00000111111
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          00000222222
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          00000333333
+        </td>
+      </tr>
+      <tr
+        class="govuk-table__row"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          Luam Berhane
+        </td>
+        <td
+          class="govuk-table__cell"
+        />
+        <td
+          class="govuk-table__cell"
+        />
+        <td
+          class="govuk-table__cell"
+        >
+          00000333333
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;
+
+exports[`Contacts component when supplied with an empty contacts list renders text indicating that no contacts are available 1`] = `
+<DocumentFragment>
+  <div
+    class="govuk-warning-text"
+  >
+    <span
+      aria-hidden="true"
+      class="govuk-warning-text__icon"
+    >
+      !
+    </span>
+    <strong
+      class="govuk-warning-text__text"
+    >
+      <span
+        class="govuk-warning-text__assistive"
+      >
+        Warning
+      </span>
+      No contact details available for this property
+    </strong>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -11,6 +11,7 @@ import {
 } from '../../Form'
 import TradeContractorRateScheduleItemView from './TradeContractorRateScheduleItemView'
 import { buildScheduleRepairFormData } from '../../../utils/hact/schedule-repair/raise-repair-form'
+import Contacts from '../Contacts/Contacts'
 
 const RaiseRepairForm = ({
   propertyReference,
@@ -22,6 +23,7 @@ const RaiseRepairForm = ({
   tenure,
   priorities,
   trades,
+  contacts,
   onFormSubmit,
 }) => {
   const { register, handleSubmit, errors } = useForm()
@@ -179,6 +181,7 @@ const RaiseRepairForm = ({
               value={address.shortAddress}
               ref={register}
             />
+            <Contacts contacts={contacts} />
             <TextInput
               name="callerName"
               label="Caller name"

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.test.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.test.js
@@ -68,6 +68,7 @@ describe('RaiseRepairForm component', () => {
         name: 'Plumbing',
       },
     ],
+    contacts: [],
     onFormSubmit: jest.fn(),
   }
 
@@ -83,6 +84,7 @@ describe('RaiseRepairForm component', () => {
         personAlerts={props.alerts.personAlert}
         priorities={props.priorities}
         trades={props.trades}
+        contacts={props.contacts}
         onFormSubmit={props.onFormSubmit}
       />
     )

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -16,6 +16,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
   const [tenure, setTenure] = useState({})
   const [trades, setTrades] = useState([])
   const [priorities, setPriorities] = useState([])
+  const [contacts, setContacts] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
   const [formSuccess, setFormSuccess] = useState(false)
@@ -53,6 +54,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
       setPersonAlerts(data.alerts.personAlert)
       setPriorities(priorities)
       setTrades(trades)
+      setContacts(data.contacts?.contacts)
     } catch (e) {
       setProperty(null)
       setPriorities(null)
@@ -104,6 +106,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
                 personAlerts={personAlerts}
                 priorities={priorities}
                 trades={trades}
+                contacts={contacts}
                 onFormSubmit={onFormSubmit}
               />
             )}

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -54,7 +54,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
       setPersonAlerts(data.alerts.personAlert)
       setPriorities(priorities)
       setTrades(trades)
-      setContacts(data.contacts?.contacts)
+      setContacts(data.contacts)
     } catch (e) {
       setProperty(null)
       setPriorities(null)

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -322,6 +322,26 @@ exports[`RaiseRepairForm component should render properly 1`] = `
           value="16 Pitcairn House  St Thomass Square"
         />
         <div
+          class="govuk-warning-text"
+        >
+          <span
+            aria-hidden="true"
+            class="govuk-warning-text__icon"
+          >
+            !
+          </span>
+          <strong
+            class="govuk-warning-text__text"
+          >
+            <span
+              class="govuk-warning-text__assistive"
+            >
+              Warning
+            </span>
+            No contact details available for this property
+          </strong>
+        </div>
+        <div
           class="govuk-form-group"
           id="callerName-form-group"
         >

--- a/src/components/Property/RaiseRepairStatus.js
+++ b/src/components/Property/RaiseRepairStatus.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
+import WarningText from '../WarningText'
 
 const RaiseRepairStatus = ({
   canRaiseRepair,
@@ -18,15 +19,7 @@ const RaiseRepairStatus = ({
     )
   } else {
     return (
-      <div className="govuk-warning-text">
-        <span className="govuk-warning-text__icon" aria-hidden="true">
-          !
-        </span>
-        <strong className="govuk-warning-text__text">
-          <span className="govuk-warning-text__assistive">Warning</span>
-          Cannot raise a repair on this property due to tenure type
-        </strong>
-      </div>
+      <WarningText text="Cannot raise a repair on this property due to tenure type" />
     )
   }
 }

--- a/src/components/WarningText.js
+++ b/src/components/WarningText.js
@@ -1,4 +1,6 @@
-const ContactsNoneAvailable = () => {
+import PropTypes from 'prop-types'
+
+const WarningText = ({ text }) => {
   return (
     <div className="govuk-warning-text">
       <span className="govuk-warning-text__icon" aria-hidden="true">
@@ -6,10 +8,14 @@ const ContactsNoneAvailable = () => {
       </span>
       <strong className="govuk-warning-text__text">
         <span className="govuk-warning-text__assistive">Warning</span>
-        No contact details available for this property
+        {text}
       </strong>
     </div>
   )
 }
 
-export default ContactsNoneAvailable
+WarningText.propTypes = {
+  text: PropTypes.string.isRequired,
+}
+
+export default WarningText

--- a/src/pages/api/properties/[id].js
+++ b/src/pages/api/properties/[id].js
@@ -1,0 +1,20 @@
+import * as HttpStatus from 'http-status-codes'
+
+import { CONTRACTOR_ROLE } from '../../../utils/user'
+import {
+  serviceAPIRequest,
+  authoriseServiceAPIRequest,
+} from '../../../utils/service-api-client'
+
+export default authoriseServiceAPIRequest(async (req, res, user) => {
+  req.query = { path: ['properties', req.query.id] }
+
+  const data = await serviceAPIRequest(req)
+
+  // redact contact information for contractor responses
+  if (user.hasRole(CONTRACTOR_ROLE)) {
+    res.status(HttpStatus.OK).json({ ...data, contacts: '[REMOVED]' })
+  } else {
+    res.status(HttpStatus.OK).json(data)
+  }
+})

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -1,0 +1,146 @@
+import axios from 'axios'
+import jsonwebtoken from 'jsonwebtoken'
+import { createRequest, createResponse } from 'node-mocks-http'
+
+import propertiesEndpoint from './[id].js'
+
+jest.mock('axios')
+
+const {
+  REPAIRS_SERVICE_API_URL,
+  HACKNEY_JWT_SECRET,
+  GSSO_TOKEN_NAME,
+  CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
+  REPAIRS_AGENTS_GOOGLE_GROUPNAME,
+  REPAIRS_SERVICE_API_KEY,
+} = process.env
+
+describe('GET /api/properties/[id] contact information redaction', () => {
+  beforeEach(() => {
+    axios.create = jest.fn(() => axios)
+
+    axios.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        data: {
+          property: {},
+          alerts: {},
+          tenure: {},
+          contacts: {
+            contacts: [
+              {
+                firstName: 'FirstName',
+                lastName: 'LastName',
+                phoneNumbers: ['0123456789', '0123456789'],
+              },
+              {
+                firstName: 'FirstName',
+                lastName: 'LastName',
+                phoneNumbers: ['0123456789', '0123456789'],
+              },
+            ],
+          },
+        },
+      })
+    )
+  })
+
+  describe('when the cookie is for an agent', () => {
+    const signedCookie = jsonwebtoken.sign(
+      {
+        name: 'name',
+        email: 'name@example.com',
+        groups: [REPAIRS_AGENTS_GOOGLE_GROUPNAME],
+      },
+      HACKNEY_JWT_SECRET
+    )
+
+    const headers = {
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+    }
+
+    test('the response can include full contact information', async () => {
+      const req = createRequest({
+        method: 'get',
+        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
+        query: {
+          id: '1',
+        },
+      })
+
+      const res = createResponse()
+
+      await propertiesEndpoint(req, res)
+
+      expect(axios).toHaveBeenCalledTimes(1)
+      expect(axios).toHaveBeenCalledWith({
+        method: 'get',
+        headers,
+        url: `${REPAIRS_SERVICE_API_URL}/properties/1`,
+        params: {},
+        data: {},
+      })
+
+      const parsedData = JSON.parse(res._getData())
+
+      expect(parsedData['contacts']).toEqual({
+        contacts: [
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('when the cookie is for a contractor', () => {
+    const signedCookie = jsonwebtoken.sign(
+      {
+        name: 'name',
+        email: 'name@example.com',
+        groups: [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME],
+      },
+      HACKNEY_JWT_SECRET
+    )
+
+    const headers = {
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+    }
+
+    test('response contact information is redacted', async () => {
+      const req = createRequest({
+        method: 'get',
+        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
+        query: {
+          id: '1',
+        },
+      })
+
+      const res = createResponse()
+
+      await propertiesEndpoint(req, res)
+
+      expect(axios).toHaveBeenCalledTimes(1)
+      expect(axios).toHaveBeenCalledWith({
+        method: 'get',
+        headers,
+        url: `${REPAIRS_SERVICE_API_URL}/properties/1`,
+        params: {},
+        data: {},
+      })
+
+      const parsedData = JSON.parse(res._getData())
+
+      expect(parsedData['contacts']).toEqual('[REMOVED]')
+    })
+  })
+})


### PR DESCRIPTION
### Description of change

Add resident contact information to the base of the raise repairs form.

Redact sensitive information for responses from the Node API which are not for agents as they have no need to see this.

 ### Before Merge

 - [x] Double-check with backend if JSON structure they return is correct - should contacts be a nested object?

### Story Link

https://trello.com/c/ckaBKNzB/345-as-an-rcc-agent-i-can-view-the-contact-name-and-number-assigned-to-a-property-when-raising-a-repair-so-i-can-check-details-if-ne


### Screenshots

These are from the base of the raise repairs form.

![image](https://user-images.githubusercontent.com/1370570/108827394-79f06b00-75bd-11eb-8561-5bc496ef2442.png)

![image](https://user-images.githubusercontent.com/1370570/108827830-fc792a80-75bd-11eb-8aaa-0c81a6234d6c.png)