### PR TITLE
Rename agents google groups environment variable name

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,7 +8,7 @@ REPAIRS_SERVICE_API_KEY=repairsApiKey
 GSSO_URL=https://auth.hackney.gov.uk/auth?redirect_uri=
 GSSO_TOKEN_NAME=hackneyToken
 HACKNEY_JWT_SECRET=sekret
-REPAIRS_AGENTS_GOOGLE_GROUPNAME=repairs-hub-frontend-staging
+AGENTS_GOOGLE_GROUPNAME=repairs-hub-frontend-staging
 CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME=repairs-hub-frontend-staging-contractors-alphatrack
 CONTRACTORS_PURDY_GOOGLE_GROUPNAME=repairs-hub-frontend-staging-contractors-purdy
 

--- a/__test__/_app.test.js
+++ b/__test__/_app.test.js
@@ -6,7 +6,7 @@ import jsonwebtoken from 'jsonwebtoken'
 import * as HttpStatus from 'http-status-codes'
 
 const {
-  REPAIRS_AGENTS_GOOGLE_GROUPNAME,
+  AGENTS_GOOGLE_GROUPNAME,
   HACKNEY_JWT_SECRET,
   GSSO_TOKEN_NAME,
 } = process.env
@@ -17,7 +17,7 @@ describe('MyApp.getInitialProps', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [REPAIRS_AGENTS_GOOGLE_GROUPNAME],
+        groups: [AGENTS_GOOGLE_GROUPNAME],
       },
       HACKNEY_JWT_SECRET
     )

--- a/serverless.yml
+++ b/serverless.yml
@@ -39,7 +39,7 @@ functions:
       GSSO_URL: ${ssm:/repairs-hub/${self:provider.stage}/gsso-url}
       GSSO_TOKEN_NAME: ${ssm:/repairs-hub/${self:provider.stage}/gsso-token-name}
       HACKNEY_JWT_SECRET: ${ssm:/repairs-hub/${self:provider.stage}/hackney-jwt-secret}
-      REPAIRS_AGENTS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/agents-group}
+      AGENTS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/agents-group}
       CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/contractors-alphatrack-group}
       CONTRACTORS_PURDY_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/contractors-purdy-group}
       REDIRECT_URL: ${ssm:/repairs-hub/${self:provider.stage}/redirect-url}

--- a/src/pages/api/[...path].test.js
+++ b/src/pages/api/[...path].test.js
@@ -11,7 +11,7 @@ const {
   REPAIRS_SERVICE_API_URL,
   REPAIRS_SERVICE_API_KEY,
   HACKNEY_JWT_SECRET,
-  REPAIRS_AGENTS_GOOGLE_GROUPNAME,
+  AGENTS_GOOGLE_GROUPNAME,
   GSSO_TOKEN_NAME,
 } = process.env
 
@@ -33,7 +33,7 @@ describe('/api/[...path]', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [REPAIRS_AGENTS_GOOGLE_GROUPNAME],
+        groups: [AGENTS_GOOGLE_GROUPNAME],
       },
       HACKNEY_JWT_SECRET + 'messedWithSecret'
     )
@@ -58,7 +58,7 @@ describe('/api/[...path]', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [REPAIRS_AGENTS_GOOGLE_GROUPNAME],
+        groups: [AGENTS_GOOGLE_GROUPNAME],
       },
       HACKNEY_JWT_SECRET
     )

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -11,7 +11,7 @@ const {
   HACKNEY_JWT_SECRET,
   GSSO_TOKEN_NAME,
   CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
-  REPAIRS_AGENTS_GOOGLE_GROUPNAME,
+  AGENTS_GOOGLE_GROUPNAME,
   REPAIRS_SERVICE_API_KEY,
 } = process.env
 
@@ -50,7 +50,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [REPAIRS_AGENTS_GOOGLE_GROUPNAME],
+        groups: [AGENTS_GOOGLE_GROUPNAME],
       },
       HACKNEY_JWT_SECRET
     )

--- a/src/utils/GoogleAuth.test.js
+++ b/src/utils/GoogleAuth.test.js
@@ -3,7 +3,7 @@ import jsonwebtoken from 'jsonwebtoken'
 import { createRequest, createResponse } from 'node-mocks-http'
 
 const {
-  REPAIRS_AGENTS_GOOGLE_GROUPNAME,
+  AGENTS_GOOGLE_GROUPNAME,
   HACKNEY_JWT_SECRET,
   GSSO_TOKEN_NAME,
 } = process.env
@@ -14,7 +14,7 @@ describe('isAuthorised', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [REPAIRS_AGENTS_GOOGLE_GROUPNAME],
+        groups: [AGENTS_GOOGLE_GROUPNAME],
       },
       HACKNEY_JWT_SECRET
     )

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -7,10 +7,10 @@ const {
 } = process.env
 
 export const buildUser = (name, email, authServiceGroups) => {
-  const { REPAIRS_AGENTS_GOOGLE_GROUPNAME } = process.env
+  const { AGENTS_GOOGLE_GROUPNAME } = process.env
 
   const groupNameRoleMap = {
-    [REPAIRS_AGENTS_GOOGLE_GROUPNAME]: AGENT_ROLE,
+    [AGENTS_GOOGLE_GROUPNAME]: AGENT_ROLE,
     [CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME]: CONTRACTOR_ROLE,
     [CONTRACTORS_PURDY_GOOGLE_GROUPNAME]: CONTRACTOR_ROLE,
   }

--- a/src/utils/user.test.js
+++ b/src/utils/user.test.js
@@ -1,13 +1,13 @@
 import { buildUser, AGENT_ROLE, CONTRACTOR_ROLE } from './user'
 
 const {
-  REPAIRS_AGENTS_GOOGLE_GROUPNAME,
+  AGENTS_GOOGLE_GROUPNAME,
   CONTRACTORS_ALPHATRACK_GOOGLE_GROUPNAME,
 } = process.env
 
 describe('buildUser', () => {
   describe('when called with a single agent group name', () => {
-    const user = buildUser('', '', [REPAIRS_AGENTS_GOOGLE_GROUPNAME])
+    const user = buildUser('', '', [AGENTS_GOOGLE_GROUPNAME])
 
     describe('hasContractorPermissions', () => {
       it('returns false', () => {
@@ -39,7 +39,7 @@ describe('buildUser', () => {
   })
 
   describe('hasRole', () => {
-    const user = buildUser('', '', [REPAIRS_AGENTS_GOOGLE_GROUPNAME])
+    const user = buildUser('', '', [AGENTS_GOOGLE_GROUPNAME])
 
     describe('when the supplied role maps to the group name for the user', () => {
       it('returns true', () => {
@@ -56,7 +56,7 @@ describe('buildUser', () => {
 
   describe('hasAnyPermissions', () => {
     describe('when the group name for the user maps to a recognised role', () => {
-      const user = buildUser('', '', [REPAIRS_AGENTS_GOOGLE_GROUPNAME])
+      const user = buildUser('', '', [AGENTS_GOOGLE_GROUPNAME])
 
       it('returns true', () => {
         expect(user.hasAnyPermissions).toBe(true)


### PR DESCRIPTION
### Description of change

Rename agents google groups environment variable name

Since the application is evolving and we added more google groups,
it makes sense to have a more specific environment key name for the
google group that is used by the agents.

#### Before Merge

 - [x] Add environment variable to circle ci environment
 - [ ] Tell dev team about changes to env
