### PR TITLE
No DLO repairs appointments in hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,9 @@ jobs:
       - *attach_workspace
       - run:
           name: Run E2E With Lighthouse Audit
-          command: yarn e2e:audit
+          command: |
+            export NEXT_PUBLIC_SCHEDULER_URL=$NEXT_PUBLIC_SCHEDULER_URL
+            yarn e2e:audit
       - store_artifacts:
           path: cypress/screenshots
       - store_artifacts:
@@ -72,6 +74,7 @@ jobs:
           name: deploy
           command: |
             export NEXT_PUBLIC_ENV_NAME=development
+            export NEXT_PUBLIC_SCHEDULER_URL=$DRS_URL_STAGING
             yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage development
 
   build-deploy-staging:
@@ -82,6 +85,7 @@ jobs:
           name: deploy
           command: |
             export NEXT_PUBLIC_ENV_NAME=staging
+            export NEXT_PUBLIC_SCHEDULER_URL=$DRS_URL_STAGING
             yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
 
   build-deploy-production:
@@ -90,7 +94,9 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production
+          command: |
+            export NEXT_PUBLIC_SCHEDULER_URL=$DRS_URL_PRODUCTION
+            yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production
 
   assume-role-development:
     executor: docker-python

--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,9 @@ CONTRACT_MANAGERS_GOOGLE_GROUPNAME=repairs-hub-contract-manager-staging
 #Redirect URL to run code locally
 REDIRECT_URL=localhost:5000
 
+#Scheduler integration
+NEXT_PUBLIC_SCHEDULER_URL=https://drs.example.hackney.gov.uk
+
 #E2E
 CYPRESS_GSSO_TEST_KEY_AGENT=
 CYPRESS_GSSO_TEST_KEY_CONTRACTOR_ALPHATRACK=

--- a/cypress/integration/raise-repair/appointment-form.spec.js
+++ b/cypress/integration/raise-repair/appointment-form.spec.js
@@ -30,7 +30,7 @@ describe('Schedule appointment form', () => {
     )
     cy.route(
       'GET',
-      'api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01',
+      'api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=*',
       '@sorCodes'
     )
     cy.route('GET', 'api/schedule-of-rates/priorities', '@priorities')
@@ -77,7 +77,7 @@ describe('Schedule appointment form', () => {
 
       cy.get('#repair-request-form').within(() => {
         cy.get('#trade').type('Plumbing - PL')
-        cy.get('#contractor').select('HH General Building Repair - H01')
+        cy.get('#contractor').select('Purdy Contracts (P) Ltd - PCL')
 
         cy.get('select[id="rateScheduleItems[0][code]"]').select(
           'DES5R005 - Normal call outs'
@@ -148,11 +148,11 @@ describe('Schedule appointment form', () => {
                 },
                 instructedBy: { name: 'Hackney Housing' },
                 assignedToPrimary: {
-                  name: 'HH General Building Repair',
+                  name: 'Purdy Contracts (P) Ltd',
                   organization: {
                     reference: [
                       {
-                        id: 'H01',
+                        id: 'PCL',
                       },
                     ],
                   },
@@ -311,7 +311,7 @@ describe('Schedule appointment form', () => {
       )
     })
 
-    it('Should display message that no appointments are availbale', () => {
+    it('Should display message that no appointments are available', () => {
       cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
       cy.get('.lbh-heading-h2')
         .contains('Raise a repair on this dwelling')
@@ -319,7 +319,7 @@ describe('Schedule appointment form', () => {
 
       cy.get('#repair-request-form').within(() => {
         cy.get('#trade').type('Plumbing - PL')
-        cy.get('#contractor').select('HH General Building Repair - H01')
+        cy.get('#contractor').select('Purdy Contracts (P) Ltd - PCL')
 
         cy.get('select[id="rateScheduleItems[0][code]"]').select(
           'DES5R005 - Normal call outs'

--- a/cypress/integration/raise-repair/e2e_flow.spec.js
+++ b/cypress/integration/raise-repair/e2e_flow.spec.js
@@ -39,7 +39,7 @@ describe('Schedule appointment form', () => {
     cy.route('GET', 'api/properties/00012345', '@property')
     cy.route(
       'GET',
-      'api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01',
+      'api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=*',
       '@sorCodes'
     )
     cy.route('GET', 'api/schedule-of-rates/priorities', '@priorities')
@@ -49,12 +49,6 @@ describe('Schedule appointment form', () => {
       'api/contractors?propertyReference=00012345&tradeCode=PL',
       '@contractors'
     )
-    cy.route('POST', '/api/repairs/schedule', {
-      id: 10102030,
-      statusCode: 200,
-      statusCodeDescription: '???',
-      externallyManagedAppointment: false,
-    }).as('apiCheck')
 
     cy.route({
       method: 'POST',
@@ -68,323 +62,380 @@ describe('Schedule appointment form', () => {
     }).as('apiCheckjobStatus')
     cy.clock(now)
   })
-  // when priority is Emergency it is not redirecting to schedule appointment page
-  it('Shows a success page right after work order created', () => {
-    cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
-    cy.get('.lbh-heading-h2')
-      .contains('Raise a repair on this dwelling')
-      .click()
 
-    cy.get('#repair-request-form').within(() => {
-      cy.get('#trade').type('Plumbing - PL')
-      cy.get('#contractor').select('HH General Building Repair - H01')
+  describe('When the order is for a contractor whose appointments are managed in repairs hub', () => {
+    beforeEach(() => {
+      cy.route('POST', '/api/repairs/schedule', {
+        id: 10102030,
+        statusCode: 200,
+        statusCodeDescription: '???',
+        externallyManagedAppointment: false,
+      }).as('apiCheck')
+    })
 
-      cy.get('select[id="rateScheduleItems[0][code]"]').select(
-        'DES5R006 - Urgent call outs'
-      )
+    it('Shows a success page right after a work order is created with an emergency priority', () => {
+      cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+      cy.get('.lbh-heading-h2')
+        .contains('Raise a repair on this dwelling')
+        .click()
 
-      cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-      cy.get('#priorityDescription').select('2 [E] EMERGENCY')
-      cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
-      cy.get('#callerName').type('Bob Leek', { force: true })
-      cy.get('#contactNumber')
-        .clear({ force: true })
-        .type('07788659111', { force: true })
-      cy.get('[type="submit"]')
-        .contains('Create works order')
-        .click({ force: true })
-      // Check body of post request, creates work order
-      cy.get('@apiCheck')
-        .its('request.body')
-        .then((body) => {
-          const referenceIdUuid = body.reference[0].id
-          const requiredCompletionDateTime =
-            body.priority.requiredCompletionDateTime
-          cy.get('@apiCheck')
-            .its('request.body')
-            .should('deep.equal', {
-              reference: [{ id: referenceIdUuid }],
-              descriptionOfWork: 'Testing',
-              priority: {
-                priorityCode: 2,
-                priorityDescription: '2 [E] EMERGENCY',
-                requiredCompletionDateTime: requiredCompletionDateTime,
-                numberOfDays: 1,
-              },
-              workClass: { workClassCode: 0 },
-              workElement: [
-                {
-                  rateScheduleItem: [
-                    {
-                      customCode: 'DES5R006',
-                      customName: 'Urgent call outs',
-                      quantity: { amount: [2] },
-                    },
-                  ],
-                  trade: [
-                    {
-                      code: 'SP',
-                      customCode: 'PL',
-                      customName: 'Plumbing - PL',
-                    },
-                  ],
+      cy.get('#repair-request-form').within(() => {
+        cy.get('#trade').type('Plumbing - PL')
+        cy.get('#contractor').select('Purdy Contracts (P) Ltd - PCL')
+
+        cy.get('select[id="rateScheduleItems[0][code]"]').select(
+          'DES5R006 - Urgent call outs'
+        )
+
+        cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
+        cy.get('#priorityDescription').select('2 [E] EMERGENCY')
+        cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
+        cy.get('#callerName').type('Bob Leek', { force: true })
+        cy.get('#contactNumber')
+          .clear({ force: true })
+          .type('07788659111', { force: true })
+        cy.get('[type="submit"]')
+          .contains('Create works order')
+          .click({ force: true })
+        // Check body of post request, creates work order
+        cy.get('@apiCheck')
+          .its('request.body')
+          .then((body) => {
+            const referenceIdUuid = body.reference[0].id
+            const requiredCompletionDateTime =
+              body.priority.requiredCompletionDateTime
+            cy.get('@apiCheck')
+              .its('request.body')
+              .should('deep.equal', {
+                reference: [{ id: referenceIdUuid }],
+                descriptionOfWork: 'Testing',
+                priority: {
+                  priorityCode: 2,
+                  priorityDescription: '2 [E] EMERGENCY',
+                  requiredCompletionDateTime: requiredCompletionDateTime,
+                  numberOfDays: 1,
                 },
-              ],
-              site: {
-                property: [
+                workClass: { workClassCode: 0 },
+                workElement: [
                   {
-                    propertyReference: '00012345',
-                    address: {
-                      addressLine: ['16 Pitcairn House  St Thomass Square'],
-                      postalCode: 'E9 6PT',
-                    },
-                    reference: [
+                    rateScheduleItem: [
                       {
-                        id: '00012345',
+                        customCode: 'DES5R006',
+                        customName: 'Urgent call outs',
+                        quantity: { amount: [2] },
+                      },
+                    ],
+                    trade: [
+                      {
+                        code: 'SP',
+                        customCode: 'PL',
+                        customName: 'Plumbing - PL',
                       },
                     ],
                   },
                 ],
-              },
-              instructedBy: { name: 'Hackney Housing' },
-              assignedToPrimary: {
-                name: 'HH General Building Repair',
-                organization: {
-                  reference: [
+                site: {
+                  property: [
                     {
-                      id: 'H01',
-                    },
-                  ],
-                },
-              },
-              customer: {
-                name: 'Bob Leek',
-                person: {
-                  name: {
-                    full: 'Bob Leek',
-                  },
-                  communication: [
-                    {
-                      channel: {
-                        medium: '20',
-                        code: '60',
+                      propertyReference: '00012345',
+                      address: {
+                        addressLine: ['16 Pitcairn House  St Thomass Square'],
+                        postalCode: 'E9 6PT',
                       },
-                      value: '07788659111',
+                      reference: [
+                        {
+                          id: '00012345',
+                        },
+                      ],
                     },
                   ],
                 },
-              },
-            })
-        })
-    })
-
-    // Confirmation screen
-    cy.get('.lbh-page-announcement').within(() => {
-      cy.get('.lbh-announcement__content').within(() => {
-        cy.get('h2').contains('Repair works order created')
-        cy.contains('Works order number')
-        cy.contains('10102030')
+                instructedBy: { name: 'Hackney Housing' },
+                assignedToPrimary: {
+                  name: 'Purdy Contracts (P) Ltd',
+                  organization: {
+                    reference: [
+                      {
+                        id: 'PCL',
+                      },
+                    ],
+                  },
+                },
+                customer: {
+                  name: 'Bob Leek',
+                  person: {
+                    name: {
+                      full: 'Bob Leek',
+                    },
+                    communication: [
+                      {
+                        channel: {
+                          medium: '20',
+                          code: '60',
+                        },
+                        value: '07788659111',
+                      },
+                    ],
+                  },
+                },
+              })
+          })
       })
+
+      // Confirmation screen
+      cy.get('.lbh-page-announcement').within(() => {
+        cy.get('.lbh-announcement__content').within(() => {
+          cy.get('h2').contains('Repair works order created')
+          cy.contains('Works order number')
+          cy.contains('10102030')
+        })
+      })
+
+      // Actions to see relevant pages
+      cy.get('.lbh-list li').within(() => {
+        cy.contains('View work order').should(
+          'have.attr',
+          'href',
+          '/work-orders/10102030'
+        )
+        cy.contains('Back to 16 Pitcairn House St Thomass Square').should(
+          'have.attr',
+          'href',
+          '/properties/00012345'
+        )
+        cy.contains('Start a new search').should('have.attr', 'href', '/')
+      })
+
+      // Run lighthouse audit for accessibility report
+      cy.audit()
     })
 
-    // Actions to see relevant pages
-    cy.get('.lbh-list li').within(() => {
-      cy.contains('View work order').should(
-        'have.attr',
-        'href',
-        '/work-orders/10102030'
-      )
-      cy.contains('Back to 16 Pitcairn House St Thomass Square').should(
-        'have.attr',
-        'href',
-        '/properties/00012345'
-      )
-      cy.contains('Start a new search').should('have.attr', 'href', '/')
-    })
+    // when priority is Normal it is redirecting to schedule appointment page
+    it('Shows an appointment booking page right after work order is created with a normal priority', () => {
+      cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+      cy.get('.lbh-heading-h2')
+        .contains('Raise a repair on this dwelling')
+        .click()
 
-    // Run lighthouse audit for accessibility report
-    cy.audit()
-  })
+      cy.get('#repair-request-form').within(() => {
+        cy.get('#trade').type('Plumbing - PL')
+        cy.get('#contractor').select('Purdy Contracts (P) Ltd - PCL')
 
-  // when priority is Normal it is redirecting to schedule appointment page
-  it('Shows a success page right after work order created', () => {
-    cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
-    cy.get('.lbh-heading-h2')
-      .contains('Raise a repair on this dwelling')
-      .click()
+        cy.get('select[id="rateScheduleItems[0][code]"]').select(
+          'DES5R005 - Normal call outs'
+        )
 
-    cy.get('#repair-request-form').within(() => {
-      cy.get('#trade').type('Plumbing - PL')
-      cy.get('#contractor').select('HH General Building Repair - H01')
-
-      cy.get('select[id="rateScheduleItems[0][code]"]').select(
-        'DES5R005 - Normal call outs'
-      )
-
-      cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-      cy.get('#priorityDescription').select('5 [N] NORMAL')
-      cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
-      cy.get('#callerName').type('Bob Leek', { force: true })
-      cy.get('#contactNumber')
-        .clear({ force: true })
-        .type('07788659111', { force: true })
-      cy.get('[type="submit"]')
-        .contains('Create works order')
-        .click({ force: true })
-      // Check body of post request, creates work order
-      cy.get('@apiCheck')
-        .its('request.body')
-        .then((body) => {
-          const referenceIdUuid = body.reference[0].id
-          const requiredCompletionDateTime =
-            body.priority.requiredCompletionDateTime
-          cy.get('@apiCheck')
-            .its('request.body')
-            .should('deep.equal', {
-              reference: [{ id: referenceIdUuid }],
-              descriptionOfWork: 'Testing',
-              priority: {
-                priorityCode: 4,
-                priorityDescription: '5 [N] NORMAL',
-                requiredCompletionDateTime: requiredCompletionDateTime,
-                numberOfDays: 21,
-              },
-              workClass: { workClassCode: 0 },
-              workElement: [
-                {
-                  rateScheduleItem: [
-                    {
-                      customCode: 'DES5R005',
-                      customName: 'Normal call outs',
-                      quantity: { amount: [2] },
-                    },
-                  ],
-                  trade: [
-                    {
-                      code: 'SP',
-                      customCode: 'PL',
-                      customName: 'Plumbing - PL',
-                    },
-                  ],
+        cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
+        cy.get('#priorityDescription').select('5 [N] NORMAL')
+        cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
+        cy.get('#callerName').type('Bob Leek', { force: true })
+        cy.get('#contactNumber')
+          .clear({ force: true })
+          .type('07788659111', { force: true })
+        cy.get('[type="submit"]')
+          .contains('Create works order')
+          .click({ force: true })
+        // Check body of post request, creates work order
+        cy.get('@apiCheck')
+          .its('request.body')
+          .then((body) => {
+            const referenceIdUuid = body.reference[0].id
+            const requiredCompletionDateTime =
+              body.priority.requiredCompletionDateTime
+            cy.get('@apiCheck')
+              .its('request.body')
+              .should('deep.equal', {
+                reference: [{ id: referenceIdUuid }],
+                descriptionOfWork: 'Testing',
+                priority: {
+                  priorityCode: 4,
+                  priorityDescription: '5 [N] NORMAL',
+                  requiredCompletionDateTime: requiredCompletionDateTime,
+                  numberOfDays: 21,
                 },
-              ],
-              site: {
-                property: [
+                workClass: { workClassCode: 0 },
+                workElement: [
                   {
-                    propertyReference: '00012345',
-                    address: {
-                      addressLine: ['16 Pitcairn House  St Thomass Square'],
-                      postalCode: 'E9 6PT',
-                    },
-                    reference: [
+                    rateScheduleItem: [
                       {
-                        id: '00012345',
+                        customCode: 'DES5R005',
+                        customName: 'Normal call outs',
+                        quantity: { amount: [2] },
+                      },
+                    ],
+                    trade: [
+                      {
+                        code: 'SP',
+                        customCode: 'PL',
+                        customName: 'Plumbing - PL',
                       },
                     ],
                   },
                 ],
-              },
-              instructedBy: { name: 'Hackney Housing' },
-              assignedToPrimary: {
-                name: 'HH General Building Repair',
-                organization: {
-                  reference: [
+                site: {
+                  property: [
                     {
-                      id: 'H01',
-                    },
-                  ],
-                },
-              },
-              customer: {
-                name: 'Bob Leek',
-                person: {
-                  name: {
-                    full: 'Bob Leek',
-                  },
-                  communication: [
-                    {
-                      channel: {
-                        medium: '20',
-                        code: '60',
+                      propertyReference: '00012345',
+                      address: {
+                        addressLine: ['16 Pitcairn House  St Thomass Square'],
+                        postalCode: 'E9 6PT',
                       },
-                      value: '07788659111',
+                      reference: [
+                        {
+                          id: '00012345',
+                        },
+                      ],
                     },
                   ],
                 },
-              },
-            })
+                instructedBy: { name: 'Hackney Housing' },
+                assignedToPrimary: {
+                  name: 'Purdy Contracts (P) Ltd',
+                  organization: {
+                    reference: [
+                      {
+                        id: 'PCL',
+                      },
+                    ],
+                  },
+                },
+                customer: {
+                  name: 'Bob Leek',
+                  person: {
+                    name: {
+                      full: 'Bob Leek',
+                    },
+                    communication: [
+                      {
+                        channel: {
+                          medium: '20',
+                          code: '60',
+                        },
+                        value: '07788659111',
+                      },
+                    ],
+                  },
+                },
+              })
+          })
+      })
+
+      //Appointment page with calendar
+      cy.url().should('contains', 'work-orders/10102030/appointment/new')
+
+      cy.get('.appointment-calendar').within(() => {
+        cy.get('.available').contains('11').click({ force: true })
+      })
+      cy.get('form').within(() => {
+        cy.contains('Thursday, 11 March')
+        cy.get('[type="radio"]').first().should('have.value', 'AM 8:00 -12:00')
+        cy.get('[type="radio"]').last().should('have.value', 'PM 12:00-4:00')
+
+        // choose AM slot and leave comment
+        cy.get('[type="radio"]').first().check()
+        cy.get('#comments').type('10 am works for me', { force: true })
+        cy.get('[type="submit"]').contains('Add').click({ force: true })
+      })
+
+      // Summary page
+      cy.contains('Confirm date and time')
+      cy.get('form').within(() => {
+        cy.contains('Appointment Details:')
+        cy.contains('Thursday, 11 March')
+        cy.contains('AM')
+        cy.contains('Comments: 10 am works for me')
+      })
+      cy.get('[type="button"]')
+        .contains('Book appointment')
+        .click({ force: true })
+      cy.get('@apiCheckAppointment')
+        .its('request.body')
+        .should('deep.equal', {
+          workOrderReference: {
+            id: 10102030,
+            description: '',
+            allocatedBy: '',
+          },
+          appointmentReference: {
+            id: '31/2021-03-11',
+            description: '',
+            allocatedBy: '',
+          },
         })
-    })
+      //jobStatusUpdate api check - adding comments
+      cy.get('@apiCheckjobStatus')
+        .its('request.body')
+        .should('deep.equal', {
+          relatedWorkOrderReference: {
+            id: '10102030',
+          },
+          comments: '10 am works for me',
+          // Other
+          typeCode: '0',
+          otherType: 'addNote',
+        })
 
-    //Appointment page with calendar
-    cy.url().should('contains', 'work-orders/10102030/appointment/new')
+      //success form
+      cy.contains('Repair work order created')
+      cy.contains('Work order number')
 
-    cy.get('.appointment-calendar').within(() => {
-      cy.get('.available').contains('11').click({ force: true })
-    })
-    cy.get('form').within(() => {
-      cy.contains('Thursday, 11 March')
-      cy.get('[type="radio"]').first().should('have.value', 'AM 8:00 -12:00')
-      cy.get('[type="radio"]').last().should('have.value', 'PM 12:00-4:00')
+      cy.contains('10102030')
 
-      // choose AM slot and leave comment
-      cy.get('[type="radio"]').first().check()
-      cy.get('#comments').type('10 am works for me', { force: true })
-      cy.get('[type="submit"]').contains('Add').click({ force: true })
-    })
-
-    // Summary page
-    cy.contains('Confirm date and time')
-    cy.get('form').within(() => {
-      cy.contains('Appointment Details:')
       cy.contains('Thursday, 11 March')
       cy.contains('AM')
       cy.contains('Comments: 10 am works for me')
+      cy.contains('a', 'View work order')
+      cy.contains('a', 'Back to 16 Pitcairn House')
+      cy.contains('a', 'Start a new search')
+
+      // Run lighthouse audit for accessibility report
+      cy.audit()
     })
-    cy.get('[type="button"]')
-      .contains('Book appointment')
-      .click({ force: true })
-    cy.get('@apiCheckAppointment')
-      .its('request.body')
-      .should('deep.equal', {
-        workOrderReference: {
-          id: 10102030,
-          description: '',
-          allocatedBy: '',
-        },
-        appointmentReference: {
-          id: '31/2021-03-11',
-          description: '',
-          allocatedBy: '',
-        },
+  })
+
+  describe('When the order is for a contrator whose appointments are managed externally', () => {
+    beforeEach(() => {
+      cy.route('POST', '/api/repairs/schedule', {
+        id: 10102030,
+        statusCode: 200,
+        statusCodeDescription: '???',
+        externallyManagedAppointment: true,
+      }).as('apiCheck')
+    })
+
+    it('Shows a success page instead of the calendar with a link to the external scheduler', () => {
+      cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+      cy.get('.lbh-heading-h2')
+        .contains('Raise a repair on this dwelling')
+        .click()
+
+      cy.get('#repair-request-form').within(() => {
+        cy.get('#trade').type('Plumbing - PL')
+        cy.get('#contractor').select('HH General Building Repair - H01')
+
+        cy.get('select[id="rateScheduleItems[0][code]"]').select(
+          'DES5R005 - Normal call outs'
+        )
+
+        cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
+        cy.get('#priorityDescription').select('5 [N] NORMAL')
+        cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
+        cy.get('[type="submit"]')
+          .contains('Create works order')
+          .click({ force: true })
       })
-    //jobStatusUpdate api check - adding comments
-    cy.get('@apiCheckjobStatus')
-      .its('request.body')
-      .should('deep.equal', {
-        relatedWorkOrderReference: {
-          id: '10102030',
-        },
-        comments: '10 am works for me',
-        // Other
-        typeCode: '0',
-        otherType: 'addNote',
-      })
 
-    //success form
-    cy.contains('Repair work order created')
-    cy.contains('Work order number')
+      //success form
+      cy.contains('Repair works order created')
+      cy.contains('Works order number')
+      cy.contains('10102030')
 
-    cy.contains('10102030')
-
-    cy.contains('Thursday, 11 March')
-    cy.contains('AM')
-    cy.contains('Comments: 10 am works for me')
-    cy.contains('a', 'View work order')
-    cy.contains('a', 'Back to 16 Pitcairn House')
-    cy.contains('a', 'Start a new search')
-
-    // Run lighthouse audit for accessibility report
-    cy.audit()
+      cy.contains('Please open DRS to book an appointment')
+      cy.contains('a', 'open DRS').should(
+        'have.attr',
+        'href',
+        Cypress.env('NEXT_PUBLIC_SCHEDULER_URL')
+      )
+    })
   })
 })

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -28,6 +28,10 @@ const RaiseRepairFormView = ({ propertyReference }) => {
     authorisationPendingApproval,
     setAuthorisationPendingApproval,
   ] = useState(false)
+  const [
+    externallyManagedAppointment,
+    setExternallyManagedAppointment,
+  ] = useState(false)
   const [workOrderReference, setWorkOrderReference] = useState()
   const [currentUser, setCurrentUser] = useState()
   const router = useRouter()
@@ -36,11 +40,15 @@ const RaiseRepairFormView = ({ propertyReference }) => {
     setLoading(true)
 
     try {
-      const { id, statusCode } = await postRepair(formData)
+      const { id, statusCode, externallyManagedAppointment } = await postRepair(
+        formData
+      )
       setWorkOrderReference(id)
 
       if (statusCode === STATUS_AUTHORISATION_PENDING_APPROVAL.code) {
         setAuthorisationPendingApproval(true)
+      } else if (externallyManagedAppointment) {
+        setExternallyManagedAppointment(true)
       } else if (
         priorityCodesRequiringAppointments.includes(
           formData.priority.priorityCode
@@ -114,6 +122,10 @@ const RaiseRepairFormView = ({ propertyReference }) => {
                 showSearchLink={true}
                 isRaiseRepairSuccess={true}
                 authorisationPendingApproval={authorisationPendingApproval}
+                externalSchedulerLink={
+                  externallyManagedAppointment &&
+                  process.env.NEXT_PUBLIC_SCHEDULER_URL
+                }
               />
             </>
           )}

--- a/src/components/SuccessPage/SuccessPage.js
+++ b/src/components/SuccessPage/SuccessPage.js
@@ -31,6 +31,18 @@ const SuccessPage = ({ ...props }) => {
       )}
 
       <ul className="lbh-list lbh-!-margin-top-9">
+        {props.externalSchedulerLink && (
+          <li>
+            Please{' '}
+            <Link href={props.externalSchedulerLink}>
+              <a>
+                <strong>open DRS</strong>
+              </a>
+            </Link>{' '}
+            to book an appointment
+          </li>
+        )}
+
         {props.workOrderReference && (
           <li>
             <Link href={`/work-orders/${props.workOrderReference}`}>

--- a/src/components/SuccessPage/SuccessPage.test.js
+++ b/src/components/SuccessPage/SuccessPage.test.js
@@ -47,34 +47,27 @@ describe('SuccessPage component', () => {
 
     describe('High cost (over raise limit) authorisation', () => {
       it('should render a success screen with a warning message', () => {
-        const { asFragment } = render(
-          <SuccessPage
-            workOrderReference={props.workOrderReference}
-            text={props.text}
-            propertyReference={props.propertyReference}
-            shortAddress={props.shortAddress}
-            showSearchLink={props.showSearchLink}
-            isRaiseRepairSuccess={props.isRaiseRepairSuccess}
-            authorisationPendingApproval={true}
-          />
-        )
+        const testProps = { ...props, authorisationPendingApproval: true }
+        const { asFragment } = render(<SuccessPage {...testProps} />)
         expect(asFragment()).toMatchSnapshot()
       })
     })
 
     describe('Within raise limit', () => {
       it('should render a success screen without a warning message', () => {
-        const { asFragment } = render(
-          <SuccessPage
-            workOrderReference={props.workOrderReference}
-            text={props.text}
-            propertyReference={props.propertyReference}
-            shortAddress={props.shortAddress}
-            showSearchLink={props.showSearchLink}
-            isRaiseRepairSuccess={props.isRaiseRepairSuccess}
-            authorisationPendingApproval={false}
-          />
-        )
+        const testProps = { ...props, authorisationPendingApproval: false }
+        const { asFragment } = render(<SuccessPage {...testProps} />)
+        expect(asFragment()).toMatchSnapshot()
+      })
+    })
+
+    describe('With an external scheduler URL', () => {
+      it('should render text with a link to schedule externally', () => {
+        const testProps = {
+          ...props,
+          externalSchedulerUrl: 'https://drs.example.com',
+        }
+        const { asFragment } = render(<SuccessPage {...testProps} />)
         expect(asFragment()).toMatchSnapshot()
       })
     })

--- a/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
+++ b/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
@@ -163,6 +163,63 @@ exports[`SuccessPage component Raising a repair High cost (over raise limit) aut
 </DocumentFragment>
 `;
 
+exports[`SuccessPage component Raising a repair With an external scheduler URL should render text with a link to schedule externally 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="text-align-center lbh-page-announcement"
+    >
+      <div
+        class="lbh-announcement__content"
+      >
+        <h2>
+          Repair works order created
+        </h2>
+        <p>
+          Works order number
+        </p>
+        <strong
+          class="govuk-!-font-size-24"
+        >
+          10000012
+        </strong>
+      </div>
+    </section>
+    <ul
+      class="lbh-list lbh-!-margin-top-9"
+    >
+      <li>
+        <a
+          href="/work-orders/10000012"
+        >
+          <strong>
+            View work order
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/properties/12345678"
+        >
+          <strong>
+            Back to 12 Random Lane
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/"
+        >
+          <strong>
+            Start a new search
+          </strong>
+        </a>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SuccessPage component Raising a repair Within raise limit should render a success screen without a warning message 1`] = `
 <DocumentFragment>
   <div>


### PR DESCRIPTION
### Description of change

Do not prompt agents raising DLO repairs of any priority to book an appointment.

This will (for the moment) be handled within DRS.

So instead we route them to the form success page with a link.

### Story Link

https://trello.com/c/olwGdpJ7/18-as-an-agent-i-see-the-work-confirmation-page-after-raising-any-dlo-order


### Before Merge

 - [x] Update Circle CI env var
 - [x] Update env var in dev, staging and production
 - [ ] Tell fellow devs about new env variable for local dev