### PR TITLE
Specify Content-Type in header

### DIFF
--- a/src/pages/api/[...path].test.js
+++ b/src/pages/api/[...path].test.js
@@ -64,6 +64,7 @@ describe('/api/[...path]', () => {
     )
 
     const headers = {
+      'Content-Type': 'application/json',
       'x-api-key': REPAIRS_SERVICE_API_KEY,
       'x-hackney-user': signedCookie,
     }

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -56,6 +56,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
     )
 
     const headers = {
+      'Content-Type': 'application/json',
       'x-api-key': REPAIRS_SERVICE_API_KEY,
       'x-hackney-user': signedCookie,
     }
@@ -112,6 +113,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
     )
 
     const headers = {
+      'Content-Type': 'application/json',
       'x-api-key': REPAIRS_SERVICE_API_KEY,
       'x-hackney-user': signedCookie,
     }

--- a/src/utils/service-api-client.js
+++ b/src/utils/service-api-client.js
@@ -17,6 +17,7 @@ export const serviceAPIRequest = async (request) => {
   const headers = {
     'x-api-key': REPAIRS_SERVICE_API_KEY,
     'x-hackney-user': token,
+    'Content-Type': 'application/json',
   }
 
   let { path, ...queryParams } = request.query


### PR DESCRIPTION
### Description of change

- Updating `"axios": "^0.21.0" -> "axios": "^0.21.1"` gave us `415 Unsupported Media Type` when making post requests with axios.
- Specifying the Content-Type header resolves this issue
