### PR TITLE
Show original tasks separately within tasks and sors tab

### DIFF
--- a/cypress/fixtures/repairs/tasks-and-sors.json
+++ b/cypress/fixtures/repairs/tasks-and-sors.json
@@ -8,7 +8,7 @@
     "cost": 10,
     "status": "Unknown",
     "original": true,
-    "originalQuantity": 2
+    "originalQuantity": 1
   },
   {
     "id": "bde7c53b-8947-414c-b88f-9c5e3d875cbg",

--- a/cypress/integration/jobs/update-job.spec.js
+++ b/cypress/integration/jobs/update-job.spec.js
@@ -279,7 +279,7 @@ describe('Contractor update a job', () => {
       cy.get('.govuk-table__body').within(() => {
         cy.get('tr[id="original-task-0"]').within(() => {
           cy.contains('DES5R006 - Urgent call outs')
-          cy.contains('2')
+          cy.contains('1')
           cy.contains('0')
         })
       })
@@ -305,11 +305,11 @@ describe('Contractor update a job', () => {
         })
         cy.get('#original-cost').within(() => {
           cy.contains('Original cost')
-          cy.contains('20.00')
+          cy.contains('10.00')
         })
         cy.get('#variation-cost').within(() => {
           cy.contains('Variation cost')
-          cy.contains('750.45')
+          cy.contains('760.45')
         })
         cy.get('#total-cost').within(() => {
           cy.contains('Total cost')

--- a/cypress/integration/tasks-and-sors/tasks-and-sors.spec.js
+++ b/cypress/integration/tasks-and-sors/tasks-and-sors.spec.js
@@ -29,7 +29,8 @@ describe('Tasks and SORs', () => {
     cy.get('#tasks-and-sors-tab').within(() => {
       cy.get('.govuk-heading-l').contains('Tasks and SORs')
 
-      cy.get('.govuk-table').within(() => {
+      cy.contains('Latest Tasks and SORs')
+      cy.get('.govuk-table.latest-tasks-and-sors-table').within(() => {
         // Tasks and SORS table headers
         cy.contains('th', 'SOR')
         cy.contains('th', 'Description')
@@ -43,7 +44,7 @@ describe('Tasks and SORs', () => {
           cy.contains('DES5R013')
           cy.contains('Inspect additional sec entrance')
           cy.contains('3 Feb 2021, 11:33 am')
-          cy.contains('2')
+          cy.contains('5')
           cy.contains('0')
           cy.contains('Unknown')
         })
@@ -59,7 +60,28 @@ describe('Tasks and SORs', () => {
           cy.contains('DES5R006')
           cy.contains('Urgent call outs')
           cy.contains('3 Feb 2021, 9:33 am')
-          cy.contains('5')
+          cy.contains('2')
+          cy.contains('0')
+          cy.contains('Unknown')
+        })
+      })
+
+      cy.contains('Original Tasks and SORs')
+      cy.get('.govuk-table.original-tasks-and-sors-table').within(() => {
+        // Tasks and SORS table headers
+        cy.contains('th', 'SOR')
+        cy.contains('th', 'Description')
+        cy.contains('th', 'Date added')
+        cy.contains('th', 'Quantity (est.)')
+        cy.contains('th', 'Cost')
+        cy.contains('th', 'Status')
+
+        // Tasks and SORS table rows
+        cy.get('[data-row-id="0"]').within(() => {
+          cy.contains('DES5R006')
+          cy.contains('Urgent call outs')
+          cy.contains('3 Feb 2021, 9:33 am')
+          cy.contains('1')
           cy.contains('0')
           cy.contains('Unknown')
         })

--- a/src/components/Layout/Table/index.js
+++ b/src/components/Layout/Table/index.js
@@ -17,7 +17,12 @@ export const TBody = (props) => (
 )
 
 export const TR = (props) => (
-  <tr className={cx('govuk-table__row', props.className)}>{props.children}</tr>
+  <tr
+    data-row-id={props.index}
+    className={cx('govuk-table__row', props.className)}
+  >
+    {props.children}
+  </tr>
 )
 
 export const TH = (props) => (

--- a/src/components/WorkOrder/TasksAndSors/TasksAndSorsRow.js
+++ b/src/components/WorkOrder/TasksAndSors/TasksAndSorsRow.js
@@ -1,35 +1,31 @@
 import PropTypes from 'prop-types'
 import { formatDateTime } from '../../../utils/time'
+import { TR, TD } from '../../Layout/Table'
 
 const tasksAndSorsRow = ({
   code,
   description,
   dateAdded,
-  quantity,
+  taskQuantity,
   cost,
   status,
   index,
 }) => (
-  <tr
-    data-row-id={index}
-    className="govuk-table__row govuk-table__row--clickable govuk-body-s"
-  >
-    <td className="govuk-table__cell">{code}</td>
-    <td className="govuk-table__cell">{description}</td>
-    <td className="govuk-table__cell">
-      {dateAdded ? formatDateTime(dateAdded) : '—'}
-    </td>
-    <td className="govuk-table__cell">{quantity}</td>
-    <td className="govuk-table__cell">{cost}</td>
-    <td className="govuk-table__cell">{status}</td>
-  </tr>
+  <TR index={index} className="govuk-body-s">
+    <TD>{code}</TD>
+    <TD>{description}</TD>
+    <TD>{dateAdded ? formatDateTime(dateAdded) : '—'}</TD>
+    <TD>{taskQuantity}</TD>
+    <TD>£{cost}</TD>
+    <TD>{status}</TD>
+  </TR>
 )
 
 tasksAndSorsRow.propTypes = {
   code: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   dateAdded: PropTypes.instanceOf(Date).isRequired,
-  quantity: PropTypes.number.isRequired,
+  taskQuantity: PropTypes.number.isRequired,
   cost: PropTypes.number.isRequired,
   status: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,

--- a/src/components/WorkOrder/TasksAndSors/TasksAndSorsTable.js
+++ b/src/components/WorkOrder/TasksAndSors/TasksAndSorsTable.js
@@ -1,49 +1,67 @@
 import PropTypes from 'prop-types'
 import TasksAndSorsRow from './TasksAndSorsRow'
+import { Table, THead, TBody, TR, TH } from '../../Layout/Table'
 
-const TasksAndSorsTable = ({ tasksAndSors, tabName }) => (
-  <>
-    <h2 className="govuk-heading-l">{tabName}</h2>
+const TasksAndSorsTable = ({
+  latestTasksAndSors,
+  originalTasksAndSors,
+  tabName,
+}) => {
+  const buildTable = (tasks, isOriginal = false) => {
+    return (
+      <>
+        <THead>
+          <TR className="govuk-body">
+            <TH scope="col">SOR</TH>
+            <TH scope="col">Description</TH>
+            <TH scope="col">Date added</TH>
+            <TH scope="col">Quantity (est.)</TH>
+            <TH scope="col">Cost (est.)</TH>
+            <TH scope="col">Status</TH>
+          </TR>
+        </THead>
+        <TBody>
+          {tasks.map((entry, index) => (
+            <TasksAndSorsRow
+              key={index}
+              index={index}
+              taskQuantity={
+                isOriginal ? entry.originalQuantity : entry.quantity
+              }
+              {...entry}
+            />
+          ))}
+        </TBody>
+      </>
+    )
+  }
 
-    <table className="govuk-table govuk-!-margin-top-5 tasks-and-sors-table">
-      <thead className="govuk-table__head">
-        <tr className="govuk-table__row govuk-body">
-          <th scope="col" className="govuk-table__header">
-            SOR
-          </th>
-          <th scope="col" className="govuk-table__header">
-            Description
-          </th>
-          <th scope="col" className="govuk-table__header">
-            Date added
-          </th>
-          <th scope="col" className="govuk-table__header">
-            Quantity (est.)
-          </th>
-          <th scope="col" className="govuk-table__header">
-            Cost (est.)
-          </th>
-          <th scope="col" className="govuk-table__header">
-            Status
-          </th>
-        </tr>
-      </thead>
-      <tbody className="govuk-table__body">
-        {tasksAndSors.map((entry, index) => (
-          <TasksAndSorsRow key={index} index={index} {...entry} />
-        ))}
-      </tbody>
-    </table>
-  </>
-)
+  return (
+    <>
+      <h2 className="govuk-heading-l">{tabName}</h2>
+
+      <p className="govuk-heading-s">Latest Tasks and SORs</p>
+      <Table className="govuk-!-margin-top-5 latest-tasks-and-sors-table">
+        {buildTable(latestTasksAndSors)}
+      </Table>
+
+      <p className="govuk-heading-s">Original Tasks and SORs</p>
+      <Table className="govuk-!-margin-top-5 original-tasks-and-sors-table">
+        {buildTable(originalTasksAndSors, true)}
+      </Table>
+    </>
+  )
+}
 
 TasksAndSorsTable.propTypes = {
   tabName: PropTypes.string.isRequired,
-  tasksAndSors: PropTypes.arrayOf(
+  originalTasksAndSors: PropTypes.array.isRequired,
+  latestTasksAndSors: PropTypes.arrayOf(
     PropTypes.shape({
       code: PropTypes.string,
       description: PropTypes.string,
       dateAdded: PropTypes.instanceOf(Date),
+      original: PropTypes.bool,
       quantity: PropTypes.number,
       cost: PropTypes.number,
       status: PropTypes.string,

--- a/src/components/WorkOrder/TasksAndSors/TasksAndSorsTable.test.js
+++ b/src/components/WorkOrder/TasksAndSors/TasksAndSorsTable.test.js
@@ -4,11 +4,25 @@ import TasksAndSorsTable from './TasksAndSorsTable'
 describe('TasksAndSorsTable component', () => {
   const props = {
     tabName: 'Tasks and SORs',
-    tasksAndSors: [
+    originalTasksAndSors: [
       {
         code: 'DES5R006',
         description: 'Urgent call outs',
         dateAdded: new Date('2021-02-03T11:33:35.757339'),
+        original: true,
+        originalQuantity: 1,
+        quantity: 2,
+        cost: 0,
+        status: 'Unknown',
+      },
+    ],
+    latestTasksAndSors: [
+      {
+        code: 'DES5R006',
+        description: 'Urgent call outs',
+        dateAdded: new Date('2021-02-03T11:33:35.757339'),
+        original: true,
+        originalQuantity: 1,
         quantity: 2,
         cost: 0,
         status: 'Unknown',
@@ -17,6 +31,8 @@ describe('TasksAndSorsTable component', () => {
         code: 'DES5R005',
         description: 'Normal call outs',
         dateAdded: new Date('2021-02-03T11:33:35.814437'),
+        original: false,
+        originalQuantity: null,
         quantity: 4,
         cost: 0,
         status: 'Unknown',
@@ -25,6 +41,8 @@ describe('TasksAndSorsTable component', () => {
         code: 'DES5R013',
         description: 'Inspect additional sec entrance',
         dateAdded: new Date('2021-02-03T11:33:35.799566'),
+        original: false,
+        originalQuantity: null,
         quantity: 5,
         cost: 0,
         status: 'Unknown',
@@ -35,7 +53,8 @@ describe('TasksAndSorsTable component', () => {
   it('should render properly', () => {
     const { asFragment } = render(
       <TasksAndSorsTable
-        tasksAndSors={props.tasksAndSors}
+        originalTasksAndSors={props.originalTasksAndSors}
+        latestTasksAndSors={props.latestTasksAndSors}
         tabName={props.tabName}
       />
     )

--- a/src/components/WorkOrder/TasksAndSors/TasksAndSorsView.js
+++ b/src/components/WorkOrder/TasksAndSors/TasksAndSorsView.js
@@ -11,6 +11,8 @@ const TasksAndSorsView = ({ workOrderReference, tabName }) => {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
 
+  const originalTasksAndSors = tasksAndSors.filter((t) => t.original)
+
   const getTasksAndSorsView = async (workOrderReference) => {
     setError(null)
 
@@ -44,7 +46,17 @@ const TasksAndSorsView = ({ workOrderReference, tabName }) => {
       ) : (
         <>
           {tasksAndSors && (
-            <TasksAndSorsTable tasksAndSors={tasksAndSors} tabName={tabName} />
+            <TasksAndSorsTable
+              /**
+                Latest refers to the latest (live) tasks and sors against the work order,
+                which will include any variations for different codes and quantities
+                whereas original refers to the tasks and sors that originated from
+                the raise repair form, along with its original quantity
+              **/
+              latestTasksAndSors={tasksAndSors}
+              originalTasksAndSors={originalTasksAndSors}
+              tabName={tabName}
+            />
           )}
           {error && <ErrorMessage label={error} />}
         </>

--- a/src/components/WorkOrder/TasksAndSors/__snapshots__/TasksAndSorsTable.test.js.snap
+++ b/src/components/WorkOrder/TasksAndSors/__snapshots__/TasksAndSorsTable.test.js.snap
@@ -7,8 +7,13 @@ exports[`TasksAndSorsTable component should render properly 1`] = `
   >
     Tasks and SORs
   </h2>
+  <p
+    class="govuk-heading-s"
+  >
+    Latest Tasks and SORs
+  </p>
   <table
-    class="govuk-table govuk-!-margin-top-5 tasks-and-sors-table"
+    class="govuk-table govuk-!-margin-top-5 latest-tasks-and-sors-table"
   >
     <thead
       class="govuk-table__head"
@@ -58,7 +63,7 @@ exports[`TasksAndSorsTable component should render properly 1`] = `
       class="govuk-table__body"
     >
       <tr
-        class="govuk-table__row govuk-table__row--clickable govuk-body-s"
+        class="govuk-table__row govuk-body-s"
         data-row-id="0"
       >
         <td
@@ -84,7 +89,7 @@ exports[`TasksAndSorsTable component should render properly 1`] = `
         <td
           class="govuk-table__cell"
         >
-          0
+          £0
         </td>
         <td
           class="govuk-table__cell"
@@ -93,7 +98,7 @@ exports[`TasksAndSorsTable component should render properly 1`] = `
         </td>
       </tr>
       <tr
-        class="govuk-table__row govuk-table__row--clickable govuk-body-s"
+        class="govuk-table__row govuk-body-s"
         data-row-id="1"
       >
         <td
@@ -119,7 +124,7 @@ exports[`TasksAndSorsTable component should render properly 1`] = `
         <td
           class="govuk-table__cell"
         >
-          0
+          £0
         </td>
         <td
           class="govuk-table__cell"
@@ -128,7 +133,7 @@ exports[`TasksAndSorsTable component should render properly 1`] = `
         </td>
       </tr>
       <tr
-        class="govuk-table__row govuk-table__row--clickable govuk-body-s"
+        class="govuk-table__row govuk-body-s"
         data-row-id="2"
       >
         <td
@@ -154,7 +159,99 @@ exports[`TasksAndSorsTable component should render properly 1`] = `
         <td
           class="govuk-table__cell"
         >
-          0
+          £0
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          Unknown
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <p
+    class="govuk-heading-s"
+  >
+    Original Tasks and SORs
+  </p>
+  <table
+    class="govuk-table govuk-!-margin-top-5 original-tasks-and-sors-table"
+  >
+    <thead
+      class="govuk-table__head"
+    >
+      <tr
+        class="govuk-table__row govuk-body"
+      >
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          SOR
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Description
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Date added
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Quantity (est.)
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Cost (est.)
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Status
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="govuk-table__body"
+    >
+      <tr
+        class="govuk-table__row govuk-body-s"
+        data-row-id="0"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          DES5R006
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          Urgent call outs
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          3 Feb 2021, 11:33 am
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          1
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          £0
         </td>
         <td
           class="govuk-table__cell"


### PR DESCRIPTION
### Description of change

Show original and varied tasks separately within the tasks and sors tab on a work order
![Screenshot 2021-03-10 at 16 57 27](https://user-images.githubusercontent.com/34001723/110668771-926aa300-81c3-11eb-818a-bdc1cb7a4516.png)


### Story Link

https://trello.com/c/CXGGjfao/22-as-a-contract-manager-i-can-see-a-breakdown-of-original-and-varied-sor-codes-and-quantities-so-i-know-what-im-approving

