### PR TITLE
Fix button styling issues

### DIFF
--- a/src/components/Form/Button/PrimarySubmitButton.js
+++ b/src/components/Form/Button/PrimarySubmitButton.js
@@ -5,11 +5,7 @@ import Button from './Button'
 // to separate them from the rest of the form
 const PrimarySubmitButton = ({ ...otherProps }) => (
   <div className="govuk-form-group">
-    <Button
-      type="submit"
-      className="lbh-button--repairs"
-      {...otherProps}
-    ></Button>
+    <Button type="submit" {...otherProps}></Button>
   </div>
 )
 

--- a/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
+++ b/src/components/Property/RaiseRepair/__snapshots__/RaiseRepairForm.test.js.snap
@@ -360,7 +360,7 @@ exports[`RaiseRepairForm component should render properly 1`] = `
           class="govuk-form-group"
         >
           <button
-            class="govuk-button lbh-button--repairs"
+            class="govuk-button"
             data-module="govuk-button"
             type="submit"
           >

--- a/src/components/WorkOrder/Appointment/TimeSlotForm.js
+++ b/src/components/WorkOrder/Appointment/TimeSlotForm.js
@@ -57,9 +57,9 @@ const TimeSlotForm = ({
               isSecondary={true}
               label="Cancel"
               onClick={onCancel}
-              className="lbh-button--repairs govuk-!-margin-right-4"
+              className="govuk-!-margin-right-4"
             />
-            <Button label="Add" type="submit" className="lbh-button--repairs" />
+            <Button label="Add" type="submit" />
           </div>
         </form>
       </div>

--- a/src/components/WorkOrder/CancelWorkOrder/__snapshots__/CancelWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrder/CancelWorkOrder/__snapshots__/CancelWorkOrderForm.test.js.snap
@@ -117,7 +117,7 @@ exports[`CancelWorkOrderForm component should render properly 1`] = `
             class="govuk-form-group"
           >
             <button
-              class="govuk-button lbh-button--repairs"
+              class="govuk-button"
               data-module="govuk-button"
               type="submit"
             >

--- a/src/components/WorkOrder/Notes/__snapshots__/NotesForm.test.js.snap
+++ b/src/components/WorkOrder/Notes/__snapshots__/NotesForm.test.js.snap
@@ -87,7 +87,7 @@ exports[`NotesForm component should render properly when display form is true 1`
           class="govuk-form-group"
         >
           <button
-            class="govuk-button lbh-button--repairs"
+            class="govuk-button"
             data-module="govuk-button"
             type="submit"
           >

--- a/src/components/WorkOrders/__snapshots__/ChooseOption.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/ChooseOption.test.js.snap
@@ -69,7 +69,7 @@ exports[`ChooseOption component should render properly 1`] = `
       class="govuk-form-group"
     >
       <button
-        class="govuk-button lbh-button--repairs"
+        class="govuk-button"
         data-module="govuk-button"
         type="submit"
       >

--- a/src/components/WorkOrders/__snapshots__/CloseJobForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/CloseJobForm.test.js.snap
@@ -130,7 +130,7 @@ exports[`CloseJobForm component should render properly 1`] = `
         class="govuk-form-group"
       >
         <button
-          class="govuk-button lbh-button--repairs"
+          class="govuk-button"
           data-module="govuk-button"
           type="submit"
         >

--- a/src/components/WorkOrders/__snapshots__/SummaryCloseJob.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/SummaryCloseJob.test.js.snap
@@ -76,7 +76,7 @@ exports[`SummaryCloseJob component should render properly 1`] = `
         class="govuk-form-group"
       >
         <button
-          class="govuk-button lbh-button--repairs"
+          class="govuk-button"
           data-module="govuk-button"
           type="submit"
         >

--- a/src/components/WorkOrders/__snapshots__/SummaryUpdateJob.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/SummaryUpdateJob.test.js.snap
@@ -175,7 +175,7 @@ exports[`SummaryUpdateJob component should render properly 1`] = `
         class="govuk-form-group"
       >
         <button
-          class="govuk-button lbh-button--repairs"
+          class="govuk-button"
           data-module="govuk-button"
           type="submit"
         >

--- a/src/components/WorkOrders/__snapshots__/UpdateJobForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/UpdateJobForm.test.js.snap
@@ -213,7 +213,7 @@ exports[`UpdateJobForm component should render properly 1`] = `
       class="govuk-form-group"
     >
       <button
-        class="govuk-button lbh-button--repairs"
+        class="govuk-button"
         data-module="govuk-button"
         type="submit"
       >

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -1,7 +1,7 @@
 // override style for primaruy govuk button without affecting
 // the styles for a secondary button
 
-.govuk-button.lbh-button--repairs:not(.govuk-button--secondary) {
+.govuk-button:not(.govuk-button--secondary) {
   background-color: repairs-hub-colour('housing-2');
   &:hover {
     background-color: #10767c;


### PR DESCRIPTION
Remove the need for adding unnecessary custom class to buttons to give them our button styles. Retains the secondary button styling for cancel buttons.

### Selected screenshots

![image](https://user-images.githubusercontent.com/1370570/109693520-aa1da800-7b81-11eb-86ee-28ed9ff4a96a.png)

![image](https://user-images.githubusercontent.com/1370570/109693555-b4d83d00-7b81-11eb-8193-310ac6bb30e2.png)

![image](https://user-images.githubusercontent.com/1370570/109693719-e8b36280-7b81-11eb-81ca-863b07853950.png)

![image](https://user-images.githubusercontent.com/1370570/109693746-f10b9d80-7b81-11eb-8f7e-561d9f52caec.png)
