### PR TITLE
Use priority code mappings consistent with backend

### DIFF
--- a/cypress/integration/raise-repair/appointment-form.spec.js
+++ b/cypress/integration/raise-repair/appointment-form.spec.js
@@ -105,10 +105,10 @@ describe('Schedule appointment form', () => {
                 reference: [{ id: referenceIdUuid }],
                 descriptionOfWork: 'Testing',
                 priority: {
-                  priorityCode: 3,
+                  priorityCode: 4,
                   priorityDescription: '5 [N] NORMAL',
                   requiredCompletionDateTime: requiredCompletionDateTime,
-                  numberOfDays: 30,
+                  numberOfDays: 21,
                 },
                 workClass: { workClassCode: 0 },
                 workElement: [

--- a/cypress/integration/raise-repair/e2e_flow.spec.js
+++ b/cypress/integration/raise-repair/e2e_flow.spec.js
@@ -105,7 +105,7 @@ describe('Schedule appointment form', () => {
               reference: [{ id: referenceIdUuid }],
               descriptionOfWork: 'Testing',
               priority: {
-                priorityCode: 1,
+                priorityCode: 2,
                 priorityDescription: '2 [E] EMERGENCY',
                 requiredCompletionDateTime: requiredCompletionDateTime,
                 numberOfDays: 1,
@@ -227,10 +227,10 @@ describe('Schedule appointment form', () => {
               reference: [{ id: referenceIdUuid }],
               descriptionOfWork: 'Testing',
               priority: {
-                priorityCode: 3,
+                priorityCode: 4,
                 priorityDescription: '5 [N] NORMAL',
                 requiredCompletionDateTime: requiredCompletionDateTime,
-                numberOfDays: 30,
+                numberOfDays: 21,
               },
               workClass: { workClassCode: 0 },
               workElement: [

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -382,7 +382,7 @@ describe('Raise repair form', () => {
             reference: [{ id: referenceIdUuid }],
             descriptionOfWork: 'A problem',
             priority: {
-              priorityCode: 1,
+              priorityCode: 2,
               priorityDescription: '2 [E] EMERGENCY',
               requiredCompletionDateTime: requiredCompletionDateTime,
               numberOfDays: 1,

--- a/src/utils/hact/helpers/priority-codes.js
+++ b/src/utils/hact/helpers/priority-codes.js
@@ -1,27 +1,27 @@
-export const mapPriorityCodeToHact = {
+export const priorityCodeCompletionTimes = {
+  // immediate
   1: {
     numberOfHours: 2,
     numberOfDays: 0,
-    priorityCodeHact: 1,
   },
+  // emergency
   2: {
     numberOfHours: 24,
     numberOfDays: 1,
-    priorityCodeHact: 1,
   },
+  // urgent
   3: {
-    numberOfHours: 168,
-    numberOfDays: 7,
-    priorityCodeHact: 2,
+    numberOfHours: 120,
+    numberOfDays: 5,
   },
+  // normal
   4: {
-    numberOfHours: 720,
-    numberOfDays: 30,
-    priorityCodeHact: 3,
+    numberOfHours: 504,
+    numberOfDays: 21,
   },
-  5: {
-    numberOfHours: 8760,
-    numberOfDays: 365,
-    priorityCodeHact: 4,
-  },
+  // inspection ?
+  // 5: {
+  //   numberOfHours: 8670,
+  //   numberOfDays: 365,
+  // },
 }

--- a/src/utils/hact/helpers/priority-codes.test.js
+++ b/src/utils/hact/helpers/priority-codes.test.js
@@ -1,31 +1,22 @@
-import { mapPriorityCodeToHact } from './priority-codes'
+import { priorityCodeCompletionTimes } from './priority-codes'
 
-describe('Priority code HACT mapping object', () => {
+describe('priorityCodeCompletionTimes', () => {
   it('should map to the correct values', () => {
-    expect(mapPriorityCodeToHact[1]).toEqual({
+    expect(priorityCodeCompletionTimes[1]).toEqual({
       numberOfHours: 2,
       numberOfDays: 0,
-      priorityCodeHact: 1,
     })
-    expect(mapPriorityCodeToHact[2]).toEqual({
+    expect(priorityCodeCompletionTimes[2]).toEqual({
       numberOfHours: 24,
       numberOfDays: 1,
-      priorityCodeHact: 1,
     })
-    expect(mapPriorityCodeToHact[3]).toEqual({
-      numberOfHours: 168,
-      numberOfDays: 7,
-      priorityCodeHact: 2,
+    expect(priorityCodeCompletionTimes[3]).toEqual({
+      numberOfHours: 120,
+      numberOfDays: 5,
     })
-    expect(mapPriorityCodeToHact[4]).toEqual({
-      numberOfHours: 720,
-      numberOfDays: 30,
-      priorityCodeHact: 3,
-    })
-    expect(mapPriorityCodeToHact[5]).toEqual({
-      numberOfHours: 8760,
-      numberOfDays: 365,
-      priorityCodeHact: 4,
+    expect(priorityCodeCompletionTimes[4]).toEqual({
+      numberOfHours: 504,
+      numberOfDays: 21,
     })
   })
 })

--- a/src/utils/hact/schedule-repair/raise-repair-form.js
+++ b/src/utils/hact/schedule-repair/raise-repair-form.js
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
-import { mapPriorityCodeToHact } from '../helpers/priority-codes'
+import { priorityCodeCompletionTimes } from '../helpers/priority-codes'
 import { calculateNewDateTimeFromDate } from '../../date'
 
 export const buildScheduleRepairFormData = (formData) => {
@@ -11,14 +11,14 @@ export const buildScheduleRepairFormData = (formData) => {
     ],
     descriptionOfWork: formData.descriptionOfWork,
     priority: {
-      priorityCode:
-        mapPriorityCodeToHact[formData.priorityCode].priorityCodeHact,
+      priorityCode: Number.parseInt(formData.priorityCode),
       priorityDescription: formData.priorityDescription,
       requiredCompletionDateTime: calculateNewDateTimeFromDate(
         new Date(),
-        mapPriorityCodeToHact[formData.priorityCode].numberOfHours
+        priorityCodeCompletionTimes[formData.priorityCode].numberOfHours
       ),
-      numberOfDays: mapPriorityCodeToHact[formData.priorityCode].numberOfDays,
+      numberOfDays:
+        priorityCodeCompletionTimes[formData.priorityCode].numberOfDays,
     },
     workClass: {
       workClassCode: 0,

--- a/src/utils/hact/schedule-repair/raise-repair-form.test.js
+++ b/src/utils/hact/schedule-repair/raise-repair-form.test.js
@@ -48,10 +48,10 @@ describe('buildRaiseRepairFormData', () => {
       ],
       descriptionOfWork: 'This is an urgent test description',
       priority: {
-        priorityCode: 2,
+        priorityCode: 3,
         priorityDescription: '4 [U] URGENT',
-        requiredCompletionDateTime: new Date('2021-01-21T18:16:20.986Z'),
-        numberOfDays: 7,
+        requiredCompletionDateTime: new Date('2021-01-19T18:16:20.986Z'),
+        numberOfDays: 5,
       },
       workClass: {
         workClassCode: 0,


### PR DESCRIPTION
When scheduling a repair we include the following priority fields:
```
priorityCode
priorityDescription
requiredCompletionDateTime
numberOfDays
```

This commit updates our priority code mappings, so we send back the same priority code as was returned from the API `/priorities` call.

It also updates some hour and day values for priorities.

By matching the backend DB `sor_priorities` table we should have consistent values for these

![image](https://user-images.githubusercontent.com/1370570/115274482-9f6ea080-a138-11eb-9c6e-e54e397a6aca.png)
