### PR TITLE
Add success page for variation approved/rejected

### DIFF
--- a/cypress/integration/jobs/job-authorisation.spec.js
+++ b/cypress/integration/jobs/job-authorisation.spec.js
@@ -44,6 +44,8 @@ describe('Contract manager can authorise variation', () => {
         comments: 'Variation rejected: Can not approve it',
         typeCode: '125',
       })
+
+    cy.contains('You have rejected a variation for work order 10000012')
   })
 
   it('Approves job variation', () => {
@@ -63,5 +65,7 @@ describe('Contract manager can authorise variation', () => {
         },
         typeCode: '100-20',
       })
+
+    cy.contains('You have approved a variation for work order 10000012')
   })
 })

--- a/src/components/SuccessPage/SuccessPage.js
+++ b/src/components/SuccessPage/SuccessPage.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+
+const SuccessPage = ({ workOrderReference, text }) => {
+  return (
+    <div>
+      <section className="lbh-page-announcement">
+        <div className="lbh-announcement__content">
+          <p>
+            {text} <strong>work order {workOrderReference}</strong>
+          </p>
+        </div>
+      </section>
+
+      <ul className="lbh-list lbh-!-margin-top-9">
+        <li>
+          <Link href={`/work-orders/${workOrderReference}`}>
+            <a>
+              <strong>View work order</strong>
+            </a>
+          </Link>
+        </li>
+
+        <li>
+          <Link href="/">
+            <a>
+              <strong>Back to dashboard</strong>
+            </a>
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}
+
+SuccessPage.propTypes = {
+  workOrderReference: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+}
+
+export default SuccessPage

--- a/src/components/SuccessPage/SuccessPage.test.js
+++ b/src/components/SuccessPage/SuccessPage.test.js
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react'
+import SuccessPage from './SuccessPage'
+
+describe('SuccessPage component', () => {
+  describe('when variation approved', () => {
+    const props = {
+      workOrder: {
+        reference: 10000012,
+      },
+      text: 'You have approved a variation for',
+    }
+    it('should render properly with approved message', () => {
+      const { asFragment } = render(
+        <SuccessPage workOrder={props.workOrder} text={props.text} />
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when variation approved', () => {
+    const props = {
+      workOrder: {
+        reference: 10000012,
+      },
+      text: 'You have rejected a variation for',
+    }
+    it('should render properly with rejected message', () => {
+      const { asFragment } = render(
+        <SuccessPage workOrder={props.workOrder} text={props.text} />
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
+++ b/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SuccessPage component when variation approved should render properly with approved message 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="lbh-page-announcement"
+    >
+      <div
+        class="lbh-announcement__content"
+      >
+        <p>
+          You have approved a variation for 
+          <strong>
+            work order 
+          </strong>
+        </p>
+      </div>
+    </section>
+    <ul
+      class="lbh-list lbh-!-margin-top-9"
+    >
+      <li>
+        <a
+          href="/work-orders/undefined"
+        >
+          <strong>
+            View work order
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/"
+        >
+          <strong>
+            Back to dashboard
+          </strong>
+        </a>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SuccessPage component when variation approved should render properly with rejected message 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="lbh-page-announcement"
+    >
+      <div
+        class="lbh-announcement__content"
+      >
+        <p>
+          You have rejected a variation for 
+          <strong>
+            work order 
+          </strong>
+        </p>
+      </div>
+    </section>
+    <ul
+      class="lbh-list lbh-!-margin-top-9"
+    >
+      <li>
+        <a
+          href="/work-orders/undefined"
+        >
+          <strong>
+            View work order
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/"
+        >
+          <strong>
+            Back to dashboard
+          </strong>
+        </a>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Created SuccessPage component so we can reuse it for contractors as well (might need to change some logic there, but we will be able to reuse it)

ticket: https://trello.com/c/DqmGK4x8/80-as-a-contract-manager-i-am-taken-to-a-confirmation-page-once-a-repair-has-been-approved-or-rejected-so-that-i-know-whats-happene
![Screenshot 2021-04-20 at 15 22 02](https://user-images.githubusercontent.com/51852726/115412425-3183b100-a1ec-11eb-8b7e-875100e1e4c1.png)


