### PR TITLE
Display original Tasks and SORs with original quantity

### DIFF
--- a/cypress/fixtures/repairs/tasks-and-sors.json
+++ b/cypress/fixtures/repairs/tasks-and-sors.json
@@ -5,8 +5,10 @@
     "description": "Urgent call outs",
     "dateAdded": "2021-02-03T09:33:35.757339",
     "quantity": 2,
-    "cost": 0,
-    "status": "Unknown"
+    "cost": 10,
+    "status": "Unknown",
+    "original": true,
+    "originalQuantity": 2
   },
   {
     "id": "bde7c53b-8947-414c-b88f-9c5e3d875cbg",
@@ -15,7 +17,9 @@
     "dateAdded": "2021-02-03T11:23:35.814437",
     "quantity": 4,
     "cost": 0,
-    "status": "Unknown"
+    "status": "Unknown",
+    "original": false,
+    "originalQuantity": null
   },
   {
     "id": "cde7c53b-8947-414c-b88f-9c5e3d875cbh",
@@ -24,6 +28,8 @@
     "dateAdded": "2021-02-03T11:33:35.799566",
     "quantity": 5,
     "cost": 0,
-    "status": "Unknown"
+    "status": "Unknown",
+    "original": false,
+    "originalQuantity": null
   }
 ]

--- a/cypress/integration/jobs/update-job.spec.js
+++ b/cypress/integration/jobs/update-job.spec.js
@@ -187,6 +187,25 @@ describe('Contractor update a job', () => {
     cy.wait('@taskListRequest')
 
     cy.get('#repair-request-form').within(() => {
+      cy.get('#original-rate-schedule-items').within(() => {
+        cy.get('.govuk-heading-m').contains(
+          'Original tasks and SORS raised with work order'
+        )
+        // Expect all input fields to be disabled
+        cy.get('input[id="originalRateScheduleItems[0][code]"]').should(
+          'be.disabled'
+        )
+        cy.get('input[id="originalRateScheduleItems[0][quantity]"]').should(
+          'be.disabled'
+        )
+      })
+      cy.get('#existing-rate-schedule-items').within(() => {
+        cy.get('.govuk-heading-m').contains(
+          'All tasks and SORS against the work order'
+        )
+        // Expect SOR code input fields to be disabled
+        cy.get('input[id="sor-code-0"]').should('be.disabled')
+      })
       cy.get('#quantity-0-form-group').within(() => {
         cy.get('input[id="quantity-0"]').clear().type('12')
       })
@@ -205,7 +224,7 @@ describe('Contractor update a job', () => {
     })
 
     cy.get('#quantity-0-form-group').within(() => {
-      cy.get('input[id="quantity-0"]').clear().type('10')
+      cy.get('input[id="quantity-0"]').clear().type('3')
     })
     cy.get('#repair-request-form').within(() => {
       cy.get('.repairs-hub-link').click()
@@ -231,31 +250,60 @@ describe('Contractor update a job', () => {
         .type('PLP5R082')
         .blur()
       cy.wait('@sorCodeRequest')
-      cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('15')
+      cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('5')
 
       cy.get('[type="submit"]').contains('Next').click()
     })
 
     cy.contains('Summary of updates to work order')
-    // Check table
-    cy.get('.govuk-table__head').within(() => {
-      cy.get('.govuk-table__header').contains('SOR code')
-      cy.get('.govuk-table__header').contains('Quantity')
-      cy.get('.govuk-table__header').contains('Cost')
+    // Check original tasks and SORS table
+    cy.contains('Original Tasks and SORs')
+    cy.get('.govuk-table.original-tasks-table').within(() => {
+      cy.get('.govuk-table__head').within(() => {
+        cy.get('.govuk-table__header').contains('SOR code')
+        cy.get('.govuk-table__header').contains('Quantity')
+        cy.get('.govuk-table__header').contains('Cost (unit)')
+      })
+      cy.get('.govuk-table__body').within(() => {
+        cy.get('tr[id="original-task-0"]').within(() => {
+          cy.contains('DES5R006 - Urgent call outs')
+          cy.contains('2')
+          cy.contains('0')
+        })
+      })
     })
-    cy.get('.govuk-table__body').within(() => {
-      cy.get('tr[id="existing-task-0"]').within(() => {
-        cy.contains('DES5R006 - Urgent call outs')
-        cy.contains('10')
-        cy.contains('0')
+    // Check updated tasks and SORS table
+    cy.contains('Updated Tasks and SORs')
+    cy.get('.govuk-table.updated-tasks-table').within(() => {
+      cy.get('.govuk-table__head').within(() => {
+        cy.get('.govuk-table__header').contains('SOR code')
+        cy.get('.govuk-table__header').contains('Quantity')
+        cy.get('.govuk-table__header').contains('Cost (unit)')
       })
-      cy.get('tr[id="added-task-0"]').within(() => {
-        cy.contains('PLP5R082 - RE ENAMEL ANY SIZE BATH')
-        cy.contains('15')
-        cy.contains('148.09')
+      cy.get('.govuk-table__body').within(() => {
+        cy.get('tr[id="existing-task-0"]').within(() => {
+          cy.contains('DES5R006 - Urgent call outs')
+          cy.contains('3')
+          cy.contains('0')
+        })
+        cy.get('tr[id="added-task-0"]').within(() => {
+          cy.contains('PLP5R082 - RE ENAMEL ANY SIZE BATH')
+          cy.contains('5')
+          cy.contains('148.09')
+        })
+        cy.get('#original-cost').within(() => {
+          cy.contains('Original cost')
+          cy.contains('20.00')
+        })
+        cy.get('#variation-cost').within(() => {
+          cy.contains('Variation cost')
+          cy.contains('750.45')
+        })
+        cy.get('#total-cost').within(() => {
+          cy.contains('Total cost')
+          cy.contains('770.45')
+        })
       })
-      cy.contains('Total cost')
-      cy.get('#total-cost').contains('2221.35')
     })
 
     cy.get('[type="submit"]').contains('Confirm and close').click()
@@ -276,14 +324,14 @@ describe('Contractor update a job', () => {
               customCode: 'DES5R006',
               customName: 'Urgent call outs',
               quantity: {
-                amount: [Number.parseInt('10')],
+                amount: [Number.parseInt('3')],
               },
             },
             {
               customCode: 'PLP5R082',
               customName: 'RE ENAMEL ANY SIZE BATH',
               quantity: {
-                amount: [Number.parseInt('15')],
+                amount: [Number.parseInt('5')],
               },
             },
           ],

--- a/src/components/WorkOrders/RateScheduleItems/ExistingRateScheduleItems.js
+++ b/src/components/WorkOrders/RateScheduleItems/ExistingRateScheduleItems.js
@@ -4,53 +4,63 @@ import { TextInput } from '../../Form'
 
 const ExistingRateScheduleItems = ({ tasks, errors, register }) => {
   return (
-    <>
-      <GridRow className="rate-schedule-items align-items-center">
-        {tasks.map((t, index) => (
-          <div key={index}>
-            <GridColumn width="two-thirds">
-              <TextInput
-                name={`sor-code-${index}`}
-                label={index == 0 ? 'SOR code' : ''}
-                widthClass={`sor-code-${index} govuk-!-width-full`}
-                register={register}
-                disabled="disabled"
-                value={`${[t.code, t.description].filter(Boolean).join(' - ')}`}
-              />
-              <input
-                id={`original-rate-schedule-item-${index}`}
-                name={`original-rate-schedule-item-${index}`}
-                type="hidden"
-                value={t.id}
-                ref={register}
-              />
-            </GridColumn>
-            <GridColumn width="one-third">
-              <TextInput
-                name={`quantity-${index}`}
-                label={index == 0 ? 'Quantity' : ''}
-                error={errors && errors.quantity}
-                widthClass={`quantity-${index} govuk-!-width-full`}
-                defaultValue={t.quantity}
-                register={register({
-                  required: 'Please enter a quantity',
-                  valueAsNumber: true,
-                  validate: (value) => {
-                    if (!Number.isInteger(value)) {
-                      return 'Quantity must be a whole number'
-                    } else if (value > 50) {
-                      return 'Quantity must be 50 or less'
-                    } else {
-                      return true
-                    }
-                  },
-                })}
-              />
-            </GridColumn>
-          </div>
-        ))}
-      </GridRow>
-    </>
+    <div>
+      <section className="section" id="existing-rate-schedule-items">
+        <h2 className="govuk-heading-m">
+          All tasks and SORS against the work order
+        </h2>
+
+        <GridRow className="rate-schedule-items align-items-center">
+          {tasks.map((t, index) => (
+            <div key={index}>
+              <GridColumn width="two-thirds">
+                <TextInput
+                  name={`sor-code-${index}`}
+                  label={index == 0 ? 'SOR code' : ''}
+                  widthClass={`sor-code-${index} govuk-!-width-full`}
+                  register={register}
+                  disabled="disabled"
+                  value={`${[t.code, t.description]
+                    .filter(Boolean)
+                    .join(' - ')}`}
+                />
+                <input
+                  id={`original-rate-schedule-item-${index}`}
+                  name={`original-rate-schedule-item-${index}`}
+                  type="hidden"
+                  value={t.id}
+                  ref={register}
+                />
+              </GridColumn>
+              <GridColumn width="one-third">
+                <TextInput
+                  name={`quantity-${index}`}
+                  label={index == 0 ? 'Quantity' : ''}
+                  error={errors && errors?.[`quantity-${index}`]}
+                  widthClass={`quantity-${index} govuk-!-width-full`}
+                  defaultValue={t.quantity}
+                  register={register({
+                    required: 'Please enter a quantity',
+                    valueAsNumber: true,
+                    validate: (value) => {
+                      if (!Number.isInteger(value)) {
+                        return 'Quantity must be a whole number'
+                      } else if (value > 50) {
+                        return 'Quantity must be 50 or less'
+                      } else {
+                        return true
+                      }
+                    },
+                  })}
+                />
+              </GridColumn>
+            </div>
+          ))}
+        </GridRow>
+
+        <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+      </section>
+    </div>
   )
 }
 

--- a/src/components/WorkOrders/RateScheduleItems/OriginalRateScheduleItems.js
+++ b/src/components/WorkOrders/RateScheduleItems/OriginalRateScheduleItems.js
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types'
+import { GridRow, GridColumn } from '../../Layout/Grid'
+import { TextInput } from '../../Form'
+
+const OriginalRateScheduleItems = ({ originalTasks }) => {
+  return (
+    <div>
+      <section className="section" id="original-rate-schedule-items">
+        <h2 className="govuk-heading-m">
+          Original tasks and SORS raised with work order
+        </h2>
+
+        <GridRow className="original-rate-schedule-items align-items-center">
+          {originalTasks.map((task, index) => (
+            <div key={index}>
+              <GridColumn width="two-thirds">
+                <TextInput
+                  name={`originalRateScheduleItems[${index}][code]`}
+                  label={index == 0 ? 'SOR code' : ''}
+                  disabled={true}
+                  value={`${[task.code, task.description]
+                    .filter(Boolean)
+                    .join(' - ')}`}
+                />
+              </GridColumn>
+              <GridColumn width="one-third">
+                <TextInput
+                  name={`originalRateScheduleItems[${index}][quantity]`}
+                  label={index == 0 ? 'Quantity' : ''}
+                  disabled={true}
+                  value={task.originalQuantity}
+                />
+              </GridColumn>
+            </div>
+          ))}
+        </GridRow>
+
+        <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+      </section>
+    </div>
+  )
+}
+
+OriginalRateScheduleItems.propTypes = {
+  originalTasks: PropTypes.array.isRequired,
+}
+
+export default OriginalRateScheduleItems

--- a/src/components/WorkOrders/RateScheduleItems/UpdateSummaryRateScheduleItems.js
+++ b/src/components/WorkOrders/RateScheduleItems/UpdateSummaryRateScheduleItems.js
@@ -1,0 +1,145 @@
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+import { calculateTotalCost } from '../../../utils/helpers/calculations'
+import { Table, THead, TBody, TR, TH } from '../../Layout/Table'
+
+const UpdateSummaryRateScheduleItems = ({
+  originalTasks,
+  tasks,
+  addedTasks,
+  changeStep,
+}) => {
+  const ORIGINAL_COST = 'Original cost'
+  const TOTAL_VARIED_COST = 'Variation cost'
+  const TOTAL_COST = 'Total cost'
+
+  const showCostBreakdown = () => {
+    const original = {
+      description: ORIGINAL_COST,
+      cost: calculateTotalCost(originalTasks, 'cost', 'originalQuantity'),
+    }
+    const total = {
+      description: TOTAL_COST,
+      cost: calculateTotalCost(tasks.concat(addedTasks), 'cost', 'quantity'),
+    }
+    const totalVaried = {
+      description: TOTAL_VARIED_COST,
+      cost: total.cost - original.cost,
+    }
+
+    return [original, totalVaried, total].map((object, index) => (
+      <tr
+        key={index}
+        className="govuk-table__row"
+        id={object.description.toLowerCase().replace(/\s/g, '-')}
+      >
+        <th scope="row">{}</th>
+        <td
+          className={cx('govuk-!-padding-top-3', {
+            'border-top-black': object.description === TOTAL_COST,
+          })}
+        >
+          <strong>{object.description}</strong>
+        </td>
+        <td
+          className={cx('govuk-!-padding-top-3', {
+            'border-top-black': object.description === TOTAL_COST,
+          })}
+        >
+          £{object.cost.toFixed(2)}
+        </td>
+        <td>{}</td>
+      </tr>
+    ))
+  }
+
+  const rateScheduleItemsTable = (
+    tasks,
+    isExisting = false,
+    isOriginal = false
+  ) => {
+    let dataAttribute
+
+    if (isExisting) {
+      dataAttribute = 'existing-task'
+    } else if (isOriginal) {
+      dataAttribute = 'original-task'
+    } else {
+      dataAttribute = 'added-task'
+    }
+
+    return tasks.map((task, index) => (
+      <tr
+        className="govuk-table__row"
+        key={`${dataAttribute}-${index}`}
+        id={`${dataAttribute}-${index}`}
+      >
+        <th scope="row" className="govuk-table__header">
+          {[task.code, task.description].filter(Boolean).join(' - ')}
+        </th>
+        <td className="govuk-table__cell">
+          {dataAttribute === 'original-task'
+            ? task.originalQuantity
+            : task.quantity}
+        </td>
+        <td className="govuk-table__cell">£{parseFloat(task.cost)}</td>
+        {dataAttribute !== 'original-task' && (
+          <td className="govuk-table__cell">
+            <a onClick={changeStep} href="#">
+              Edit
+            </a>
+          </td>
+        )}
+      </tr>
+    ))
+  }
+
+  const buildTableTemplate = (...callbacks) => {
+    return (
+      <>
+        <THead>
+          <TR className="govuk-body">
+            <TH scope="col" width="one-half">
+              SOR code
+            </TH>
+            <TH scope="col" width="one-quarter">
+              Quantity
+            </TH>
+            <TH scope="col" width="one-quarter">
+              Cost (unit)
+            </TH>
+            <TH scope="col">{''}</TH>
+          </TR>
+        </THead>
+        <TBody>{callbacks}</TBody>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <p className="govuk-heading-s">Original Tasks and SORs</p>
+      <Table className="original-tasks-table">
+        {buildTableTemplate(rateScheduleItemsTable(originalTasks, false, true))}
+      </Table>
+
+      <p className="govuk-heading-s">Updated Tasks and SORs</p>
+      <Table className="updated-tasks-table">
+        {buildTableTemplate(
+          rateScheduleItemsTable(tasks, true),
+          rateScheduleItemsTable(addedTasks),
+          showCostBreakdown()
+        )}
+      </Table>
+    </>
+  )
+}
+
+UpdateSummaryRateScheduleItems.propTypes = {
+  originalTasks: PropTypes.array.isRequired,
+  tasks: PropTypes.array,
+  addedTasks: PropTypes.array,
+  changeStep: PropTypes.func,
+}
+
+export default UpdateSummaryRateScheduleItems

--- a/src/components/WorkOrders/RateScheduleItems/VariedRateScheduleItems.js
+++ b/src/components/WorkOrders/RateScheduleItems/VariedRateScheduleItems.js
@@ -8,21 +8,17 @@ import { getSorCode } from '../../../utils/frontend-api-client/schedule-of-rates
 const VariedRateScheduleItems = ({
   register,
   errors,
-  existingAddedRateScheduleItems,
+  addedTasks,
   isContractorUpdatePage,
   propertyReference,
 }) => {
   const [error, setError] = useState()
   const [loading, setLoading] = useState(false)
-  const [rateScheduleItems, setRateScheduleItems] = useState([
-    ...existingAddedRateScheduleItems,
-  ])
+  const [rateScheduleItems, setRateScheduleItems] = useState([...addedTasks])
   const [sorCodesList, setSorCodesList] = useState(
-    existingAddedRateScheduleItems.map((item) => item.code)
+    addedTasks.map((item) => item.code)
   )
-  const [nextFreeIndex, setNextFreeIndex] = useState(
-    existingAddedRateScheduleItems.length
-  )
+  const [nextFreeIndex, setNextFreeIndex] = useState(addedTasks.length)
 
   const addRateScheduleItem = () => {
     rateScheduleItems.push({ id: nextFreeIndex })
@@ -155,7 +151,7 @@ VariedRateScheduleItems.propTypes = {
   register: PropTypes.func.isRequired,
   errors: PropTypes.object.isRequired,
   isContractorUpdatePage: PropTypes.bool.isRequired,
-  existingAddedRateScheduleItems: PropTypes.array.isRequired,
+  addedTasks: PropTypes.array.isRequired,
 }
 
 export default VariedRateScheduleItems

--- a/src/components/WorkOrders/SummaryUpdateJob.js
+++ b/src/components/WorkOrders/SummaryUpdateJob.js
@@ -1,57 +1,17 @@
 import PropTypes from 'prop-types'
 import { useForm } from 'react-hook-form'
 import { PrimarySubmitButton } from '../Form'
-import { calculateTotalCost } from '../../utils/helpers/calculations'
+import UpdateSummaryRateScheduleItems from './RateScheduleItems/UpdateSummaryRateScheduleItems'
 
 const SummaryUpdateJob = ({
   reference,
   onJobSubmit,
+  originalTasks,
   tasks,
   addedTasks,
   changeStep,
 }) => {
   const { handleSubmit } = useForm({})
-
-  const showCostBreakdown = (allTasks) => {
-    const totalCost = calculateTotalCost(allTasks, 'cost', 'quantity')
-
-    return (
-      <tr className="govuk-table__row">
-        <th scope="row">{}</th>
-        <td className="govuk-!-padding-top-5">
-          <strong>Total cost</strong>
-        </td>
-        <td className="govuk-!-padding-top-5" id="total-cost">
-          £{totalCost.toFixed(2)}
-        </td>
-        <td>{}</td>
-      </tr>
-    )
-  }
-
-  const rateScheduleItemsTable = (data, isExisting = false) => {
-    let dataAttribute = isExisting ? 'existing-task' : 'added-task'
-    return data.map((t, index) => (
-      <tr
-        className={`tasks-${index} govuk-table__row`}
-        key={`${dataAttribute}-${index}`}
-        id={`${dataAttribute}-${index}`}
-      >
-        <th scope="row" className={`sor-code-${index} govuk-table__header`}>
-          {[t.code, t.description].filter(Boolean).join(' - ')}
-        </th>
-        <td className={`quantity-${index} govuk-table__cell`}>{t.quantity}</td>
-        <td className={`cost-${index} govuk-table__cell`}>
-          £{parseFloat(t.cost) || 0}
-        </td>
-        <td className={`edit-${index} govuk-table__cell`}>
-          <a onClick={changeStep} href="#">
-            Edit
-          </a>
-        </td>
-      </tr>
-    ))
-  }
 
   return (
     <div>
@@ -62,30 +22,14 @@ const SummaryUpdateJob = ({
         onSubmit={handleSubmit(onJobSubmit)}
       >
         <p className="govuk-heading-s">Summary of updates to work order</p>
-        <p className="govuk-heading-s">Tasks and SORs</p>
-        <table className="govuk-table">
-          <thead className="govuk-table__head">
-            <tr className="govuk-table__row">
-              <th scope="col" className="govuk-table__header">
-                SOR code
-              </th>
-              <th scope="col" className="govuk-table__header">
-                Quantity
-              </th>
-              <th scope="col" className="govuk-table__header">
-                Cost
-              </th>
-              <th scope="col" className="govuk-table__header">
-                {''}
-              </th>
-            </tr>
-          </thead>
-          <tbody className="govuk-table__body">
-            {rateScheduleItemsTable(tasks, true)}
-            {rateScheduleItemsTable(addedTasks)}
-            {showCostBreakdown(tasks.concat(addedTasks))}
-          </tbody>
-        </table>
+
+        <UpdateSummaryRateScheduleItems
+          originalTasks={originalTasks}
+          tasks={tasks}
+          addedTasks={addedTasks}
+          changeStep={changeStep}
+        />
+
         <PrimarySubmitButton label="Confirm and close" />
       </form>
     </div>

--- a/src/components/WorkOrders/SummaryUpdateJob.test.js
+++ b/src/components/WorkOrders/SummaryUpdateJob.test.js
@@ -4,15 +4,28 @@ import SummaryUpdateJob from './SummaryUpdateJob'
 describe('SummaryUpdateJob component', () => {
   const props = {
     reference: '10000012',
-    tasks: [
+    originalTasks: [
       {
         code: 'DES5R006',
         quantity: 2,
+        original: true,
+        originalQuantity: 2,
+        cost: '10.5',
+      },
+    ],
+    tasks: [
+      {
+        code: 'DES5R006',
+        quantity: 3,
+        original: true,
+        originalQuantity: 2,
         cost: '10.5',
       },
       {
         code: 'DES5R005',
         quantity: 1,
+        original: false,
+        originalQuantity: null,
         cost: '14.5',
       },
     ],
@@ -20,6 +33,8 @@ describe('SummaryUpdateJob component', () => {
       {
         code: 'DES5R004',
         quantity: 2,
+        original: false,
+        originalQuantity: null,
         cost: '22.5',
       },
     ],
@@ -33,6 +48,7 @@ describe('SummaryUpdateJob component', () => {
       <SummaryUpdateJob
         reference={props.reference}
         onJobSubmit={props.onJobSubmit}
+        originalTasks={props.originalTasks}
         tasks={props.tasks}
         addedTasks={props.addedTasks}
         changeStep={props.changeStep}

--- a/src/components/WorkOrders/UpdateJob.js
+++ b/src/components/WorkOrders/UpdateJob.js
@@ -14,6 +14,7 @@ import { useRouter } from 'next/router'
 
 const UpdateJob = ({ reference }) => {
   const [tasks, setTasks] = useState([])
+  const [originalTasks, setOriginalTasks] = useState([])
   const [propertyReference, setPropertyReference] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
@@ -78,6 +79,7 @@ const UpdateJob = ({ reference }) => {
       const tasks = await getTasks(reference)
 
       setTasks(tasks)
+      setOriginalTasks(tasks.filter((t) => t.original))
       setPropertyReference(workOrder.propertyReference)
     } catch (e) {
       setTasks(null)
@@ -125,6 +127,7 @@ const UpdateJob = ({ reference }) => {
               {showSummaryPage && (
                 <SummaryUpdateJob
                   addedTasks={rateScheduleItems}
+                  originalTasks={originalTasks}
                   tasks={tasks}
                   reference={reference}
                   onJobSubmit={onJobUpdateSubmit}

--- a/src/components/WorkOrders/UpdateJobForm.js
+++ b/src/components/WorkOrders/UpdateJobForm.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import { PrimarySubmitButton } from '../Form'
 import { useForm } from 'react-hook-form'
+import OriginalRateScheduleItems from './RateScheduleItems/OriginalRateScheduleItems'
 import ExistingRateScheduleItems from './RateScheduleItems/ExistingRateScheduleItems'
 import VariedRateScheduleItems from './RateScheduleItems/VariedRateScheduleItems'
 
@@ -12,6 +13,7 @@ const UpdateJobForm = ({
 }) => {
   const { register, handleSubmit, errors } = useForm()
   const isContractorUpdatePage = true
+  const originalTasks = tasks.filter((t) => t.original)
 
   return (
     <>
@@ -20,6 +22,7 @@ const UpdateJobForm = ({
         id="repair-request-form"
         onSubmit={handleSubmit(onGetToSummary)}
       >
+        <OriginalRateScheduleItems originalTasks={originalTasks} />
         <ExistingRateScheduleItems
           tasks={tasks}
           register={register}
@@ -28,7 +31,7 @@ const UpdateJobForm = ({
         <VariedRateScheduleItems
           register={register}
           errors={errors}
-          existingAddedRateScheduleItems={addedTasks}
+          addedTasks={addedTasks}
           isContractorUpdatePage={isContractorUpdatePage}
           propertyReference={propertyReference}
         />

--- a/src/components/WorkOrders/__snapshots__/SummaryUpdateJob.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/SummaryUpdateJob.test.js.snap
@@ -20,34 +20,34 @@ exports[`SummaryUpdateJob component should render properly 1`] = `
       <p
         class="govuk-heading-s"
       >
-        Tasks and SORs
+        Original Tasks and SORs
       </p>
       <table
-        class="govuk-table"
+        class="govuk-table original-tasks-table"
       >
         <thead
           class="govuk-table__head"
         >
           <tr
-            class="govuk-table__row"
+            class="govuk-table__row govuk-body"
           >
             <th
-              class="govuk-table__header"
+              class="govuk-table__header govuk-!-width-one-half"
               scope="col"
             >
               SOR code
             </th>
             <th
-              class="govuk-table__header"
+              class="govuk-table__header govuk-!-width-one-quarter"
               scope="col"
             >
               Quantity
             </th>
             <th
-              class="govuk-table__header"
+              class="govuk-table__header govuk-!-width-one-quarter"
               scope="col"
             >
-              Cost
+              Cost (unit)
             </th>
             <th
               class="govuk-table__header"
@@ -59,87 +59,91 @@ exports[`SummaryUpdateJob component should render properly 1`] = `
           class="govuk-table__body"
         >
           <tr
-            class="tasks-0 govuk-table__row"
-            id="existing-task-0"
+            class="govuk-table__row"
+            id="original-task-0"
           >
             <th
-              class="sor-code-0 govuk-table__header"
+              class="govuk-table__header"
               scope="row"
             >
               DES5R006
             </th>
             <td
-              class="quantity-0 govuk-table__cell"
+              class="govuk-table__cell"
             >
               2
             </td>
             <td
-              class="cost-0 govuk-table__cell"
+              class="govuk-table__cell"
+            >
+              £10.5
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p
+        class="govuk-heading-s"
+      >
+        Updated Tasks and SORs
+      </p>
+      <table
+        class="govuk-table updated-tasks-table"
+      >
+        <thead
+          class="govuk-table__head"
+        >
+          <tr
+            class="govuk-table__row govuk-body"
+          >
+            <th
+              class="govuk-table__header govuk-!-width-one-half"
+              scope="col"
+            >
+              SOR code
+            </th>
+            <th
+              class="govuk-table__header govuk-!-width-one-quarter"
+              scope="col"
+            >
+              Quantity
+            </th>
+            <th
+              class="govuk-table__header govuk-!-width-one-quarter"
+              scope="col"
+            >
+              Cost (unit)
+            </th>
+            <th
+              class="govuk-table__header"
+              scope="col"
+            />
+          </tr>
+        </thead>
+        <tbody
+          class="govuk-table__body"
+        >
+          <tr
+            class="govuk-table__row"
+            id="existing-task-0"
+          >
+            <th
+              class="govuk-table__header"
+              scope="row"
+            >
+              DES5R006
+            </th>
+            <td
+              class="govuk-table__cell"
+            >
+              3
+            </td>
+            <td
+              class="govuk-table__cell"
             >
               £10.5
             </td>
             <td
-              class="edit-0 govuk-table__cell"
-            >
-              <a
-                href="#"
-              >
-                Edit
-              </a>
-            </td>
-          </tr>
-          <tr
-            class="tasks-1 govuk-table__row"
-            id="existing-task-1"
-          >
-            <th
-              class="sor-code-1 govuk-table__header"
-              scope="row"
-            >
-              DES5R005
-            </th>
-            <td
-              class="quantity-1 govuk-table__cell"
-            >
-              1
-            </td>
-            <td
-              class="cost-1 govuk-table__cell"
-            >
-              £14.5
-            </td>
-            <td
-              class="edit-1 govuk-table__cell"
-            >
-              <a
-                href="#"
-              >
-                Edit
-              </a>
-            </td>
-          </tr>
-          <tr
-            class="tasks-0 govuk-table__row"
-            id="added-task-0"
-          >
-            <th
-              class="sor-code-0 govuk-table__header"
-              scope="row"
-            >
-              DES5R004
-            </th>
-            <td
-              class="quantity-0 govuk-table__cell"
-            >
-              2
-            </td>
-            <td
-              class="cost-0 govuk-table__cell"
-            >
-              £22.5
-            </td>
-            <td
-              class="edit-0 govuk-table__cell"
+              class="govuk-table__cell"
             >
               <a
                 href="#"
@@ -150,22 +154,124 @@ exports[`SummaryUpdateJob component should render properly 1`] = `
           </tr>
           <tr
             class="govuk-table__row"
+            id="existing-task-1"
+          >
+            <th
+              class="govuk-table__header"
+              scope="row"
+            >
+              DES5R005
+            </th>
+            <td
+              class="govuk-table__cell"
+            >
+              1
+            </td>
+            <td
+              class="govuk-table__cell"
+            >
+              £14.5
+            </td>
+            <td
+              class="govuk-table__cell"
+            >
+              <a
+                href="#"
+              >
+                Edit
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="govuk-table__row"
+            id="added-task-0"
+          >
+            <th
+              class="govuk-table__header"
+              scope="row"
+            >
+              DES5R004
+            </th>
+            <td
+              class="govuk-table__cell"
+            >
+              2
+            </td>
+            <td
+              class="govuk-table__cell"
+            >
+              £22.5
+            </td>
+            <td
+              class="govuk-table__cell"
+            >
+              <a
+                href="#"
+              >
+                Edit
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="govuk-table__row"
+            id="original-cost"
           >
             <th
               scope="row"
             />
             <td
-              class="govuk-!-padding-top-5"
+              class="govuk-!-padding-top-3"
+            >
+              <strong>
+                Original cost
+              </strong>
+            </td>
+            <td
+              class="govuk-!-padding-top-3"
+            >
+              £21.00
+            </td>
+            <td />
+          </tr>
+          <tr
+            class="govuk-table__row"
+            id="variation-cost"
+          >
+            <th
+              scope="row"
+            />
+            <td
+              class="govuk-!-padding-top-3"
+            >
+              <strong>
+                Variation cost
+              </strong>
+            </td>
+            <td
+              class="govuk-!-padding-top-3"
+            >
+              £70.00
+            </td>
+            <td />
+          </tr>
+          <tr
+            class="govuk-table__row"
+            id="total-cost"
+          >
+            <th
+              scope="row"
+            />
+            <td
+              class="govuk-!-padding-top-3 border-top-black"
             >
               <strong>
                 Total cost
               </strong>
             </td>
             <td
-              class="govuk-!-padding-top-5"
-              id="total-cost"
+              class="govuk-!-padding-top-3 border-top-black"
             >
-              £80.50
+              £91.00
             </td>
             <td />
           </tr>

--- a/src/components/WorkOrders/__snapshots__/UpdateJobForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/UpdateJobForm.test.js.snap
@@ -6,115 +6,148 @@ exports[`UpdateJobForm component should render properly 1`] = `
     id="repair-request-form"
     role="form"
   >
-    <div
-      class="govuk-grid-row rate-schedule-items align-items-center"
-    >
-      <div>
-        <div
-          class="govuk-grid-column-two-thirds"
+    <div>
+      <section
+        class="section"
+        id="original-rate-schedule-items"
+      >
+        <h2
+          class="govuk-heading-m"
         >
-          <div
-            class="govuk-form-group"
-            id="sor-code-0-form-group"
-          >
-            <label
-              class="govuk-label"
-              for="sor-code-0"
-            >
-              SOR code 
-            </label>
-            <input
-              class="govuk-input sor-code-0 govuk-!-width-full"
-              disabled=""
-              id="sor-code-0"
-              name="sor-code-0"
-              type="text"
-              value="DES5R006"
-            />
-          </div>
-          <input
-            id="original-rate-schedule-item-0"
-            name="original-rate-schedule-item-0"
-            type="hidden"
-            value=""
-          />
-        </div>
+          Original tasks and SORS raised with work order
+        </h2>
         <div
-          class="govuk-grid-column-one-third"
+          class="govuk-grid-row original-rate-schedule-items align-items-center"
+        />
+        <hr
+          class="govuk-section-break govuk-section-break--l govuk-section-break--visible"
+        />
+      </section>
+    </div>
+    <div>
+      <section
+        class="section"
+        id="existing-rate-schedule-items"
+      >
+        <h2
+          class="govuk-heading-m"
         >
-          <div
-            class="govuk-form-group"
-            id="quantity-0-form-group"
-          >
-            <label
-              class="govuk-label"
-              for="quantity-0"
-            >
-              Quantity 
-            </label>
-            <input
-              class="govuk-input quantity-0 govuk-!-width-full"
-              id="quantity-0"
-              name="quantity-0"
-              type="text"
-              value="2"
-            />
-          </div>
-        </div>
-      </div>
-      <div>
+          All tasks and SORS against the work order
+        </h2>
         <div
-          class="govuk-grid-column-two-thirds"
+          class="govuk-grid-row rate-schedule-items align-items-center"
         >
-          <div
-            class="govuk-form-group"
-            id="sor-code-1-form-group"
-          >
-            <label
-              class="govuk-label"
-              for="sor-code-1"
+          <div>
+            <div
+              class="govuk-grid-column-two-thirds"
             >
-               
-            </label>
-            <input
-              class="govuk-input sor-code-1 govuk-!-width-full"
-              disabled=""
-              id="sor-code-1"
-              name="sor-code-1"
-              type="text"
-              value="DES5R005"
-            />
-          </div>
-          <input
-            id="original-rate-schedule-item-1"
-            name="original-rate-schedule-item-1"
-            type="hidden"
-            value=""
-          />
-        </div>
-        <div
-          class="govuk-grid-column-one-third"
-        >
-          <div
-            class="govuk-form-group"
-            id="quantity-1-form-group"
-          >
-            <label
-              class="govuk-label"
-              for="quantity-1"
+              <div
+                class="govuk-form-group"
+                id="sor-code-0-form-group"
+              >
+                <label
+                  class="govuk-label"
+                  for="sor-code-0"
+                >
+                  SOR code 
+                </label>
+                <input
+                  class="govuk-input sor-code-0 govuk-!-width-full"
+                  disabled=""
+                  id="sor-code-0"
+                  name="sor-code-0"
+                  type="text"
+                  value="DES5R006"
+                />
+              </div>
+              <input
+                id="original-rate-schedule-item-0"
+                name="original-rate-schedule-item-0"
+                type="hidden"
+                value=""
+              />
+            </div>
+            <div
+              class="govuk-grid-column-one-third"
             >
-               
-            </label>
-            <input
-              class="govuk-input quantity-1 govuk-!-width-full"
-              id="quantity-1"
-              name="quantity-1"
-              type="text"
-              value="1"
-            />
+              <div
+                class="govuk-form-group"
+                id="quantity-0-form-group"
+              >
+                <label
+                  class="govuk-label"
+                  for="quantity-0"
+                >
+                  Quantity 
+                </label>
+                <input
+                  class="govuk-input quantity-0 govuk-!-width-full"
+                  id="quantity-0"
+                  name="quantity-0"
+                  type="text"
+                  value="2"
+                />
+              </div>
+            </div>
+          </div>
+          <div>
+            <div
+              class="govuk-grid-column-two-thirds"
+            >
+              <div
+                class="govuk-form-group"
+                id="sor-code-1-form-group"
+              >
+                <label
+                  class="govuk-label"
+                  for="sor-code-1"
+                >
+                   
+                </label>
+                <input
+                  class="govuk-input sor-code-1 govuk-!-width-full"
+                  disabled=""
+                  id="sor-code-1"
+                  name="sor-code-1"
+                  type="text"
+                  value="DES5R005"
+                />
+              </div>
+              <input
+                id="original-rate-schedule-item-1"
+                name="original-rate-schedule-item-1"
+                type="hidden"
+                value=""
+              />
+            </div>
+            <div
+              class="govuk-grid-column-one-third"
+            >
+              <div
+                class="govuk-form-group"
+                id="quantity-1-form-group"
+              >
+                <label
+                  class="govuk-label"
+                  for="quantity-1"
+                >
+                   
+                </label>
+                <input
+                  class="govuk-input quantity-1 govuk-!-width-full"
+                  id="quantity-1"
+                  name="quantity-1"
+                  type="text"
+                  value="1"
+                />
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+        <hr
+          class="govuk-section-break govuk-section-break--l govuk-section-break--visible"
+        />
+      </section>
     </div>
     <div
       class="govuk-!-padding-bottom-5"

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -23,3 +23,7 @@
 .min-height-120 {
   min-height: 120px;
 }
+
+.border-top-black {
+  border-top: 2px solid black;
+}


### PR DESCRIPTION
### Description of change

- Separate original task (raised with work order)  from live (existing tasks) 
- Uses an orignalQuantity field where original = true in the repairs/:id/tasks api response
- Show cost breakdown with variation cost and total cost

### Story Link

https://trello.com/c/IyMOzmCX/403-cost-breakdown-for-sor-code-variation-stage
https://trello.com/c/4sBExgX8/394-as-a-contractor-the-sors-raised-against-the-w-o-are-marked-as-original-so-that-i-can-see-what-the-job-was-raised-for

![Screenshot 2021-03-04 at 10 05 23](https://user-images.githubusercontent.com/34001723/109951575-c599c780-7cd5-11eb-9107-b42126f81af0.png)
![Screenshot 2021-03-04 at 10 05 29](https://user-images.githubusercontent.com/34001723/109951580-c7638b00-7cd5-11eb-8968-2e05d95e4d3d.png)

