### PR TITLE
Fix contractor group detection for non-production environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,13 +145,13 @@ workflows:
             - e2e
           filters:
             branches:
-              only: develop
+              only: fix-contractor-group-detection
       - build-deploy-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: develop
+              only: fix-contractor-group-detection
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:

--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,7 @@ HACKNEY_JWT_SECRET=sekret
 
 AGENTS_GOOGLE_GROUPNAME=repairs-hub-agents-staging
 CONTRACTORS_GOOGLE_GROUPNAME_PREFIX=repairs-hub-contractors
+CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX=staging
 CONTRACT_MANAGERS_GOOGLE_GROUPNAME=repairs-hub-contract-manager-staging
 
 #Redirect URL to run code locally

--- a/serverless.yml
+++ b/serverless.yml
@@ -41,6 +41,7 @@ functions:
       HACKNEY_JWT_SECRET: ${ssm:/repairs-hub/${self:provider.stage}/hackney-jwt-secret}
       AGENTS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/agents-group}
       CONTRACTORS_GOOGLE_GROUPNAME_PREFIX: ${ssm:/repairs-hub/${self:provider.stage}/contractors-group-prefix}
+      CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX: ${ssm:/repairs-hub/${self:provider.stage}/contractors-group-suffix, ''}
       CONTRACT_MANAGERS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/contract-managers-group}
       REDIRECT_URL: ${ssm:/repairs-hub/${self:provider.stage}/redirect-url}
 

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -11,6 +11,7 @@ const {
   HACKNEY_JWT_SECRET,
   GSSO_TOKEN_NAME,
   CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
+  CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX,
   AGENTS_GOOGLE_GROUPNAME,
   REPAIRS_SERVICE_API_KEY,
 } = process.env
@@ -107,7 +108,9 @@ describe('GET /api/properties/[id] contact information redaction', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [`${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack`],
+        groups: [
+          `${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack-${CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX}`,
+        ],
       },
       HACKNEY_JWT_SECRET
     )

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -9,8 +9,11 @@ export const buildUser = (name, email, authServiceGroups) => {
     AGENTS_GOOGLE_GROUPNAME,
   } = process.env
 
+  const CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX =
+    process.env.CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX || ''
+
   const contractorGroupRegex = new RegExp(
-    `^${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}`
+    `^${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}.*${CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX}$`
   )
 
   const rolesFromGroups = (groupNames) => {
@@ -19,7 +22,7 @@ export const buildUser = (name, email, authServiceGroups) => {
         return AGENT_ROLE
       } else if (groupName === CONTRACT_MANAGERS_GOOGLE_GROUPNAME) {
         return CONTRACT_MANAGER_ROLE
-      } else if (hasContractorGroupPrefix(groupName)) {
+      } else if (isContractorGroupName(groupName)) {
         return CONTRACTOR_ROLE
       }
 
@@ -27,14 +30,14 @@ export const buildUser = (name, email, authServiceGroups) => {
     })
   }
 
-  const hasContractorGroupPrefix = (groupName) =>
+  const isContractorGroupName = (groupName) =>
     !!contractorGroupRegex.test(groupName)
 
   const groupNames = authServiceGroups.filter(
     (groupName) =>
       groupName === AGENTS_GOOGLE_GROUPNAME ||
       groupName === CONTRACT_MANAGERS_GOOGLE_GROUPNAME ||
-      hasContractorGroupPrefix(groupName)
+      isContractorGroupName(groupName)
   )
 
   const roles = rolesFromGroups(groupNames)

--- a/src/utils/user.test.js
+++ b/src/utils/user.test.js
@@ -8,6 +8,7 @@ import {
 const {
   AGENTS_GOOGLE_GROUPNAME,
   CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
+  CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX,
   CONTRACT_MANAGERS_GOOGLE_GROUPNAME,
 } = process.env
 
@@ -36,7 +37,7 @@ describe('buildUser', () => {
 
   describe('when called with a single contractor group name', () => {
     const user = buildUser('', '', [
-      `${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack`,
+      `${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack-${CONTRACTORS_GOOGLE_GROUPNAME_SUFFIX}`,
     ])
 
     describe('hasContractorPermissions', () => {


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/etSxCp8h/111-bug-fix-use-correct-contractor-group-detection-in-staging-and-development)

### Description of change

Correct detection of contractor groups in the staging and development environments.

Our group formats have changed so that `staging` is a suffix.

That's not a problem for our agent and contractor manager groups because those are described in a single environment variable.

But we currently do not correctly detect contractor groups because we ignore the staging suffix.

This PR adds a suffix for this and updates the regex for detection of this role.

Production should not have this variable set to anything so we can just rely on the fallback of no suffix.

### Before merge

 - [ ] Double check development parameter store variable for PREFIX
 - [ ] Add development parameter store variable for SUFFIX
 - [ ] Check staging parameter store variable for PREFIX
 - [ ] Add staging parameter store variable for SUFFIX
 - [ ] Tell dev team about updates required for local development
