### PR TITLE
Allow contractor admins to view the work order details

### DIFF
--- a/__test__/work-orders/[id]/index.test.js
+++ b/__test__/work-orders/[id]/index.test.js
@@ -2,14 +2,9 @@ import WorkOrderPage from 'src/pages/work-orders/[id]'
 import { AGENT_ROLE, CONTRACTOR_ROLE } from 'src/utils/user'
 
 describe('WorkOrderPage.permittedRoles', () => {
-  ;[AGENT_ROLE].forEach((role) => {
+  ;[AGENT_ROLE, CONTRACTOR_ROLE].forEach((role) => {
     it(`permits the ${role} role to access the page`, () => {
       expect(WorkOrderPage.permittedRoles).toContain(role)
-    })
-  })
-  ;[CONTRACTOR_ROLE].forEach((role) => {
-    it(`does not permit the ${role} role to access the page`, () => {
-      expect(WorkOrderPage.permittedRoles).not.toContain(role)
     })
   })
 })

--- a/cypress/integration/home_page.spec.js
+++ b/cypress/integration/home_page.spec.js
@@ -102,7 +102,6 @@ describe('Home page', () => {
               cy.contains('N - Normal')
               cy.contains('315 Banister House Homerton High Street')
               cy.contains('An emergency repair')
-              cy.contains('a', 'Update')
             })
             // Run lighthouse audit for accessibility report
             cy.audit()

--- a/cypress/integration/jobs/close-job.spec.js
+++ b/cypress/integration/jobs/close-job.spec.js
@@ -6,20 +6,29 @@ describe('Contractor closing a job', () => {
     cy.loginWithContractorRole()
     cy.server()
     cy.fixture('repairs/work-orders.json').as('workorderslist')
+    cy.fixture('properties/property.json').as('property')
     cy.route('GET', 'api/repairs/?PageSize=10&PageNumber=1', '@workorderslist')
     cy.route({
       method: 'POST',
       url: '/api/workOrderComplete',
       response: '',
     }).as('apiCheck')
+
+    // Viewing the work order page
+    cy.fixture('properties/property.json').then((property) => {
+      cy.intercept('GET', 'api/properties/00012345', property)
+    })
+    cy.fixture('repairs/work-orders.json').then((workOrders) => {
+      cy.intercept('GET', 'api/repairs/10000040', workOrders[0])
+    })
   })
 
   it('takes you to close-job page', () => {
     cy.visit(`${Cypress.env('HOST')}/`)
     cy.get('.govuk-table__cell').within(() => {
-      cy.contains('10000040')
-      cy.contains('a', 'Update').click()
+      cy.contains('a', '10000040').click()
     })
+    cy.contains('a', 'Update Works Order').click()
     cy.contains('Update work order: 10000040')
     cy.get('form').within(() => {
       cy.get('[type="radio"]').check('Close job')

--- a/cypress/integration/jobs/update-job.spec.js
+++ b/cypress/integration/jobs/update-job.spec.js
@@ -28,15 +28,23 @@ describe('Contractor update a job', () => {
       url: '/api/jobStatusUpdate',
       response: '',
     }).as('apiCheck')
+
+    // Viewing the work order page
+    cy.fixture('properties/property.json').then((property) => {
+      cy.intercept('GET', 'api/properties/00012345', property)
+    })
+    cy.fixture('repairs/work-orders.json').then((workOrders) => {
+      cy.intercept('GET', 'api/repairs/10000040', workOrders[0])
+    })
   })
 
   it('throws errors if input values are empty or not valid', () => {
     cy.visit(`${Cypress.env('HOST')}/`)
 
     cy.get('.govuk-table__cell').within(() => {
-      cy.contains('10000040')
-      cy.contains('a', 'Update').click()
+      cy.contains('a', '10000040').click()
     })
+    cy.contains('a', 'Update Works Order').click()
     cy.contains('Update work order: 10000040')
     cy.get('form').within(() => {
       cy.get('[type="radio"]').check('Update')
@@ -88,9 +96,9 @@ describe('Contractor update a job', () => {
   it('allows the user to update the job by changing the existing quantity', () => {
     cy.visit(`${Cypress.env('HOST')}/`)
     cy.get('.govuk-table__cell').within(() => {
-      cy.contains('10000040')
-      cy.contains('a', 'Update').click()
+      cy.contains('a', '10000040').click()
     })
+    cy.contains('a', 'Update Works Order').click()
     cy.contains('Update work order: 10000040')
     cy.get('form').within(() => {
       cy.get('[type="radio"]').check('Update')

--- a/src/components/Property/RepairsHistory/RepairsHistoryRow.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryRow.js
@@ -1,31 +1,41 @@
+import { useContext } from 'react'
 import PropTypes from 'prop-types'
+import UserContext from '../../UserContext/UserContext'
 import { dateToStr } from '../../../utils/date'
 import { extractTimeFromDate } from '../../../utils/time'
 
-const RepairsHistoryRow = ({ reference, dateRaised, description, status }) => (
-  <tr
-    className="govuk-table__row govuk-table__row--clickable govuk-body-s"
-    data-ref={reference}
-  >
-    <td className="govuk-table__cell">
-      <a href={`/work-orders/${reference}`}>{reference}</a>
-    </td>
-    <td className="govuk-table__cell">
-      {dateRaised ? dateToStr(dateRaised) : '—'}
-      <div className="work-order-hours">
-        {dateRaised ? extractTimeFromDate(dateRaised) : ''}
-      </div>
-    </td>
-    <td className="govuk-table__cell">
-      <span
-        className={`status status-${status.replace(/\s+/g, '-').toLowerCase()}`}
-      >
-        {status}
-      </span>
-    </td>
-    <td className="govuk-table__cell description">{description}</td>
-  </tr>
-)
+const RepairsHistoryRow = ({ reference, dateRaised, description, status }) => {
+  const { user } = useContext(UserContext)
+
+  return (
+    <tr
+      className="govuk-table__row govuk-table__row--clickable govuk-body-s"
+      data-ref={reference}
+    >
+      {user && user.hasAgentPermissions && (
+        <td className="govuk-table__cell">
+          <a href={`/work-orders/${reference}`}>{reference}</a>
+        </td>
+      )}
+      <td className="govuk-table__cell">
+        {dateRaised ? dateToStr(dateRaised) : '—'}
+        <div className="work-order-hours">
+          {dateRaised ? extractTimeFromDate(dateRaised) : ''}
+        </div>
+      </td>
+      <td className="govuk-table__cell">
+        <span
+          className={`status status-${status
+            .replace(/\s+/g, '-')
+            .toLowerCase()}`}
+        >
+          {status}
+        </span>
+      </td>
+      <td className="govuk-table__cell description">{description}</td>
+    </tr>
+  )
+}
 
 RepairsHistoryRow.propTypes = {
   reference: PropTypes.number.isRequired,

--- a/src/components/Property/RepairsHistory/RepairsHistoryTable.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryTable.js
@@ -1,5 +1,7 @@
+import { useContext } from 'react'
 import PropTypes from 'prop-types'
 import { PAGE_SIZE_AGENTS } from 'src/utils/frontend-api-client/repairs'
+import UserContext from '../../UserContext/UserContext'
 import RepairsHistoryRow from './RepairsHistoryRow'
 
 const RepairsHistoryTable = ({
@@ -8,6 +10,8 @@ const RepairsHistoryTable = ({
   pageNumber,
   loadMoreWorkOrders,
 }) => {
+  const { user } = useContext(UserContext)
+
   const moreWorkOrdersAvailable = () => {
     // TODO: Replace with a real count from the API
     const maxWorkOrders = pageNumber * PAGE_SIZE_AGENTS
@@ -38,9 +42,11 @@ const RepairsHistoryTable = ({
       <table className="govuk-table govuk-!-margin-top-5 repairs-history-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row govuk-body">
-            <th scope="col" className="govuk-table__header">
-              Reference
-            </th>
+            {user && user.hasAgentPermissions && (
+              <th scope="col" className="govuk-table__header">
+                Reference
+              </th>
+            )}
             <th scope="col" className="govuk-table__header">
               Date raised
             </th>

--- a/src/components/Property/RepairsHistory/RepairsHistoryTable.test.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryTable.test.js
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import UserContext from '../../UserContext/UserContext'
 import RepairsHistoryTable from './RepairsHistoryTable'
 
 describe('RepairsHistoryTable component', () => {
@@ -30,13 +31,51 @@ describe('RepairsHistoryTable component', () => {
     ],
   }
 
-  it('should render properly', () => {
-    const { asFragment } = render(
-      <RepairsHistoryTable
-        workOrders={props.workOrders}
-        tabName={props.tabName}
-      />
-    )
-    expect(asFragment()).toMatchSnapshot()
+  describe('when logged in as an agent', () => {
+    const user = {
+      name: 'An Agent',
+      email: 'an.agent@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: true,
+      hasContractorPermissions: false,
+      hasAnyPermissions: true,
+      contractorReference: null,
+    }
+
+    it('should render properly', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <RepairsHistoryTable
+            workOrders={props.workOrders}
+            tabName={props.tabName}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when logged in as a contractor', () => {
+    const user = {
+      name: 'A Contractor',
+      email: 'a.contractor@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: true,
+      hasAnyPermissions: true,
+      contractorReference: 'SCC',
+    }
+
+    it('should render properly', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <RepairsHistoryTable
+            workOrders={props.workOrders}
+            tabName={props.tabName}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
   })
 })

--- a/src/components/Property/RepairsHistory/__snapshots__/RepairsHistoryTable.test.js.snap
+++ b/src/components/Property/RepairsHistory/__snapshots__/RepairsHistoryTable.test.js.snap
@@ -1,6 +1,108 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RepairsHistoryTable component should render properly 1`] = `
+exports[`RepairsHistoryTable component when logged in as a contractor should render properly 1`] = `
+<DocumentFragment>
+  <h2
+    class="govuk-heading-l"
+  >
+    Repairs history
+  </h2>
+  <table
+    class="govuk-table govuk-!-margin-top-5 repairs-history-table"
+  >
+    <thead
+      class="govuk-table__head"
+    >
+      <tr
+        class="govuk-table__row govuk-body"
+      >
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Date raised
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Status
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="govuk-table__body"
+    >
+      <tr
+        class="govuk-table__row govuk-table__row--clickable govuk-body-s"
+        data-ref="10000012"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          18 Jan 2021
+          <div
+            class="work-order-hours"
+          >
+            3:28 pm
+          </div>
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          <span
+            class="status status-in-progress"
+          >
+            In progress
+          </span>
+        </td>
+        <td
+          class="govuk-table__cell description"
+        >
+          This is an immediate repair description
+        </td>
+      </tr>
+      <tr
+        class="govuk-table__row govuk-table__row--clickable govuk-body-s"
+        data-ref="10000013"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          23 Jan 2021
+          <div
+            class="work-order-hours"
+          >
+            4:28 pm
+          </div>
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          <span
+            class="status status-in-progress"
+          >
+            In progress
+          </span>
+        </td>
+        <td
+          class="govuk-table__cell description"
+        >
+          This is an urgent repair description
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;
+
+exports[`RepairsHistoryTable component when logged in as an agent should render properly 1`] = `
 <DocumentFragment>
   <h2
     class="govuk-heading-l"

--- a/src/components/WorkOrder/AppointmentDetails.js
+++ b/src/components/WorkOrder/AppointmentDetails.js
@@ -1,16 +1,29 @@
+import { useContext } from 'react'
 import PropTypes from 'prop-types'
+import UserContext from '../UserContext/UserContext'
 import Link from 'next/link'
 
 const AppointmentDetails = ({ workOrder }) => {
+  const { user } = useContext(UserContext)
+  const STATUS_CANCELLED = 'Work Cancelled'
+
   if (workOrder.priorityCode > 1) {
     return (
       <div className="appointment-details">
         <span className="govuk-!-font-size-14">Appointment details</span>
         <br></br>
         <div className="govuk-body-s">
-          <Link href={`/work-orders/${workOrder.reference}/appointment/new`}>
-            <a className="govuk-!-font-weight-bold">Schedule an appointment</a>
-          </Link>
+          {user &&
+            user.hasAgentPermissions &&
+            workOrder.status !== STATUS_CANCELLED && (
+              <Link
+                href={`/work-orders/${workOrder.reference}/appointment/new`}
+              >
+                <a className="govuk-!-font-weight-bold">
+                  Schedule an appointment
+                </a>
+              </Link>
+            )}
         </div>
       </div>
     )

--- a/src/components/WorkOrder/WorkOrderDetails.js
+++ b/src/components/WorkOrder/WorkOrderDetails.js
@@ -1,5 +1,8 @@
+import { useContext } from 'react'
 import PropTypes from 'prop-types'
+import UserContext from '../UserContext/UserContext'
 import WorkOrderHeader from './WorkOrderHeader'
+import BackButton from '../Layout/BackButton/BackButton'
 import Link from 'next/link'
 
 const WorkOrderDetails = ({
@@ -12,19 +15,28 @@ const WorkOrderDetails = ({
   tenure,
   canRaiseRepair,
 }) => {
+  const { user } = useContext(UserContext)
   const STATUS_CANCELLED = 'Work Cancelled'
 
   return (
     <div>
+      <BackButton />
       <div>
         <h1 className="govuk-heading-l display-inline govuk-!-margin-right-6">
           Works order: {workOrder.reference}
         </h1>
-        {workOrder.status !== STATUS_CANCELLED && (
-          <Link href={`/work-orders/${workOrder.reference}/cancel`}>
-            <a className="govuk-body-m">Cancel Works Order</a>
+        {user && user.hasContractorPermissions && (
+          <Link href={`/repairs/jobs/${workOrder.reference}/choose-option`}>
+            <a className="govuk-body-m">Update Works Order</a>
           </Link>
         )}
+        {user &&
+          user.hasAgentPermissions &&
+          workOrder.status !== STATUS_CANCELLED && (
+            <Link href={`/work-orders/${workOrder.reference}/cancel`}>
+              <a className="govuk-body-m">Cancel Works Order</a>
+            </Link>
+          )}
       </div>
       <p className="govuk-body-m">{workOrder.description}</p>
 

--- a/src/components/WorkOrder/WorkOrderDetails.test.js
+++ b/src/components/WorkOrder/WorkOrderDetails.test.js
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
 import MockDate from 'mockdate'
+import UserContext from '../UserContext/UserContext'
 import WorkOrderDetails from './WorkOrderDetails'
 
 describe('WorkOrderDetails component', () => {
@@ -59,43 +60,115 @@ describe('WorkOrderDetails component', () => {
     },
   }
 
-  it('should render properly without a link to cancel work order', () => {
-    // Link isn't shown if current time is greater than dateRaised + 1 hour
-    const { asFragment } = render(
-      <WorkOrderDetails
-        propertyReference={props.property.propertyReference}
-        workOrder={props.workOrder}
-        address={props.property.address}
-        subTypeDescription={props.property.hierarchyType.subTypeDescription}
-        tenure={props.tenure}
-        locationAlerts={props.alerts.locationAlert}
-        personAlerts={props.alerts.personAlert}
-        hasLinkToProperty={true}
-        canRaiseRepair={props.property.canRaiseRepair}
-      />
-    )
-    expect(asFragment()).toMatchSnapshot()
+  describe('when logged in as an agent', () => {
+    const user = {
+      name: 'An Agent',
+      email: 'an.agent@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: true,
+      hasContractorPermissions: false,
+      hasAnyPermissions: true,
+      contractorReference: null,
+    }
+
+    it('should render properly without a link to cancel work order', () => {
+      // Link isn't shown if current time is greater than dateRaised + 1 hour
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrderDetails
+            propertyReference={props.property.propertyReference}
+            workOrder={props.workOrder}
+            address={props.property.address}
+            subTypeDescription={props.property.hierarchyType.subTypeDescription}
+            tenure={props.tenure}
+            locationAlerts={props.alerts.locationAlert}
+            personAlerts={props.alerts.personAlert}
+            hasLinkToProperty={true}
+            canRaiseRepair={props.property.canRaiseRepair}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+
+    it('should render properly with link to cancel work order', () => {
+      // 2021-01-14T18:16:20.986Z
+      MockDate.set(1610648180986)
+      // Set current time to within an hour of date raised
+      props.workOrder.dateRaised = '2021-01-14T18:56:20.986Z'
+
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrderDetails
+            propertyReference={props.property.propertyReference}
+            workOrder={props.workOrder}
+            address={props.property.address}
+            subTypeDescription={props.property.hierarchyType.subTypeDescription}
+            tenure={props.tenure}
+            locationAlerts={props.alerts.locationAlert}
+            personAlerts={props.alerts.personAlert}
+            hasLinkToProperty={true}
+            canRaiseRepair={props.property.canRaiseRepair}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
   })
 
-  it('should render properly with link to cancel work order', () => {
-    // 2021-01-14T18:16:20.986Z
-    MockDate.set(1610648180986)
-    // Set current time to within an hour of date raised
-    props.workOrder.dateRaised = '2021-01-14T18:56:20.986Z'
+  describe('when logged in as a contractor', () => {
+    const user = {
+      name: 'A Contractor',
+      email: 'a.contractor@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: true,
+      hasAnyPermissions: true,
+      contractorReference: 'SCC',
+    }
 
-    const { asFragment } = render(
-      <WorkOrderDetails
-        propertyReference={props.property.propertyReference}
-        workOrder={props.workOrder}
-        address={props.property.address}
-        subTypeDescription={props.property.hierarchyType.subTypeDescription}
-        tenure={props.tenure}
-        locationAlerts={props.alerts.locationAlert}
-        personAlerts={props.alerts.personAlert}
-        hasLinkToProperty={true}
-        canRaiseRepair={props.property.canRaiseRepair}
-      />
-    )
-    expect(asFragment()).toMatchSnapshot()
+    it('should render properly without a link to cancel work order', () => {
+      // Link isn't shown if current time is greater than dateRaised + 1 hour
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrderDetails
+            propertyReference={props.property.propertyReference}
+            workOrder={props.workOrder}
+            address={props.property.address}
+            subTypeDescription={props.property.hierarchyType.subTypeDescription}
+            tenure={props.tenure}
+            locationAlerts={props.alerts.locationAlert}
+            personAlerts={props.alerts.personAlert}
+            hasLinkToProperty={true}
+            canRaiseRepair={props.property.canRaiseRepair}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+
+    it('should render properly without a link to cancel work order', () => {
+      // 2021-01-14T18:16:20.986Z
+      MockDate.set(1610648180986)
+      // Set current time to within an hour of date raised
+      props.workOrder.dateRaised = '2021-01-14T18:56:20.986Z'
+
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrderDetails
+            propertyReference={props.property.propertyReference}
+            workOrder={props.workOrder}
+            address={props.property.address}
+            subTypeDescription={props.property.hierarchyType.subTypeDescription}
+            tenure={props.tenure}
+            locationAlerts={props.alerts.locationAlert}
+            personAlerts={props.alerts.personAlert}
+            hasLinkToProperty={true}
+            canRaiseRepair={props.property.canRaiseRepair}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
   })
 })

--- a/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
@@ -1,8 +1,352 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WorkOrderDetails component should render properly with link to cancel work order 1`] = `
+exports[`WorkOrderDetails component when logged in as a contractor should render properly without a link to cancel work order 1`] = `
 <DocumentFragment>
   <div>
+    <a
+      class="govuk-back-link"
+      role="button"
+    >
+      Back
+    </a>
+    <div>
+      <h1
+        class="govuk-heading-l display-inline govuk-!-margin-right-6"
+      >
+        Works order: 10000012
+      </h1>
+      <a
+        class="govuk-body-m"
+        href="/repairs/jobs/10000012/choose-option"
+      >
+        Update Works Order
+      </a>
+    </div>
+    <p
+      class="govuk-body-m"
+    >
+      This is an urgent repair description
+    </p>
+    <div
+      class="govuk-body-s govuk-grid-row"
+    >
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="property-details-main-section"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Dwelling
+          </span>
+          <br />
+          <a
+            href="/properties/00012345"
+          >
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
+            >
+              16 Pitcairn House
+              <br />
+              St Thomass Square
+              <br />
+              <span
+                class="govuk-!-font-size-14"
+              >
+                E9 6PT
+              </span>
+            </div>
+          </a>
+        </div>
+        <ul
+          class="hackney-property-alerts"
+        >
+          <li
+            class="bg-turquoise"
+          >
+            Tenure: Secure
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Address Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Contact Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="work-order-info"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Works order
+          </span>
+          <div
+            class="govuk-body-s govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Status: In Progress
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-size-14"
+            >
+              Priority: U - Urgent (5 Working days)
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Raised by Dummy Agent
+            </span>
+            <br />
+            <span>
+              14 Jan 2021, 6:56 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Target: 23 Jan 2021, 6:30 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Caller: Jill Smith
+            </span>
+            <br />
+            <span>
+              07700 900999
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="appointment-details"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Appointment details
+          </span>
+          <br />
+          <div
+            class="govuk-body-s"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WorkOrderDetails component when logged in as a contractor should render properly without a link to cancel work order 2`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link"
+      role="button"
+    >
+      Back
+    </a>
+    <div>
+      <h1
+        class="govuk-heading-l display-inline govuk-!-margin-right-6"
+      >
+        Works order: 10000012
+      </h1>
+      <a
+        class="govuk-body-m"
+        href="/repairs/jobs/10000012/choose-option"
+      >
+        Update Works Order
+      </a>
+    </div>
+    <p
+      class="govuk-body-m"
+    >
+      This is an urgent repair description
+    </p>
+    <div
+      class="govuk-body-s govuk-grid-row"
+    >
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="property-details-main-section"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Dwelling
+          </span>
+          <br />
+          <a
+            href="/properties/00012345"
+          >
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
+            >
+              16 Pitcairn House
+              <br />
+              St Thomass Square
+              <br />
+              <span
+                class="govuk-!-font-size-14"
+              >
+                E9 6PT
+              </span>
+            </div>
+          </a>
+        </div>
+        <ul
+          class="hackney-property-alerts"
+        >
+          <li
+            class="bg-turquoise"
+          >
+            Tenure: Secure
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Address Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Contact Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="work-order-info"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Works order
+          </span>
+          <div
+            class="govuk-body-s govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Status: In Progress
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-size-14"
+            >
+              Priority: U - Urgent (5 Working days)
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Raised by Dummy Agent
+            </span>
+            <br />
+            <span>
+              14 Jan 2021, 6:56 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Target: 23 Jan 2021, 6:30 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Caller: Jill Smith
+            </span>
+            <br />
+            <span>
+              07700 900999
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="appointment-details"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Appointment details
+          </span>
+          <br />
+          <div
+            class="govuk-body-s"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WorkOrderDetails component when logged in as an agent should render properly with link to cancel work order 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link"
+      role="button"
+    >
+      Back
+    </a>
     <div>
       <h1
         class="govuk-heading-l display-inline govuk-!-margin-right-6"
@@ -170,9 +514,15 @@ exports[`WorkOrderDetails component should render properly with link to cancel w
 </DocumentFragment>
 `;
 
-exports[`WorkOrderDetails component should render properly without a link to cancel work order 1`] = `
+exports[`WorkOrderDetails component when logged in as an agent should render properly without a link to cancel work order 1`] = `
 <DocumentFragment>
   <div>
+    <a
+      class="govuk-back-link"
+      role="button"
+    >
+      Back
+    </a>
     <div>
       <h1
         class="govuk-heading-l display-inline govuk-!-margin-right-6"

--- a/src/components/WorkOrders/JobRow.js
+++ b/src/components/WorkOrders/JobRow.js
@@ -13,7 +13,11 @@ const JobRow = ({
   description,
 }) => (
   <tr className="govuk-table__row govuk-table__row--clickable govuk-body-s hackney-work-order-table">
-    <td className="govuk-table__cell">{reference}</td>
+    <td className="govuk-table__cell">
+      <Link href={`/work-orders/${reference}`}>
+        <a>{reference}</a>
+      </Link>
+    </td>
     <td className="govuk-table__cell">
       {dateRaised ? dateToStr(dateRaised) : '—'}
       <div className="work-order-hours">
@@ -31,11 +35,6 @@ const JobRow = ({
     <td className="govuk-table__cell">{status}</td>
     <td className="govuk-table__cell">
       <p className="description">{description}</p>
-    </td>
-    <td className="govuk-table__cell">
-      <Link href={`/repairs/jobs/${reference}/choose-option`}>
-        <a>Update</a>
-      </Link>
     </td>
   </tr>
 )

--- a/src/components/WorkOrders/JobsTable.js
+++ b/src/components/WorkOrders/JobsTable.js
@@ -29,7 +29,6 @@ const JobsTable = ({ workOrders, pageNumber, handlePageClick }) => (
           <th scope="col" className="govuk-table__header">
             Description
           </th>
-          <th scope="col" className="govuk-table__header"></th>
         </tr>
       </thead>
       <tbody className="govuk-table__body">

--- a/src/components/WorkOrders/__snapshots__/JobsTable.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/JobsTable.test.js.snap
@@ -59,10 +59,6 @@ exports[`JobsTable component should render properly 1`] = `
           >
             Description
           </th>
-          <th
-            class="govuk-table__header"
-            scope="col"
-          />
         </tr>
       </thead>
       <tbody
@@ -74,7 +70,11 @@ exports[`JobsTable component should render properly 1`] = `
           <td
             class="govuk-table__cell"
           >
-            10000012
+            <a
+              href="/work-orders/10000012"
+            >
+              10000012
+            </a>
           </td>
           <td
             class="govuk-table__cell"
@@ -119,15 +119,6 @@ exports[`JobsTable component should render properly 1`] = `
             >
               ALPHA- Pitcairn house op stucl behind carpark gates from power network pls remedy AND Communal: Door entry; Residents locked out/in
             </p>
-          </td>
-          <td
-            class="govuk-table__cell"
-          >
-            <a
-              href="/repairs/jobs/10000012/choose-option"
-            >
-              Update
-            </a>
           </td>
         </tr>
       </tbody>

--- a/src/pages/work-orders/[id]/index.js
+++ b/src/pages/work-orders/[id]/index.js
@@ -1,5 +1,5 @@
 import WorkOrderView from '../../../components/WorkOrder/WorkOrderView'
-import { AGENT_ROLE } from '../../../utils/user'
+import { AGENT_ROLE, CONTRACTOR_ROLE } from '../../../utils/user'
 
 const WorkOrderPage = ({ query }) => {
   return <WorkOrderView workOrderReference={query.id} />
@@ -15,6 +15,6 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-WorkOrderPage.permittedRoles = [AGENT_ROLE]
+WorkOrderPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE]
 
 export default WorkOrderPage


### PR DESCRIPTION
### Description of change

Contractor admins can now view the work order page and update it there - changes included are:

* Reference linked to work order page in job list
* Update link removed from job list
* Update link added to work order page
* References are removed from the repair history for contractors
* Back link added to work order page

### Story Link

https://trello.com/c/71X8CaIT/299-as-a-contractor-admin-i-can-select-and-view-a-work-order-so-that-i-can-view-the-full-details-of-the-repair

### Decisions

* 'Cancel Works Order' link is only available to agents and 'Update Works Order' link is only available to contractor admins.
* 'Schedule appointment' link is hidden from contractor admins

### Screenshots

New jobs list for contractor admins:

![image](https://user-images.githubusercontent.com/6321/109349396-cbbf1c80-786d-11eb-9c75-94673f316df8.png)

New work order header for contractor admins:

![image](https://user-images.githubusercontent.com/6321/109349530-03c65f80-786e-11eb-8bc5-5d76486bdcdb.png)

New repairs history table for contractor admins:

![image](https://user-images.githubusercontent.com/6321/109349660-3a9c7580-786e-11eb-94ac-933f54b51c6b.png)
