### PR TITLE
Use raise repair return object

### DIFF
--- a/cypress/integration/raise-repair/appointment-form.spec.js
+++ b/cypress/integration/raise-repair/appointment-form.spec.js
@@ -40,10 +40,11 @@ describe('Schedule appointment form', () => {
       'api/contractors?propertyReference=00012345&tradeCode=PL',
       '@contractors'
     )
-    cy.route({
-      method: 'POST',
-      url: '/api/repairs/schedule',
-      response: '10102030',
+    cy.route('POST', '/api/repairs/schedule', {
+      id: 10102030,
+      statusCode: 200,
+      statusCodeDescription: '???',
+      externallyManagedAppointment: false,
     }).as('apiCheck')
 
     cy.route({

--- a/cypress/integration/raise-repair/e2e_flow.spec.js
+++ b/cypress/integration/raise-repair/e2e_flow.spec.js
@@ -49,10 +49,11 @@ describe('Schedule appointment form', () => {
       'api/contractors?propertyReference=00012345&tradeCode=PL',
       '@contractors'
     )
-    cy.route({
-      method: 'POST',
-      url: '/api/repairs/schedule',
-      response: '10102030',
+    cy.route('POST', '/api/repairs/schedule', {
+      id: 10102030,
+      statusCode: 200,
+      statusCodeDescription: '???',
+      externallyManagedAppointment: false,
     }).as('apiCheck')
 
     cy.route({

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -30,10 +30,11 @@ describe('Raise repair form', () => {
       'api/contractors?propertyReference=00012345&tradeCode=PL',
       '@contractors'
     )
-    cy.route({
-      method: 'POST',
-      url: '/api/repairs/schedule',
-      response: '10102030',
+    cy.route('POST', '/api/repairs/schedule', {
+      id: 10102030,
+      statusCode: 200,
+      statusCodeDescription: '???',
+      externallyManagedAppointment: false,
     }).as('apiCheck')
   })
 

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -31,14 +31,14 @@ const RaiseRepairFormView = ({ propertyReference }) => {
     setLoading(true)
 
     try {
-      const ref = await postRepair(formData)
-      setWorkOrderReference(ref)
+      const { id } = await postRepair(formData)
+      setWorkOrderReference(id)
       if (
         priorityCodesRequiringAppointments.includes(
           formData.priority.priorityCode
         )
       ) {
-        router.push(`/work-orders/${ref}/appointment/new`)
+        router.push(`/work-orders/${id}/appointment/new`)
         return
       } else {
         setFormSuccess(true)


### PR DESCRIPTION
### Description of change

The backend will soon return a more informative response after repair raising, created to support DRS functionality.

This commit updates the existing frontend to use this new object.

This should be merged in tandem with the necessary breaking API change to support it here https://github.com/LBHackney-IT/repairs-api-dotnet/pull/209

### Story Link

https://trello.com/c/Pl98YCBk/8-return-object-from-schedulerepair
