### PR TITLE
Fix contractor group detection

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,7 +10,7 @@ GSSO_TOKEN_NAME=hackneyToken
 HACKNEY_JWT_SECRET=sekret
 
 AGENTS_GOOGLE_GROUPNAME=repairs-hub-agents-staging
-CONTRACTORS_GOOGLE_GROUPNAME_PREFIX=repairs-hub-contractors
+CONTRACTORS_GOOGLE_GROUPNAME_REGEX=^repairs-hub-contractors-.*-staging$
 CONTRACT_MANAGERS_GOOGLE_GROUPNAME=repairs-hub-contract-manager-staging
 
 #Redirect URL to run code locally

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,7 +40,7 @@ functions:
       GSSO_TOKEN_NAME: ${ssm:/repairs-hub/${self:provider.stage}/gsso-token-name}
       HACKNEY_JWT_SECRET: ${ssm:/repairs-hub/${self:provider.stage}/hackney-jwt-secret}
       AGENTS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/agents-group}
-      CONTRACTORS_GOOGLE_GROUPNAME_PREFIX: ${ssm:/repairs-hub/${self:provider.stage}/contractors-group-prefix}
+      CONTRACTORS_GOOGLE_GROUPNAME_REGEX: ${ssm:/repairs-hub/${self:provider.stage}/contractors-group-regex}
       CONTRACT_MANAGERS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/contract-managers-group}
       REDIRECT_URL: ${ssm:/repairs-hub/${self:provider.stage}/redirect-url}
 

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -10,7 +10,6 @@ const {
   REPAIRS_SERVICE_API_URL,
   HACKNEY_JWT_SECRET,
   GSSO_TOKEN_NAME,
-  CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
   AGENTS_GOOGLE_GROUPNAME,
   REPAIRS_SERVICE_API_KEY,
 } = process.env
@@ -107,7 +106,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
       {
         name: 'name',
         email: 'name@example.com',
-        groups: [`${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack`],
+        groups: ['repairs-hub-contractors-alphatrack-staging'],
       },
       HACKNEY_JWT_SECRET
     )

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -5,13 +5,13 @@ export const CONTRACT_MANAGER_ROLE = 'contract_manager'
 export const buildUser = (name, email, authServiceGroups) => {
   const {
     CONTRACT_MANAGERS_GOOGLE_GROUPNAME,
-    CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
     AGENTS_GOOGLE_GROUPNAME,
   } = process.env
 
-  const contractorGroupRegex = new RegExp(
-    `^${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}`
-  )
+  const CONTRACTORS_GOOGLE_GROUPNAME_REGEX =
+    process.env.CONTRACTORS_GOOGLE_GROUPNAME_REGEX || false
+
+  const contractorGroupRegex = new RegExp(CONTRACTORS_GOOGLE_GROUPNAME_REGEX)
 
   const rolesFromGroups = (groupNames) => {
     return groupNames.map((groupName) => {
@@ -19,7 +19,7 @@ export const buildUser = (name, email, authServiceGroups) => {
         return AGENT_ROLE
       } else if (groupName === CONTRACT_MANAGERS_GOOGLE_GROUPNAME) {
         return CONTRACT_MANAGER_ROLE
-      } else if (hasContractorGroupPrefix(groupName)) {
+      } else if (isContractorGroupName(groupName)) {
         return CONTRACTOR_ROLE
       }
 
@@ -27,14 +27,14 @@ export const buildUser = (name, email, authServiceGroups) => {
     })
   }
 
-  const hasContractorGroupPrefix = (groupName) =>
+  const isContractorGroupName = (groupName) =>
     !!contractorGroupRegex.test(groupName)
 
   const groupNames = authServiceGroups.filter(
     (groupName) =>
       groupName === AGENTS_GOOGLE_GROUPNAME ||
       groupName === CONTRACT_MANAGERS_GOOGLE_GROUPNAME ||
-      hasContractorGroupPrefix(groupName)
+      isContractorGroupName(groupName)
   )
 
   const roles = rolesFromGroups(groupNames)

--- a/src/utils/user.test.js
+++ b/src/utils/user.test.js
@@ -7,7 +7,6 @@ import {
 
 const {
   AGENTS_GOOGLE_GROUPNAME,
-  CONTRACTORS_GOOGLE_GROUPNAME_PREFIX,
   CONTRACT_MANAGERS_GOOGLE_GROUPNAME,
 } = process.env
 
@@ -36,7 +35,7 @@ describe('buildUser', () => {
 
   describe('when called with a single contractor group name', () => {
     const user = buildUser('', '', [
-      `${CONTRACTORS_GOOGLE_GROUPNAME_PREFIX}-alphatrack`,
+      'repairs-hub-contractors-alphatrack-staging',
     ])
 
     describe('hasContractorPermissions', () => {


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/etSxCp8h/111-bug-fix-use-correct-contractor-group-detection-in-staging-and-development)

### Description of change

Correct detection of contractor groups in the staging and development environments.

Our group formats have changed so that `staging` is a suffix.

That's not a problem for our agent and contractor manager groups because those are described in a single environment variable.

But we currently do not correctly detect contractor groups because we ignore the staging suffix.

This PR adds a regex so we can selectively include or ignore the suffix depending on the environment.

### Before merge

 - [x] Add new environment variable to Circle CI
 - [x] Test deploy on development with development regex
 - [x] Test deploy on development with production regex
 - [x] Ensure development has the development regex
 - [x] Ensure staging has the staging regex
 - [x] Ensure production has the production regex
 - [x] Remove temporary dev deploy commit
 - [x] Tell dev team about updates required for local development - regex and contractor group values