### PR TITLE
CM can see reference in RepairsHistoryTable

### DIFF
--- a/src/components/Property/RepairsHistory/RepairsHistoryRow.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryRow.js
@@ -18,11 +18,12 @@ const RepairsHistoryRow = ({
       className="govuk-table__row govuk-table__row--clickable govuk-body-s"
       data-ref={reference}
     >
-      {user && user.hasAgentPermissions && (
-        <td className="govuk-table__cell">
-          <a href={`/work-orders/${reference}`}>{reference}</a>
-        </td>
-      )}
+      {user &&
+        (user.hasAgentPermissions || user.hasContractManagerPermissions) && (
+          <td className="govuk-table__cell">
+            <a href={`/work-orders/${reference}`}>{reference}</a>
+          </td>
+        )}
       <td className="govuk-table__cell">
         {dateRaised ? dateToStr(dateRaised) : '—'}
         <div className="work-order-hours">

--- a/src/components/Property/RepairsHistory/RepairsHistoryTable.js
+++ b/src/components/Property/RepairsHistory/RepairsHistoryTable.js
@@ -42,11 +42,13 @@ const RepairsHistoryTable = ({
       <table className="govuk-table govuk-!-margin-top-5 repairs-history-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row govuk-body">
-            {user && user.hasAgentPermissions && (
-              <th scope="col" className="govuk-table__header">
-                Reference
-              </th>
-            )}
+            {user &&
+              (user.hasAgentPermissions ||
+                user.hasContractManagerPermissions) && (
+                <th scope="col" className="govuk-table__header">
+                  Reference
+                </th>
+              )}
             <th scope="col" className="govuk-table__header">
               Date raised
             </th>

--- a/src/components/Property/RepairsHistory/__snapshots__/RepairsHistoryTable.test.js.snap
+++ b/src/components/Property/RepairsHistory/__snapshots__/RepairsHistoryTable.test.js.snap
@@ -20,6 +20,12 @@ exports[`RepairsHistoryTable component when logged in as a contract manager shou
           class="govuk-table__header"
           scope="col"
         >
+          Reference
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
           Date raised
         </th>
         <th
@@ -49,6 +55,15 @@ exports[`RepairsHistoryTable component when logged in as a contract manager shou
         class="govuk-table__row govuk-table__row--clickable govuk-body-s"
         data-ref="10000012"
       >
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            href="/work-orders/10000012"
+          >
+            10000012
+          </a>
+        </td>
         <td
           class="govuk-table__cell"
         >
@@ -83,6 +98,15 @@ exports[`RepairsHistoryTable component when logged in as a contract manager shou
         class="govuk-table__row govuk-table__row--clickable govuk-body-s"
         data-ref="10000013"
       >
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            href="/work-orders/10000013"
+          >
+            10000013
+          </a>
+        </td>
         <td
           class="govuk-table__cell"
         >


### PR DESCRIPTION

ticket: https://trello.com/c/ybtyJ7N8/82-as-a-contract-manager-i-can-select-work-orders-from-work-order-history-so-that-i-can-view-the-history-of-repairs-before-approvin

![Screenshot 2021-04-19 at 14 46 35](https://user-images.githubusercontent.com/51852726/115246731-0f236200-a11e-11eb-8d85-4866bb811db0.png)
