### PR TITLE
Permit frontend to accept new contractors without code changes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,9 +8,9 @@ REPAIRS_SERVICE_API_KEY=repairsApiKey
 GSSO_URL=https://auth.hackney.gov.uk/auth?redirect_uri=
 GSSO_TOKEN_NAME=hackneyToken
 HACKNEY_JWT_SECRET=sekret
+
 AGENTS_GOOGLE_GROUPNAME=repairs-hub-frontend-staging
-CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME=repairs-hub-frontend-staging-contractors-alphatrack
-CONTRACTORS_PURDY_GOOGLE_GROUPNAME=repairs-hub-frontend-staging-contractors-purdy
+CONTRACTORS_GOOGLE_GROUPNAME_PREFIX=repairs-hub-frontend-staging-contractors
 
 #Redirect URL to run code locally
 REDIRECT_URL=localhost:5000

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,8 +40,7 @@ functions:
       GSSO_TOKEN_NAME: ${ssm:/repairs-hub/${self:provider.stage}/gsso-token-name}
       HACKNEY_JWT_SECRET: ${ssm:/repairs-hub/${self:provider.stage}/hackney-jwt-secret}
       AGENTS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/agents-group}
-      CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/contractors-alphatrack-group}
-      CONTRACTORS_PURDY_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/contractors-purdy-group}
+      CONTRACTORS_GOOGLE_GROUPNAME_PREFIX: ${ssm:/repairs-hub/${self:provider.stage}/contractors-group-prefix}
       REDIRECT_URL: ${ssm:/repairs-hub/${self:provider.stage}/redirect-url}
 
 resources:

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -10,7 +10,7 @@ const {
   REPAIRS_SERVICE_API_URL,
   HACKNEY_JWT_SECRET,
   GSSO_TOKEN_NAME,
-  CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
+  CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
   AGENTS_GOOGLE_GROUPNAME,
   REPAIRS_SERVICE_API_KEY,
 } = process.env
@@ -106,7 +106,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME],
+        groups: [`${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack`],
       },
       HACKNEY_JWT_SECRET
     )

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -1,25 +1,36 @@
 export const AGENT_ROLE = 'agent'
 export const CONTRACTOR_ROLE = 'contractor'
 
-const {
-  CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
-  CONTRACTORS_PURDY_GOOGLE_GROUPNAME,
-} = process.env
-
 export const buildUser = (name, email, authServiceGroups) => {
-  const { AGENTS_GOOGLE_GROUPNAME } = process.env
+  const {
+    CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
+    AGENTS_GOOGLE_GROUPNAME,
+  } = process.env
 
-  const groupNameRoleMap = {
-    [AGENTS_GOOGLE_GROUPNAME]: AGENT_ROLE,
-    [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME]: CONTRACTOR_ROLE,
-    [CONTRACTORS_PURDY_GOOGLE_GROUPNAME]: CONTRACTOR_ROLE,
-  }
-
-  const groupName = authServiceGroups.find((groupName) =>
-    Object.keys(groupNameRoleMap).includes(groupName)
+  const contractorGroupRegex = new RegExp(
+    `^${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}`
   )
 
-  const role = groupNameRoleMap[groupName]
+  const roleFromGroup = (groupName) => {
+    if (groupName === AGENTS_GOOGLE_GROUPNAME) {
+      return AGENT_ROLE
+    } else if (hasContractorGroupPrefix(groupName)) {
+      return CONTRACTOR_ROLE
+    }
+
+    console.log(`User group name not recognised: ${groupName}`)
+  }
+
+  const hasContractorGroupPrefix = (groupName) =>
+    !!contractorGroupRegex.test(groupName)
+
+  const groupName = authServiceGroups.find(
+    (groupName) =>
+      groupName === AGENTS_GOOGLE_GROUPNAME ||
+      hasContractorGroupPrefix(groupName)
+  )
+
+  const role = roleFromGroup(groupName)
 
   const hasRole = (r) => r === role
 

--- a/src/utils/user.test.js
+++ b/src/utils/user.test.js
@@ -2,7 +2,7 @@ import { buildUser, AGENT_ROLE, CONTRACTOR_ROLE } from './user'
 
 const {
   AGENTS_GOOGLE_GROUPNAME,
-  CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
+  CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
 } = process.env
 
 describe('buildUser', () => {
@@ -23,7 +23,9 @@ describe('buildUser', () => {
   })
 
   describe('when called with a single contractor group name', () => {
-    const user = buildUser('', '', [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME])
+    const user = buildUser('', '', [
+      `${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack`,
+    ])
 
     describe('hasContractorPermissions', () => {
       it('returns true', () => {


### PR DESCRIPTION
We've started to go down the route of adding individual environment
variables per contractor, but in fact the frontend shouldn't need to
know which particular contractor the user belongs to for its
current functionality.

This commit replaces our specific checks for contractor groups with
a partial match on the group name prefix. It relies on a consistent
group naming scheme and a new environment variable to hold that prefix.

The intention is to remove the need to manage lots of environment
variables as contractors are added and removed.

The backend is relied upon to perform specific group checks instead.

#### Before Merge

 - [x] Add new prefix var to the staging environment
 - [x] Add new prefix var to the production environment
 - [x] Tell dev team about changes to env
