### PR TITLE
Update contractor reference mapping

### DIFF
--- a/src/pages/api/repairs.test.js
+++ b/src/pages/api/repairs.test.js
@@ -19,7 +19,7 @@ describe('GET /api/repairs', () => {
     {
       name: 'name',
       email: 'name@example.com',
-      groups: [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME], // mapped internally to the 'H01' contractor Ref
+      groups: [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME], // mapped internally to the 'SCC' contractor Ref
     },
     HACKNEY_JWT_SECRET
   )
@@ -55,7 +55,7 @@ describe('GET /api/repairs', () => {
         method: 'get',
         headers,
         url: `${REPAIRS_SERVICE_API_URL}/repairs`,
-        params: { ContractorReference: 'H01' }, // request to service API made with user's contractor ref from cookie
+        params: { ContractorReference: 'SCC' }, // request to service API made with user's contractor ref from cookie
         data: {},
       })
     })

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -7,8 +7,8 @@ const {
 } = process.env
 
 const CONTRACTOR_GROUP_REF_MAP = {
-  [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME]: 'H01',
-  [CONTRACTORS_PURDY_GOOGLE_GROUPNAME]: 'PDY', // TODO: Update to a real value
+  [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME]: 'SCC',
+  [CONTRACTORS_PURDY_GOOGLE_GROUPNAME]: 'PCL',
 }
 
 export const buildUser = (name, email, authServiceGroups) => {

--- a/src/utils/user.test.js
+++ b/src/utils/user.test.js
@@ -95,7 +95,7 @@ describe('buildUser', () => {
       ])
 
       it(`ref returns the mapped contractor ref for the supplied group`, () => {
-        expect(user.contractorReference).toEqual('H01')
+        expect(user.contractorReference).toEqual('SCC')
       })
     })
   })


### PR DESCRIPTION
### Description of change

Update our configuration for the query parameters we send to request sets of repairs for the two contractors we currently model in the system. 
