### PR TITLE
Allow partial match when deciding slot choice text

### DIFF
--- a/cypress/fixtures/appointment/availability.json
+++ b/cypress/fixtures/appointment/availability.json
@@ -83,13 +83,13 @@
     "slots": [
       {
         "reference": "31/2021-03-18",
-        "description": "AM Slot",
+        "description": "AM",
         "start": "2000-01-01T08:00:00",
         "end": "2000-01-01T13:00:00"
       },
       {
         "reference": "41/2021-03-18",
-        "description": "PM Slot",
+        "description": "PM",
         "start": "2000-01-01T12:00:00",
         "end": "2000-01-01T18:00:00"
       }
@@ -100,13 +100,13 @@
     "slots": [
       {
         "reference": "32/2021-03-19",
-        "description": "AM Slot",
+        "description": "AM",
         "start": "2000-01-01T08:00:00",
         "end": "2000-01-01T13:00:00"
       },
       {
         "reference": "42/2021-03-19",
-        "description": "PM Slot",
+        "description": "PM",
         "start": "2000-01-01T12:00:00",
         "end": "2000-01-01T18:00:00"
       }

--- a/src/components/WorkOrder/Appointment/TimeSlotForm.js
+++ b/src/components/WorkOrder/Appointment/TimeSlotForm.js
@@ -28,10 +28,9 @@ const TimeSlotForm = ({
             label=""
             name="options"
             options={availableSlots['slots'].map((slot) => {
-              let text =
-                slot['description'] == 'AM Slot'
-                  ? 'AM 8:00 -12:00'
-                  : 'PM 12:00-4:00'
+              let text = slot['description'].match('AM')
+                ? 'AM 8:00 -12:00'
+                : 'PM 12:00-4:00'
               return {
                 text: text,
                 value: text,

--- a/src/utils/appointments.test.js
+++ b/src/utils/appointments.test.js
@@ -8,17 +8,17 @@ describe('getAvailableSlots', () => {
     const availableSlots = [
       {
         date: '2021-02-16T00:00:00',
-        slots: [{ description: 'AM Slot' }, { description: 'PM Slot' }],
+        slots: [{ description: 'AM' }, { description: 'PM' }],
       },
       {
         date: '2021-02-26T00:00:00',
-        slots: [{ description: 'AM Slot' }, { description: 'PM Slot' }],
+        slots: [{ description: 'AM' }, { description: 'PM' }],
       },
     ]
 
     expect(getAvailableSlots(date, availableSlots)).toEqual({
       date: '2021-02-26T00:00:00',
-      slots: [{ description: 'AM Slot' }, { description: 'PM Slot' }],
+      slots: [{ description: 'AM' }, { description: 'PM' }],
     })
   })
 })


### PR DESCRIPTION
### Description of change

Previously the frontend would do a match on fairly specific text when deciding how to present slots. This commit makes that matching broader so the frontend will work with some slight variations in slot descriptions.
