### PR TITLE
Allow contract managers to search by address

### DIFF
--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -9,7 +9,8 @@ import { getProperties } from '../../utils/frontend-api-client/properties'
 
 const Search = ({ query }) => {
   const { user } = useContext(UserContext)
-  const canSearchForProperty = user && user.hasAgentPermissions
+  const canSearchForProperty =
+    user && (user.hasAgentPermissions || user.hasContractManagerPermissions)
   const [searchQuery, setSearchQuery] = useState('')
   const [properties, setProperties] = useState([])
   const [loading, setLoading] = useState(false)

--- a/src/components/Search/Search.test.js
+++ b/src/components/Search/Search.test.js
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react'
+import UserContext from '../UserContext/UserContext'
+import Search from './Search'
+
+describe('Search component', () => {
+  describe('when logged in as an agent', () => {
+    const user = {
+      name: 'An Agent',
+      email: 'an.agent@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: true,
+      hasContractorPermissions: false,
+      hasContractManagerPermissions: false,
+      hasAnyPermissions: true,
+    }
+
+    it('should render properly', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <Search />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when logged in as a contract manager', () => {
+    const user = {
+      name: 'A contract manager',
+      email: 'a.contract-manager@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: false,
+      hasContractManagerPermissions: true,
+      hasAnyPermissions: true,
+    }
+
+    it('should render properly', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <Search />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when logged in as a contractor', () => {
+    const user = {
+      name: 'An Agent',
+      email: 'a.contractor@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: true,
+      hasContractManagerPermissions: false,
+      hasAnyPermissions: true,
+    }
+
+    it('should render properly', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <Search />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -1,0 +1,142 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Search component when logged in as a contract manager should render properly 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="section"
+    >
+      <h1
+        class="lbh-heading-h2"
+      >
+        Find repair job or property
+      </h1>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <form>
+          <label
+            class="govuk-label lbh-label"
+          >
+            <p
+              class="govuk-body-s govuk-!-margin-bottom-0"
+            >
+              Search by work order reference, postcode or address
+            </p>
+            <input
+              class="govuk-input lbh-input govuk-input--width-10 focus-colour"
+              type="text"
+              value=""
+            />
+          </label>
+          <div
+            class="govuk-form-group lbh-form-group"
+          >
+            <button
+              class="govuk-button lbh-button"
+              data-module="govuk-button"
+              type="submit"
+            >
+              Search
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Search component when logged in as a contractor should render properly 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="section"
+    >
+      <h1
+        class="lbh-heading-h2"
+      >
+        Find repair job
+      </h1>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <form>
+          <label
+            class="govuk-label lbh-label"
+          >
+            <p
+              class="govuk-body-s govuk-!-margin-bottom-0"
+            >
+              Search by work order reference
+            </p>
+            <input
+              class="govuk-input lbh-input govuk-input--width-10 focus-colour"
+              type="text"
+              value=""
+            />
+          </label>
+          <div
+            class="govuk-form-group lbh-form-group"
+          >
+            <button
+              class="govuk-button lbh-button"
+              data-module="govuk-button"
+              type="submit"
+            >
+              Search
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Search component when logged in as an agent should render properly 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="section"
+    >
+      <h1
+        class="lbh-heading-h2"
+      >
+        Find repair job or property
+      </h1>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <form>
+          <label
+            class="govuk-label lbh-label"
+          >
+            <p
+              class="govuk-body-s govuk-!-margin-bottom-0"
+            >
+              Search by work order reference, postcode or address
+            </p>
+            <input
+              class="govuk-input lbh-input govuk-input--width-10 focus-colour"
+              type="text"
+              value=""
+            />
+          </label>
+          <div
+            class="govuk-form-group lbh-form-group"
+          >
+            <button
+              class="govuk-button lbh-button"
+              data-module="govuk-button"
+              type="submit"
+            >
+              Search
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
### Description of change

Allow contract managers to search by address
- Add snapshot tests for Search page for the different user groups (agent, contractors, contract managers)

https://trello.com/c/1w84FwGV/96-as-a-contract-manager-i-can-search-for-an-address-in-my-dashboard-so-that-i-can-raise-orders