### PR TITLE
Add serverless and CI config for development env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,14 @@ jobs:
       - store_artifacts:
           path: cypress/reports
 
+  build-deploy-development:
+    executor: aws-cli/default
+    steps:
+      - *attach_workspace
+      - run:
+          name: deploy
+          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage development
+
   build-deploy-staging:
     executor: aws-cli/default
     steps:
@@ -79,6 +87,19 @@ jobs:
       - run:
           name: deploy
           command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production
+
+  assume-role-development:
+    executor: docker-python
+    steps:
+      - checkout
+      - aws_assume_role/assume_role:
+          account: $AWS_ACCOUNT_DEVELOPMENT
+          profile_name: default
+          role: 'LBH_Circle_CI_Deployment_Role'
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
 
   assume-role-staging:
     executor: docker-python
@@ -117,6 +138,20 @@ workflows:
       - e2e:
           requires:
             - install-dependencies
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - tests
+            - e2e
+          filters:
+            branches:
+              only: develop
+      - build-deploy-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: develop
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:

--- a/serverless.yml
+++ b/serverless.yml
@@ -93,17 +93,24 @@ custom:
         - eu-west-2
         - amazonaws.com
   aliases:
+    development: repairs-hub-development.hackney.gov.uk
     staging: repairs-hub-staging.hackney.gov.uk
     production: repairs-hub.hackney.gov.uk
   certificate-arn:
+    development: arn:aws:acm:us-east-1:364864573329:certificate/d903d9e2-c3da-482b-8768-916ec09e461f
     staging: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
     production: arn:aws:acm:us-east-1:282997303675:certificate/a43b1303-83ff-496e-b7a2-a75fa3ebfe87
   securityGroups:
+    development:
+      - sg-08e28776da7918e4b
     staging:
       - sg-0166cbf56b7e77af0
     production:
       - sg-0c40b8cfd2d03c359
   subnets:
+    development:
+      - subnet-0140d06fb84fdb547
+      - subnet-05ce390ba88c42bfd
     staging:
       - subnet-06d3de1bd9181b0d7
       - subnet-0ed7d7713d1127656


### PR DESCRIPTION
### Description of change

- Add serverless and CI config for development env
- Point to subnets, security groups and add certificate arn in serverless.yml

We still need a DNS to be set up so that we can point to a custom Hackney domain in order to use google authentication
