### PR TITLE
Disable priority select until SOR code is selected

### DIFF
--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -106,6 +106,13 @@ describe('Raise repair form', () => {
       cy.get('input[id="rateScheduleItems[0][quantity]"]').should(
         'not.be.disabled'
       )
+      // Priority disabled until SOR is selected
+      cy.get('#priorityDescription').should('be.disabled')
+      cy.get('select[id="rateScheduleItems[0][code]"]').select(
+        'INP5R001 - Pre insp of wrks by Constructr'
+      )
+      cy.get('#priorityDescription').should('not.be.disabled')
+
       // Selecting no trade clears contractor and SOR code select options
       cy.get('#trade').clear()
       cy.get('#contractor').should('be.disabled')

--- a/src/components/Property/RaiseRepair/RaiseRepairForm.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairForm.js
@@ -136,6 +136,7 @@ const RaiseRepairForm = ({
               label="Task priority"
               options={priorityList}
               onChange={onPrioritySelect}
+              disabled={true}
               required={true}
               register={register({
                 required: 'Please select a priority',

--- a/src/components/Property/RaiseRepair/RateScheduleItemView.js
+++ b/src/components/Property/RaiseRepair/RateScheduleItemView.js
@@ -32,6 +32,8 @@ const RateScheduleItemView = ({
   }
 
   const onRateScheduleItemSelect = (index, event) => {
+    document.getElementById('priorityDescription').disabled = false
+
     const value = event.target.value.split(' - ')[0]
     const sorCodeObject = getSorCodeObject(value)
     const sorCodeDescription = sorCodeObject?.shortDescription || ''

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -243,6 +243,7 @@ exports[`RaiseRepairForm component should render properly 1`] = `
           <select
             class="govuk-select govuk-!-width-full"
             data-testid="priorityDescription"
+            disabled=""
             id="priorityDescription"
             name="priorityDescription"
           >


### PR DESCRIPTION
### Description of change

Disable priority select until SOR code has been selected

https://trello.com/c/J883dFVQ/399-as-an-rcc-agent-task-priority-can-only-be-selected-after-the-sor-code-has-been-completed
