### PR TITLE
Contractors must add a reason when varying a work order

### DIFF
--- a/cypress/integration/jobs/update-job.spec.js
+++ b/cypress/integration/jobs/update-job.spec.js
@@ -82,9 +82,18 @@ describe('Contractor update a job', () => {
       cy.get('[type="submit"]').contains('Next').click()
     })
 
-    cy.get('form').within(() => {
+    cy.get(
+      'div[id="rateScheduleItems[0][code]-form-group"] .govuk-error-message'
+    ).within(() => {
       cy.contains('Please enter an SOR code')
+    })
+    cy.get(
+      'div[id="rateScheduleItems[0][quantity]-form-group"] .govuk-error-message'
+    ).within(() => {
       cy.contains('Please enter a quantity')
+    })
+    cy.get('#variationReason-form-group .govuk-error-message').within(() => {
+      cy.contains('Please enter a reason')
     })
 
     cy.get('#repair-request-form').within(() => {
@@ -155,6 +164,7 @@ describe('Contractor update a job', () => {
       cy.get('#quantity-0-form-group').within(() => {
         cy.get('input[id="quantity-0"]').clear().type('0')
       })
+      cy.get('#variationReason').get('.govuk-textarea').type('Needs more work')
       cy.get('[type="submit"]').contains('Next').click()
     })
     cy.get('[type="submit"]').contains('Confirm and close').click()
@@ -163,10 +173,9 @@ describe('Contractor update a job', () => {
       .should('deep.equal', {
         relatedWorkOrderReference: {
           id: '10000040',
-          description: '',
-          allocatedBy: '',
         },
         typeCode: 8,
+        comments: 'Variation reason: Needs more work',
         moreSpecificSORCode: {
           rateScheduleItem: [
             {
@@ -209,6 +218,9 @@ describe('Contractor update a job', () => {
       cy.get('#quantity-0-form-group').within(() => {
         cy.get('input[id="quantity-0"]').clear().type('12')
       })
+
+      // Enter variation reason
+      cy.get('#variationReason').get('.govuk-textarea').type('Needs more work')
 
       cy.get('[type="submit"]').contains('Next').click()
     })
@@ -305,6 +317,10 @@ describe('Contractor update a job', () => {
         })
       })
     })
+    cy.get('.variation-reason-summary').within(() => {
+      cy.contains('Variation reason')
+      cy.contains('Needs more work')
+    })
 
     cy.get('[type="submit"]').contains('Confirm and close').click()
 
@@ -313,10 +329,9 @@ describe('Contractor update a job', () => {
       .should('deep.equal', {
         relatedWorkOrderReference: {
           id: '10000040',
-          description: '',
-          allocatedBy: '',
         },
         typeCode: 8,
+        comments: 'Variation reason: Needs more work',
         moreSpecificSORCode: {
           rateScheduleItem: [
             {

--- a/src/components/WorkOrders/SummaryUpdateJob.js
+++ b/src/components/WorkOrders/SummaryUpdateJob.js
@@ -10,6 +10,7 @@ const SummaryUpdateJob = ({
   tasks,
   addedTasks,
   changeStep,
+  variationReason,
 }) => {
   const { handleSubmit } = useForm({})
 
@@ -30,6 +31,11 @@ const SummaryUpdateJob = ({
           changeStep={changeStep}
         />
 
+        <div className="variation-reason-summary govuk-body-s govuk-!-margin-bottom-7">
+          <p className="govuk-heading-s">Variation reason</p>
+          <p>{variationReason}</p>
+        </div>
+
         <PrimarySubmitButton label="Confirm and close" />
       </form>
     </div>
@@ -39,8 +45,11 @@ const SummaryUpdateJob = ({
 SummaryUpdateJob.propTypes = {
   reference: PropTypes.string.isRequired,
   onJobSubmit: PropTypes.func.isRequired,
+  originalTasks: PropTypes.array.isRequired,
+  tasks: PropTypes.array.isRequired,
   addedTasks: PropTypes.array,
   changeStep: PropTypes.func.isRequired,
+  variationReason: PropTypes.string.isRequired,
 }
 
 export default SummaryUpdateJob

--- a/src/components/WorkOrders/SummaryUpdateJob.test.js
+++ b/src/components/WorkOrders/SummaryUpdateJob.test.js
@@ -41,6 +41,7 @@ describe('SummaryUpdateJob component', () => {
     onJobSubmit: jest.fn(),
     changeStep: jest.fn(),
     calculateTotalCost: jest.fn(),
+    variationReason: 'More work is necessary',
   }
 
   it('should render properly', () => {
@@ -52,6 +53,7 @@ describe('SummaryUpdateJob component', () => {
         tasks={props.tasks}
         addedTasks={props.addedTasks}
         changeStep={props.changeStep}
+        variationReason={props.variationReason}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/WorkOrders/UpdateJob.js
+++ b/src/components/WorkOrders/UpdateJob.js
@@ -16,6 +16,7 @@ const UpdateJob = ({ reference }) => {
   const [tasks, setTasks] = useState([])
   const [originalTasks, setOriginalTasks] = useState([])
   const [propertyReference, setPropertyReference] = useState('')
+  const [variationReason, setVariationReason] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
   const [rateScheduleItems, setRateScheduleItems] = useState([])
@@ -51,7 +52,8 @@ const UpdateJob = ({ reference }) => {
     const updateJobFormData = buildUpdateJob(
       tasks,
       rateScheduleItems,
-      reference
+      reference,
+      variationReason
     )
     makePostRequest(updateJobFormData)
   }
@@ -121,6 +123,8 @@ const UpdateJob = ({ reference }) => {
                     }
                     addedTasks={rateScheduleItems}
                     onGetToSummary={onGetToSummary}
+                    setVariationReason={setVariationReason}
+                    variationReason={variationReason}
                   />
                 </>
               )}
@@ -132,6 +136,7 @@ const UpdateJob = ({ reference }) => {
                   reference={reference}
                   onJobSubmit={onJobUpdateSubmit}
                   changeStep={changeCurrentPage}
+                  variationReason={variationReason}
                 />
               )}
             </>

--- a/src/components/WorkOrders/UpdateJobForm.js
+++ b/src/components/WorkOrders/UpdateJobForm.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { PrimarySubmitButton } from '../Form'
+import { PrimarySubmitButton, CharacterCountLimitedTextArea } from '../Form'
 import { useForm } from 'react-hook-form'
 import OriginalRateScheduleItems from './RateScheduleItems/OriginalRateScheduleItems'
 import ExistingRateScheduleItems from './RateScheduleItems/ExistingRateScheduleItems'
@@ -10,6 +10,8 @@ const UpdateJobForm = ({
   propertyReference,
   onGetToSummary,
   addedTasks,
+  setVariationReason,
+  variationReason,
 }) => {
   const { register, handleSubmit, errors } = useForm()
   const isContractorUpdatePage = true
@@ -35,6 +37,18 @@ const UpdateJobForm = ({
           isContractorUpdatePage={isContractorUpdatePage}
           propertyReference={propertyReference}
         />
+        <CharacterCountLimitedTextArea
+          name="variationReason"
+          maxLength={250}
+          value={variationReason}
+          requiredText="Please enter a reason"
+          label="Variation reason"
+          placeholder="Write a reason for the variation..."
+          required={true}
+          register={register}
+          onChange={(event) => setVariationReason(event.target.value)}
+          error={errors && errors.variationReason}
+        />
         <PrimarySubmitButton label="Next" />
       </form>
     </>
@@ -46,6 +60,8 @@ UpdateJobForm.propTypes = {
   propertyReference: PropTypes.string.isRequired,
   onGetToSummary: PropTypes.func.isRequired,
   addedTasks: PropTypes.array.isRequired,
+  setVariationReason: PropTypes.func.isRequired,
+  variationReason: PropTypes.string.isRequired,
 }
 
 export default UpdateJobForm

--- a/src/components/WorkOrders/UpdateJobForm.test.js
+++ b/src/components/WorkOrders/UpdateJobForm.test.js
@@ -21,6 +21,8 @@ describe('UpdateJobForm component', () => {
       },
     ],
     onGetToSummary: jest.fn(),
+    setVariationReason: jest.fn(),
+    variationReason: 'More work is necessary',
   }
 
   it('should render properly', () => {
@@ -30,6 +32,8 @@ describe('UpdateJobForm component', () => {
         tasks={props.tasks}
         addedTasks={props.addedTasks}
         onGetToSummary={props.onGetToSummary}
+        setVariationReason={props.setVariationReason}
+        variationReason={props.variationReason}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/WorkOrders/__snapshots__/SummaryUpdateJob.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/SummaryUpdateJob.test.js.snap
@@ -278,6 +278,18 @@ exports[`SummaryUpdateJob component should render properly 1`] = `
         </tbody>
       </table>
       <div
+        class="variation-reason-summary govuk-body-s govuk-!-margin-bottom-7"
+      >
+        <p
+          class="govuk-heading-s"
+        >
+          Variation reason
+        </p>
+        <p>
+          More work is necessary
+        </p>
+      </div>
+      <div
         class="govuk-form-group"
       >
         <button

--- a/src/components/WorkOrders/__snapshots__/UpdateJobForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/UpdateJobForm.test.js.snap
@@ -244,6 +244,37 @@ exports[`UpdateJobForm component should render properly 1`] = `
     </div>
     <div
       class="govuk-form-group"
+      id="variationReason-form-group"
+    >
+      <label
+        class="govuk-label"
+        for="variationReason"
+      >
+        Variation reason 
+        <span
+          class="govuk-required"
+        >
+          *
+        </span>
+      </label>
+      <textarea
+        aria-describedby="variationReason-hint variationReason-error"
+        class="govuk-textarea"
+        id="variationReason"
+        name="variationReason"
+        placeholder="Write a reason for the variation..."
+        rows="4"
+      >
+        More work is necessary
+      </textarea>
+    </div>
+    <span
+      class="govuk-hint govuk-!-margin-bottom-6"
+    >
+      You have 250 characters remaining.
+    </span>
+    <div
+      class="govuk-form-group"
     >
       <button
         class="govuk-button"

--- a/src/utils/hact/job-status-update/update-job.js
+++ b/src/utils/hact/job-status-update/update-job.js
@@ -1,4 +1,9 @@
-export const buildUpdateJob = (existingTasks, addedTasks, reference) => {
+export const buildUpdateJob = (
+  existingTasks,
+  addedTasks,
+  reference,
+  variationReason
+) => {
   const buildRateScheduleItems = (tasks, existing = false) => {
     return tasks.map((task) => {
       return {
@@ -21,9 +26,8 @@ export const buildUpdateJob = (existingTasks, addedTasks, reference) => {
   return {
     relatedWorkOrderReference: {
       id: reference,
-      description: '',
-      allocatedBy: '',
     },
+    comments: `Variation reason: ${variationReason}`,
     typeCode: 8,
     moreSpecificSORCode: {
       rateScheduleItem: rateScheduleItems,

--- a/src/utils/hact/job-status-update/update-job.test.js
+++ b/src/utils/hact/job-status-update/update-job.test.js
@@ -19,15 +19,15 @@ describe('buildUpdateJob', () => {
     },
   ]
   const reference = '00012345'
+  const variationReason = 'More work is required'
 
   it('builds the UpdateJob form data to post to the Repairs API', async () => {
     const updateJobFormData = {
       relatedWorkOrderReference: {
         id: '00012345',
-        description: '',
-        allocatedBy: '',
       },
       typeCode: 8,
+      comments: 'Variation reason: More work is required',
       moreSpecificSORCode: {
         rateScheduleItem: [
           {
@@ -49,7 +49,12 @@ describe('buildUpdateJob', () => {
       },
     }
 
-    const response = buildUpdateJob(existingTasks, addedTasks, reference)
+    const response = buildUpdateJob(
+      existingTasks,
+      addedTasks,
+      reference,
+      variationReason
+    )
     expect(response).toEqual(updateJobFormData)
   })
 })


### PR DESCRIPTION
### Description of change

- Adds text area to variation screen which is mandatory
- This reflects in the summary page
- This appears within the notes tab prepended by 'Variation reason: ...'

### Story Link

https://trello.com/c/HAqGwTEN/25-as-a-contractor-i-can-add-notes-when-varying-a-works-order-to-justify-the-additional-spend

![Screenshot 2021-03-08 at 14 44 51](https://user-images.githubusercontent.com/34001723/110340349-10db0f80-8021-11eb-9f5e-c73f59a243ce.png)
![Screenshot 2021-03-08 at 14 45 04](https://user-images.githubusercontent.com/34001723/110340359-12a4d300-8021-11eb-9ccc-2bef6b538a36.png)
![Screenshot 2021-03-08 at 14 45 26](https://user-images.githubusercontent.com/34001723/110340364-133d6980-8021-11eb-89b6-9d15dd7bdfea.png)

