### PR TITLE
High cost authorisations workflow

### DIFF
--- a/__test__/properties/[id]/index.test.js
+++ b/__test__/properties/[id]/index.test.js
@@ -3,14 +3,17 @@ import {
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 } from 'src/utils/user'
 
 describe('PropertyPage.permittedRoles', () => {
-  ;[AGENT_ROLE, CONTRACT_MANAGER_ROLE].forEach((role) => {
-    it(`permits the ${role} role to access the page`, () => {
-      expect(PropertyPage.permittedRoles).toContain(role)
-    })
-  })
+  ;[AGENT_ROLE, CONTRACT_MANAGER_ROLE, AUTHORISATION_MANAGER_ROLE].forEach(
+    (role) => {
+      it(`permits the ${role} role to access the page`, () => {
+        expect(PropertyPage.permittedRoles).toContain(role)
+      })
+    }
+  )
   ;[CONTRACTOR_ROLE].forEach((role) => {
     it(`does not permit the ${role} role to access the page`, () => {
       expect(PropertyPage.permittedRoles).not.toContain(role)

--- a/__test__/repairs/jobs/[id]/authorisation.test.js
+++ b/__test__/repairs/jobs/[id]/authorisation.test.js
@@ -1,19 +1,34 @@
 import AuthorisationPage from 'src/pages/repairs/jobs/[id]/authorisation'
+import VariationAuthorisationPage from 'src/pages/repairs/jobs/[id]/variation-authorisation'
 import {
   AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
 } from 'src/utils/user'
 
 describe('AuthorisationPage.permittedRoles', () => {
-  ;[CONTRACT_MANAGER_ROLE].forEach((role) => {
+  ;[AUTHORISATION_MANAGER_ROLE].forEach((role) => {
     it(`permits the ${role} role to access the page`, () => {
       expect(AuthorisationPage.permittedRoles).toContain(role)
     })
   })
-  ;[AGENT_ROLE, CONTRACTOR_ROLE].forEach((role) => {
+  ;[AGENT_ROLE, CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE].forEach((role) => {
     it(`does not permit the ${role} role to access the page`, () => {
       expect(AuthorisationPage.permittedRoles).not.toContain(role)
+    })
+  })
+})
+
+describe('VariationAuthorisationPage.permittedRoles', () => {
+  ;[CONTRACT_MANAGER_ROLE].forEach((role) => {
+    it(`permits the ${role} role to access the page`, () => {
+      expect(VariationAuthorisationPage.permittedRoles).toContain(role)
+    })
+  })
+  ;[AGENT_ROLE, AUTHORISATION_MANAGER_ROLE, CONTRACTOR_ROLE].forEach((role) => {
+    it(`does not permit the ${role} role to access the page`, () => {
+      expect(VariationAuthorisationPage.permittedRoles).not.toContain(role)
     })
   })
 })

--- a/__test__/repairs/jobs/[id]/choose-option.test.js
+++ b/__test__/repairs/jobs/[id]/choose-option.test.js
@@ -3,6 +3,7 @@ import {
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 } from 'src/utils/user'
 
 describe('ChooseJobOptionPage.permittedRoles', () => {
@@ -11,7 +12,7 @@ describe('ChooseJobOptionPage.permittedRoles', () => {
       expect(ChooseJobOptionPage.permittedRoles).toContain(role)
     })
   })
-  ;[AGENT_ROLE].forEach((role) => {
+  ;[AGENT_ROLE, AUTHORISATION_MANAGER_ROLE].forEach((role) => {
     it(`does not permit the ${role} role to access the page`, () => {
       expect(ChooseJobOptionPage.permittedRoles).not.toContain(role)
     })

--- a/__test__/repairs/jobs/[id]/close-job.test.js
+++ b/__test__/repairs/jobs/[id]/close-job.test.js
@@ -3,6 +3,7 @@ import {
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 } from 'src/utils/user'
 
 describe('CloseJobPage.permittedRoles', () => {
@@ -11,7 +12,7 @@ describe('CloseJobPage.permittedRoles', () => {
       expect(CloseJobPage.permittedRoles).toContain(role)
     })
   })
-  ;[AGENT_ROLE].forEach((role) => {
+  ;[AGENT_ROLE, AUTHORISATION_MANAGER_ROLE].forEach((role) => {
     it(`does not permit the ${role} role to access the page`, () => {
       expect(CloseJobPage.permittedRoles).not.toContain(role)
     })

--- a/__test__/repairs/jobs/[id]/update-job.test.js
+++ b/__test__/repairs/jobs/[id]/update-job.test.js
@@ -1,6 +1,7 @@
 import UpdateJobPage from 'src/pages/repairs/jobs/[id]/update-job'
 import {
   AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
 } from 'src/utils/user'
@@ -11,7 +12,7 @@ describe('UpdateJobPage.permittedRoles', () => {
       expect(UpdateJobPage.permittedRoles).toContain(role)
     })
   })
-  ;[AGENT_ROLE].forEach((role) => {
+  ;[AGENT_ROLE, AUTHORISATION_MANAGER_ROLE].forEach((role) => {
     it(`does not permit the ${role} role to access the page`, () => {
       expect(UpdateJobPage.permittedRoles).not.toContain(role)
     })

--- a/__test__/work-orders/[id]/appointment/new.test.js
+++ b/__test__/work-orders/[id]/appointment/new.test.js
@@ -3,14 +3,17 @@ import {
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 } from 'src/utils/user'
 
 describe('AppointmentPage.permittedRoles', () => {
-  ;[AGENT_ROLE, CONTRACT_MANAGER_ROLE].forEach((role) => {
-    it(`permits the ${role} role to access the page`, () => {
-      expect(AppointmentPage.permittedRoles).toContain(role)
-    })
-  })
+  ;[AGENT_ROLE, CONTRACT_MANAGER_ROLE, AUTHORISATION_MANAGER_ROLE].forEach(
+    (role) => {
+      it(`permits the ${role} role to access the page`, () => {
+        expect(AppointmentPage.permittedRoles).toContain(role)
+      })
+    }
+  )
   ;[CONTRACTOR_ROLE].forEach((role) => {
     it(`does not permit the ${role} role to access the page`, () => {
       expect(AppointmentPage.permittedRoles).not.toContain(role)

--- a/__test__/work-orders/[id]/cancel.test.js
+++ b/__test__/work-orders/[id]/cancel.test.js
@@ -3,10 +3,11 @@ import {
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 } from 'src/utils/user'
 
 describe('CancelWorkOrderPage.permittedRoles', () => {
-  ;[AGENT_ROLE].forEach((role) => {
+  ;[AGENT_ROLE, AUTHORISATION_MANAGER_ROLE].forEach((role) => {
     it(`permits the ${role} role to access the page`, () => {
       expect(CancelWorkOrderPage.permittedRoles).toContain(role)
     })

--- a/__test__/work-orders/[id]/index.test.js
+++ b/__test__/work-orders/[id]/index.test.js
@@ -3,10 +3,16 @@ import {
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 } from 'src/utils/user'
 
 describe('WorkOrderPage.permittedRoles', () => {
-  ;[AGENT_ROLE, CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE].forEach((role) => {
+  ;[
+    AGENT_ROLE,
+    CONTRACTOR_ROLE,
+    CONTRACT_MANAGER_ROLE,
+    AUTHORISATION_MANAGER_ROLE,
+  ].forEach((role) => {
     it(`permits the ${role} role to access the page`, () => {
       expect(WorkOrderPage.permittedRoles).toContain(role)
     })

--- a/cypress/fixtures/repairs/work-order-pending-approval.json
+++ b/cypress/fixtures/repairs/work-order-pending-approval.json
@@ -7,7 +7,7 @@
   "owner": "",
   "description": "This is an urgent repair description",
   "propertyReference": "00012345",
-  "status": "Pending Approval",
+  "status": "Variation Pending Approval",
   "priorityCode": 2,
   "raisedBy": "Dummy Agent",
   "target": "2021-01-23T18:30:00.00000",

--- a/cypress/integration/jobs/job-authorisation.spec.js
+++ b/cypress/integration/jobs/job-authorisation.spec.js
@@ -20,8 +20,8 @@ describe('Contract manager can authorise variation', () => {
 
   it('Rejects job variation', () => {
     cy.visit(`${Cypress.env('HOST')}/work-orders/10000012`)
-    cy.contains('a', 'Update Works Order').click()
-    cy.contains('Authorisation request: 10000012')
+    cy.contains('a', 'Authorise Works Order').click()
+    cy.contains('Authorisation variation request: 10000012')
 
     // Throws an error when rejected without comments
     // Notes section appears when clicked "reject request"
@@ -50,8 +50,13 @@ describe('Contract manager can authorise variation', () => {
 
   it('Approves job variation', () => {
     cy.visit(`${Cypress.env('HOST')}/work-orders/10000012`)
-    cy.contains('a', 'Update Works Order').click()
-    cy.contains('Authorisation request: 10000012')
+    cy.contains('a', 'Authorise Works Order').click()
+    cy.contains('Authorisation variation request: 10000012')
+
+    cy.url().should(
+      'contains',
+      '/repairs/jobs/10000012/variation-authorisation'
+    )
 
     // When click approve default comments appear
     cy.get('[type="radio"]').check('Approve request')

--- a/cypress/integration/raise-repair/appointment-form.spec.js
+++ b/cypress/integration/raise-repair/appointment-form.spec.js
@@ -338,8 +338,16 @@ describe('Schedule appointment form', () => {
       })
 
       // shows that there are no available appointments
-
       cy.get('#no-appointment').contains('No available appointments')
+
+      // Link back to work order
+      cy.get('.govuk-list li').within(() => {
+        cy.contains('View work order').should(
+          'have.attr',
+          'href',
+          '/work-orders/10102030'
+        )
+      })
 
       // Run lighthouse audit for accessibility report
       cy.audit()

--- a/cypress/integration/raise-repair/e2e_flow.spec.js
+++ b/cypress/integration/raise-repair/e2e_flow.spec.js
@@ -178,13 +178,29 @@ describe('Schedule appointment form', () => {
         })
     })
 
-    //success form
-    cy.contains('Repair work order created')
-    cy.contains('Work order number')
-    cy.contains('10102030')
-    cy.contains('a', 'View work order')
-    cy.contains('a', 'Back to 16 Pitcairn House')
-    cy.contains('a', 'Start a new search')
+    // Confirmation screen
+    cy.get('.lbh-page-announcement').within(() => {
+      cy.get('.lbh-announcement__content').within(() => {
+        cy.get('h2').contains('Repair works order created')
+        cy.contains('Works order number')
+        cy.contains('10102030')
+      })
+    })
+
+    // Actions to see relevant pages
+    cy.get('.lbh-list li').within(() => {
+      cy.contains('View work order').should(
+        'have.attr',
+        'href',
+        '/work-orders/10102030'
+      )
+      cy.contains('Back to 16 Pitcairn House St Thomass Square').should(
+        'have.attr',
+        'href',
+        '/properties/00012345'
+      )
+      cy.contains('Start a new search').should('have.attr', 'href', '/')
+    })
 
     // Run lighthouse audit for accessibility report
     cy.audit()

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,7 @@ functions:
       AGENTS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/agents-group}
       CONTRACTORS_GOOGLE_GROUPNAME_REGEX: ${ssm:/repairs-hub/${self:provider.stage}/contractors-group-regex}
       CONTRACT_MANAGERS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/contract-managers-group}
+      AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME: ${ssm:/repairs-hub/${self:provider.stage}/authorisation-managers-group}
       REDIRECT_URL: ${ssm:/repairs-hub/${self:provider.stage}/redirect-url}
 
 resources:

--- a/src/components/SuccessPage/SuccessPage.js
+++ b/src/components/SuccessPage/SuccessPage.js
@@ -1,33 +1,75 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
+import WarningText from '../Template/WarningText'
 
-const SuccessPage = ({ workOrderReference, text }) => {
+const SuccessPage = ({ ...props }) => {
   return (
     <div>
-      <section className="lbh-page-announcement">
-        <div className="lbh-announcement__content">
-          <p>
-            {text} <strong>work order {workOrderReference}</strong>
-          </p>
-        </div>
+      <section className="text-align-center lbh-page-announcement">
+        {props.isRaiseRepairSuccess ? (
+          <div className="lbh-announcement__content">
+            <h2>{props.text}</h2>
+            <p>Works order number</p>
+            <strong className="govuk-!-font-size-24">
+              {props.workOrderReference}
+            </strong>
+          </div>
+        ) : (
+          <div className="lbh-announcement__content">
+            <p>
+              {props.text}{' '}
+              <strong>work order {props.workOrderReference}</strong>
+            </p>
+          </div>
+        )}
       </section>
 
-      <ul className="lbh-list lbh-!-margin-top-9">
-        <li>
-          <Link href={`/work-orders/${workOrderReference}`}>
-            <a>
-              <strong>View work order</strong>
-            </a>
-          </Link>
-        </li>
+      {props.authorisationPendingApproval && (
+        <WarningText
+          text={`Works order ${props.workOrderReference} requires authorisation. Please request authorisation from a manager.`}
+        />
+      )}
 
-        <li>
-          <Link href="/">
-            <a>
-              <strong>Back to dashboard</strong>
-            </a>
-          </Link>
-        </li>
+      <ul className="lbh-list lbh-!-margin-top-9">
+        {props.workOrderReference && (
+          <li>
+            <Link href={`/work-orders/${props.workOrderReference}`}>
+              <a>
+                <strong>View work order</strong>
+              </a>
+            </Link>
+          </li>
+        )}
+
+        {props.shortAddress && (
+          <li>
+            <Link href={`/properties/${props.propertyReference}`}>
+              <a>
+                <strong>Back to {props.shortAddress}</strong>
+              </a>
+            </Link>
+          </li>
+        )}
+
+        {props.showSearchLink && (
+          <li>
+            <Link href="/">
+              <a>
+                <strong>Start a new search</strong>
+              </a>
+            </Link>
+          </li>
+        )}
+
+        {props.showDashboardLink && (
+          <li>
+            <Link href="/">
+              <a>
+                <strong>Back to dashboard</strong>
+              </a>
+            </Link>
+          </li>
+        )}
       </ul>
     </div>
   )
@@ -36,6 +78,11 @@ const SuccessPage = ({ workOrderReference, text }) => {
 SuccessPage.propTypes = {
   workOrderReference: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
+  isRaiseRepairSuccess: PropTypes.bool,
+  showDashboardLink: PropTypes.bool,
+  shortAddress: PropTypes.string,
+  showSearchLink: PropTypes.bool,
+  authorisationPendingApproval: PropTypes.bool,
 }
 
 export default SuccessPage

--- a/src/components/SuccessPage/SuccessPage.test.js
+++ b/src/components/SuccessPage/SuccessPage.test.js
@@ -2,39 +2,81 @@ import { render } from '@testing-library/react'
 import SuccessPage from './SuccessPage'
 
 describe('SuccessPage component', () => {
-  describe('when variation approved', () => {
+  describe('Approving / Rejecting a work order', () => {
     const props = {
-      workOrder: {
-        reference: '10000012',
-      },
-      text: 'You have approved a variation for',
+      workOrderReference: '10000012',
+      showDashboardLink: true,
     }
-    it('should render properly with approved message', () => {
-      const { asFragment } = render(
-        <SuccessPage
-          workOrderReference={props.workOrder.reference}
-          text={props.text}
-        />
-      )
-      expect(asFragment()).toMatchSnapshot()
+
+    describe('when variation is approved', () => {
+      it('should render success screen with approved message', () => {
+        const { asFragment } = render(
+          <SuccessPage
+            workOrderReference={props.workOrderReference}
+            text="You have approved a variation for"
+            showDashboardLink={props.showDashboardLink}
+          />
+        )
+        expect(asFragment()).toMatchSnapshot()
+      })
+    })
+
+    describe('when variation is rejected', () => {
+      it('should render success screen with rejected message', () => {
+        const { asFragment } = render(
+          <SuccessPage
+            workOrderReference={props.workOrderReference}
+            text="You have rejected a variation for"
+            showDashboardLink={props.showDashboardLink}
+          />
+        )
+        expect(asFragment()).toMatchSnapshot()
+      })
     })
   })
 
-  describe('when variation approved', () => {
+  describe('Raising a repair', () => {
     const props = {
-      workOrder: {
-        reference: '10000012',
-      },
-      text: 'You have rejected a variation for',
+      workOrderReference: '10000012',
+      text: 'Repair works order created',
+      propertyReference: '12345678',
+      shortAddress: '12 Random Lane',
+      showSearchLink: true,
+      isRaiseRepairSuccess: true,
     }
-    it('should render properly with rejected message', () => {
-      const { asFragment } = render(
-        <SuccessPage
-          workOrderReference={props.workOrder.reference}
-          text={props.text}
-        />
-      )
-      expect(asFragment()).toMatchSnapshot()
+
+    describe('High cost (over raise limit) authorisation', () => {
+      it('should render a success screen with a warning message', () => {
+        const { asFragment } = render(
+          <SuccessPage
+            workOrderReference={props.workOrderReference}
+            text={props.text}
+            propertyReference={props.propertyReference}
+            shortAddress={props.shortAddress}
+            showSearchLink={props.showSearchLink}
+            isRaiseRepairSuccess={props.isRaiseRepairSuccess}
+            authorisationPendingApproval={true}
+          />
+        )
+        expect(asFragment()).toMatchSnapshot()
+      })
+    })
+
+    describe('Within raise limit', () => {
+      it('should render a success screen without a warning message', () => {
+        const { asFragment } = render(
+          <SuccessPage
+            workOrderReference={props.workOrderReference}
+            text={props.text}
+            propertyReference={props.propertyReference}
+            shortAddress={props.shortAddress}
+            showSearchLink={props.showSearchLink}
+            isRaiseRepairSuccess={props.isRaiseRepairSuccess}
+            authorisationPendingApproval={false}
+          />
+        )
+        expect(asFragment()).toMatchSnapshot()
+      })
     })
   })
 })

--- a/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
+++ b/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SuccessPage component when variation approved should render properly with approved message 1`] = `
+exports[`SuccessPage component Approving / Rejecting a work order when variation is approved should render success screen with approved message 1`] = `
 <DocumentFragment>
   <div>
     <section
-      class="lbh-page-announcement"
+      class="text-align-center lbh-page-announcement"
     >
       <div
         class="lbh-announcement__content"
@@ -43,11 +43,11 @@ exports[`SuccessPage component when variation approved should render properly wi
 </DocumentFragment>
 `;
 
-exports[`SuccessPage component when variation approved should render properly with rejected message 1`] = `
+exports[`SuccessPage component Approving / Rejecting a work order when variation is rejected should render success screen with rejected message 1`] = `
 <DocumentFragment>
   <div>
     <section
-      class="lbh-page-announcement"
+      class="text-align-center lbh-page-announcement"
     >
       <div
         class="lbh-announcement__content"
@@ -78,6 +78,140 @@ exports[`SuccessPage component when variation approved should render properly wi
         >
           <strong>
             Back to dashboard
+          </strong>
+        </a>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SuccessPage component Raising a repair High cost (over raise limit) authorisation should render a success screen with a warning message 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="text-align-center lbh-page-announcement"
+    >
+      <div
+        class="lbh-announcement__content"
+      >
+        <h2>
+          Repair works order created
+        </h2>
+        <p>
+          Works order number
+        </p>
+        <strong
+          class="govuk-!-font-size-24"
+        >
+          10000012
+        </strong>
+      </div>
+    </section>
+    <div
+      class="govuk-warning-text lbh-warning-text"
+    >
+      <span
+        aria-hidden="true"
+        class="govuk-warning-text__icon"
+      >
+        !
+      </span>
+      <strong
+        class="govuk-warning-text__text"
+      >
+        <span
+          class="govuk-warning-text__assistive"
+        >
+          Warning
+        </span>
+        Works order 10000012 requires authorisation. Please request authorisation from a manager.
+      </strong>
+    </div>
+    <ul
+      class="lbh-list lbh-!-margin-top-9"
+    >
+      <li>
+        <a
+          href="/work-orders/10000012"
+        >
+          <strong>
+            View work order
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/properties/12345678"
+        >
+          <strong>
+            Back to 12 Random Lane
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/"
+        >
+          <strong>
+            Start a new search
+          </strong>
+        </a>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SuccessPage component Raising a repair Within raise limit should render a success screen without a warning message 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="text-align-center lbh-page-announcement"
+    >
+      <div
+        class="lbh-announcement__content"
+      >
+        <h2>
+          Repair works order created
+        </h2>
+        <p>
+          Works order number
+        </p>
+        <strong
+          class="govuk-!-font-size-24"
+        >
+          10000012
+        </strong>
+      </div>
+    </section>
+    <ul
+      class="lbh-list lbh-!-margin-top-9"
+    >
+      <li>
+        <a
+          href="/work-orders/10000012"
+        >
+          <strong>
+            View work order
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/properties/12345678"
+        >
+          <strong>
+            Back to 12 Random Lane
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          href="/"
+        >
+          <strong>
+            Start a new search
           </strong>
         </a>
       </li>

--- a/src/components/WorkOrder/Appointment/AppointmentView.js
+++ b/src/components/WorkOrder/Appointment/AppointmentView.js
@@ -132,7 +132,9 @@ const AppointmentView = ({ workOrderReference }) => {
                 />
                 <RepairTasks tasks={tasksAndSors} />
                 {!availableAppointments.length ? (
-                  <NoAvailableAppointments />
+                  <NoAvailableAppointments
+                    workOrderReference={workOrderReference}
+                  />
                 ) : (
                   <AppointmentCalendar
                     availableAppointments={availableAppointments}

--- a/src/components/WorkOrder/Appointment/NoAvailableAppointments.js
+++ b/src/components/WorkOrder/Appointment/NoAvailableAppointments.js
@@ -1,4 +1,7 @@
-const NoAvailableAppointments = () => {
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+
+const NoAvailableAppointments = ({ workOrderReference }) => {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-full">
@@ -11,9 +14,22 @@ const NoAvailableAppointments = () => {
             Contractor should contact the resident to make the appointment.
           </p>
         </div>
+        <ul className="govuk-list govuk-!-margin-top-9">
+          <li>
+            <Link href={`/work-orders/${workOrderReference}`}>
+              <a>
+                <strong>View work order</strong>
+              </a>
+            </Link>
+          </li>
+        </ul>
       </div>
     </div>
   )
+}
+
+NoAvailableAppointments.propTypes = {
+  workOrderReference: PropTypes.string.isRequired,
 }
 
 export default NoAvailableAppointments

--- a/src/components/WorkOrder/AppointmentDetails.js
+++ b/src/components/WorkOrder/AppointmentDetails.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types'
 import UserContext from '../UserContext/UserContext'
 import Link from 'next/link'
 import { dateToStr } from '../../utils/date'
+import {
+  STATUS_CANCELLED,
+  STATUS_AUTHORISATION_PENDING_APPROVAL,
+} from '../../utils/status-codes'
 
 const AppointmentDetails = ({ workOrder }) => {
   const { user } = useContext(UserContext)
-  const STATUS_CANCELLED = 'Work Cancelled'
+
   if (workOrder.priorityCode > 1) {
     return (
       <div className="appointment-details">
@@ -14,8 +18,12 @@ const AppointmentDetails = ({ workOrder }) => {
         <br></br>
         <div className="govuk-body-s">
           {user &&
-            user.hasAgentPermissions &&
-            workOrder.status !== STATUS_CANCELLED &&
+            (user.hasAgentPermissions ||
+              user.hasContractManagerPermissions ||
+              user.hasAuthorisationManagerPermissions) &&
+            workOrder.status !== STATUS_CANCELLED.description &&
+            workOrder.status !==
+              STATUS_AUTHORISATION_PENDING_APPROVAL.description &&
             !workOrder.appointment && (
               <Link
                 href={`/work-orders/${workOrder.reference}/appointment/new`}

--- a/src/components/WorkOrder/WorkOrderDetails.js
+++ b/src/components/WorkOrder/WorkOrderDetails.js
@@ -4,6 +4,11 @@ import UserContext from '../UserContext/UserContext'
 import WorkOrderHeader from './WorkOrderHeader'
 import BackButton from '../Layout/BackButton/BackButton'
 import Link from 'next/link'
+import {
+  STATUS_CANCELLED,
+  STATUS_VARIATION_PENDING_APPROVAL,
+  STATUS_AUTHORISATION_PENDING_APPROVAL,
+} from '../../utils/status-codes'
 
 const WorkOrderDetails = ({
   propertyReference,
@@ -16,8 +21,6 @@ const WorkOrderDetails = ({
   canRaiseRepair,
 }) => {
   const { user } = useContext(UserContext)
-  const STATUS_CANCELLED = 'Work Cancelled'
-  const STATUS_PENDING_APPROVAL = 'Pending Approval'
 
   return (
     <div>
@@ -26,21 +29,36 @@ const WorkOrderDetails = ({
         <h1 className="lbh-heading-l display-inline govuk-!-margin-right-6">
           Works order: {workOrder.reference}
         </h1>
-        {user && user.hasContractorPermissions && (
-          <Link href={`/repairs/jobs/${workOrder.reference}/choose-option`}>
-            <a className="govuk-body-m">Update Works Order</a>
-          </Link>
-        )}
         {user &&
-          user.hasContractManagerPermissions &&
-          workOrder.status == STATUS_PENDING_APPROVAL && (
-            <Link href={`/repairs/jobs/${workOrder.reference}/authorisation`}>
+          (user.hasContractorPermissions ||
+            user.hasContractManagerPermissions) && (
+            <Link href={`/repairs/jobs/${workOrder.reference}/choose-option`}>
               <a className="govuk-body-m">Update Works Order</a>
             </Link>
           )}
         {user &&
-          user.hasAgentPermissions &&
-          workOrder.status !== STATUS_CANCELLED && (
+          user.hasContractManagerPermissions &&
+          workOrder.status ===
+            STATUS_VARIATION_PENDING_APPROVAL.description && (
+            <Link
+              href={`/repairs/jobs/${workOrder.reference}/variation-authorisation`}
+            >
+              <a className="govuk-body-m">Authorise Works Order Variation</a>
+            </Link>
+          )}
+        {user &&
+          user.hasAuthorisationManagerPermissions &&
+          workOrder.status ===
+            STATUS_AUTHORISATION_PENDING_APPROVAL.description && (
+            <Link href={`/repairs/jobs/${workOrder.reference}/authorisation`}>
+              <a className="govuk-body-m">Authorise Works Order</a>
+            </Link>
+          )}
+        {user &&
+          (user.hasAgentPermissions ||
+            user.hasAuthorisationManagerPermissions ||
+            user.hasContractManagerPermissions) &&
+          workOrder.status !== STATUS_CANCELLED.description && (
             <Link href={`/work-orders/${workOrder.reference}/cancel`}>
               <a className="govuk-body-m">Cancel Works Order</a>
             </Link>

--- a/src/components/WorkOrder/WorkOrderDetails.test.js
+++ b/src/components/WorkOrder/WorkOrderDetails.test.js
@@ -123,8 +123,8 @@ describe('WorkOrderDetails component', () => {
 
   describe('when logged in as a contract manager', () => {
     const user = {
-      name: 'A Contractor',
-      email: 'a.contractor@hackney.gov.uk',
+      name: 'A Contract Manager',
+      email: 'a.contract-manager@hackney.gov.uk',
       hasRole: true,
       hasAgentPermissions: false,
       hasContractorPermissions: false,
@@ -132,7 +132,7 @@ describe('WorkOrderDetails component', () => {
       hasAnyPermissions: true,
     }
 
-    it('should render properly without a link to cancel work order', () => {
+    it('should render properly with a link to cancel work order', () => {
       const { asFragment } = render(
         <UserContext.Provider value={{ user }}>
           <WorkOrderDetails
@@ -151,9 +151,9 @@ describe('WorkOrderDetails component', () => {
       expect(asFragment()).toMatchSnapshot()
     })
 
-    it('should render properly with a link to update work order', () => {
-      // Work order status is Pending Approval
-      props.workOrder.status = 'Pending Approval'
+    it('should render with a link to authorise a variation request when status is variation pending approval', () => {
+      // Work order status is Variation Pending Approval
+      props.workOrder.status = 'Variation Pending Approval'
       const { asFragment } = render(
         <UserContext.Provider value={{ user }}>
           <WorkOrderDetails
@@ -172,7 +172,81 @@ describe('WorkOrderDetails component', () => {
       expect(asFragment()).toMatchSnapshot()
     })
 
-    it('should render properly without a link to update work order', () => {
+    it('should render without a link to authorise a variation request when status is not variation pending approval', () => {
+      // Work order status is In Progress
+      props.workOrder.status = 'In Progress'
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrderDetails
+            propertyReference={props.property.propertyReference}
+            workOrder={props.workOrder}
+            address={props.property.address}
+            subTypeDescription={props.property.hierarchyType.subTypeDescription}
+            tenure={props.tenure}
+            locationAlerts={props.alerts.locationAlert}
+            personAlerts={props.alerts.personAlert}
+            hasLinkToProperty={true}
+            canRaiseRepair={props.property.canRaiseRepair}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when logged in as an authorisation manager', () => {
+    const user = {
+      name: 'An authorisation manager',
+      email: 'an.authorisation-manager@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: false,
+      hasContractManagerPermissions: false,
+      hasAuthorisationManagerPermissions: true,
+      hasAnyPermissions: true,
+    }
+
+    it('should render properly with a link to cancel work order', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrderDetails
+            propertyReference={props.property.propertyReference}
+            workOrder={props.workOrder}
+            address={props.property.address}
+            subTypeDescription={props.property.hierarchyType.subTypeDescription}
+            tenure={props.tenure}
+            locationAlerts={props.alerts.locationAlert}
+            personAlerts={props.alerts.personAlert}
+            hasLinkToProperty={true}
+            canRaiseRepair={props.property.canRaiseRepair}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+
+    it('should render with a link to authorise a new work order when status is authorisation pending approval', () => {
+      // Work order status is Authorisation Pending Approval
+      props.workOrder.status = 'Authorisation Pending Approval'
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrderDetails
+            propertyReference={props.property.propertyReference}
+            workOrder={props.workOrder}
+            address={props.property.address}
+            subTypeDescription={props.property.hierarchyType.subTypeDescription}
+            tenure={props.tenure}
+            locationAlerts={props.alerts.locationAlert}
+            personAlerts={props.alerts.personAlert}
+            hasLinkToProperty={true}
+            canRaiseRepair={props.property.canRaiseRepair}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+
+    it('should render without a link to authorise a new work order when status is not authorisation pending approval', () => {
       // Work order status is In Progress
       props.workOrder.status = 'In Progress'
       const { asFragment } = render(

--- a/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderDetails.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WorkOrderDetails component when logged in as a contract manager should render properly with a link to update work order 1`] = `
+exports[`WorkOrderDetails component when logged in as a contract manager should render properly with a link to cancel work order 1`] = `
 <DocumentFragment>
   <div>
     <a
@@ -17,9 +17,15 @@ exports[`WorkOrderDetails component when logged in as a contract manager should 
       </h1>
       <a
         class="govuk-body-m"
-        href="/repairs/jobs/10000012/authorisation"
+        href="/repairs/jobs/10000012/choose-option"
       >
         Update Works Order
+      </a>
+      <a
+        class="govuk-body-m"
+        href="/work-orders/10000012/cancel"
+      >
+        Cancel Works Order
       </a>
     </div>
     <p
@@ -105,7 +111,7 @@ exports[`WorkOrderDetails component when logged in as a contract manager should 
             <span
               class="govuk-!-font-weight-bold"
             >
-              Status: Pending Approval
+              Status: In Progress
             </span>
             <br />
             <span
@@ -161,7 +167,14 @@ exports[`WorkOrderDetails component when logged in as a contract manager should 
           <br />
           <div
             class="govuk-body-s"
-          />
+          >
+            <a
+              class="govuk-!-font-weight-bold"
+              href="/work-orders/10000012/appointment/new"
+            >
+              Schedule an appointment
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -169,7 +182,7 @@ exports[`WorkOrderDetails component when logged in as a contract manager should 
 </DocumentFragment>
 `;
 
-exports[`WorkOrderDetails component when logged in as a contract manager should render properly without a link to cancel work order 1`] = `
+exports[`WorkOrderDetails component when logged in as a contract manager should render with a link to authorise a variation request when status is variation pending approval 1`] = `
 <DocumentFragment>
   <div>
     <a
@@ -184,6 +197,206 @@ exports[`WorkOrderDetails component when logged in as a contract manager should 
       >
         Works order: 10000012
       </h1>
+      <a
+        class="govuk-body-m"
+        href="/repairs/jobs/10000012/choose-option"
+      >
+        Update Works Order
+      </a>
+      <a
+        class="govuk-body-m"
+        href="/repairs/jobs/10000012/variation-authorisation"
+      >
+        Authorise Works Order Variation
+      </a>
+      <a
+        class="govuk-body-m"
+        href="/work-orders/10000012/cancel"
+      >
+        Cancel Works Order
+      </a>
+    </div>
+    <p
+      class="govuk-body-m"
+    >
+      This is an urgent repair description
+    </p>
+    <div
+      class="govuk-body-s govuk-grid-row"
+    >
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="property-details-main-section"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Dwelling
+          </span>
+          <br />
+          <a
+            href="/properties/00012345"
+          >
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
+            >
+              16 Pitcairn House
+              <br />
+              St Thomass Square
+              <br />
+              <span
+                class="govuk-!-font-size-14"
+              >
+                E9 6PT
+              </span>
+            </div>
+          </a>
+        </div>
+        <ul
+          class="hackney-property-alerts"
+        >
+          <li
+            class="bg-turquoise"
+          >
+            Tenure: Secure
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Address Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Contact Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="work-order-info"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Works order
+          </span>
+          <div
+            class="govuk-body-s govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Status: Variation Pending Approval
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-size-14"
+            >
+              Priority: U - Urgent (5 Working days)
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Raised by Dummy Agent
+            </span>
+            <br />
+            <span>
+              18 Jan 2021, 3:28 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Target: 23 Jan 2021, 6:30 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Caller: Jill Smith
+            </span>
+            <br />
+            <span>
+              07700 900999
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="appointment-details"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Appointment details
+          </span>
+          <br />
+          <div
+            class="govuk-body-s"
+          >
+            <a
+              class="govuk-!-font-weight-bold"
+              href="/work-orders/10000012/appointment/new"
+            >
+              Schedule an appointment
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WorkOrderDetails component when logged in as a contract manager should render without a link to authorise a variation request when status is not variation pending approval 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link lbh-back-link"
+      role="button"
+    >
+      Back
+    </a>
+    <div>
+      <h1
+        class="lbh-heading-l display-inline govuk-!-margin-right-6"
+      >
+        Works order: 10000012
+      </h1>
+      <a
+        class="govuk-body-m"
+        href="/repairs/jobs/10000012/choose-option"
+      >
+        Update Works Order
+      </a>
+      <a
+        class="govuk-body-m"
+        href="/work-orders/10000012/cancel"
+      >
+        Cancel Works Order
+      </a>
     </div>
     <p
       class="govuk-body-m"
@@ -324,170 +537,14 @@ exports[`WorkOrderDetails component when logged in as a contract manager should 
           <br />
           <div
             class="govuk-body-s"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`WorkOrderDetails component when logged in as a contract manager should render properly without a link to update work order 1`] = `
-<DocumentFragment>
-  <div>
-    <a
-      class="govuk-back-link lbh-back-link"
-      role="button"
-    >
-      Back
-    </a>
-    <div>
-      <h1
-        class="lbh-heading-l display-inline govuk-!-margin-right-6"
-      >
-        Works order: 10000012
-      </h1>
-    </div>
-    <p
-      class="govuk-body-m"
-    >
-      This is an urgent repair description
-    </p>
-    <div
-      class="govuk-body-s govuk-grid-row"
-    >
-      <div
-        class="govuk-grid-column-one-third"
-      >
-        <div
-          class="property-details-main-section"
-        >
-          <span
-            class="govuk-!-font-size-14"
           >
-            Dwelling
-          </span>
-          <br />
-          <a
-            href="/properties/00012345"
-          >
-            <div
-              class="text-!-green govuk-!-font-weight-bold"
-            >
-              16 Pitcairn House
-              <br />
-              St Thomass Square
-              <br />
-              <span
-                class="govuk-!-font-size-14"
-              >
-                E9 6PT
-              </span>
-            </div>
-          </a>
-        </div>
-        <ul
-          class="hackney-property-alerts"
-        >
-          <li
-            class="bg-turquoise"
-          >
-            Tenure: Secure
-          </li>
-          <li
-            class="bg-orange"
-          >
-            Address Alert: Property Under Disrepair (
-            <strong>
-              DIS
-            </strong>
-            )
-          </li>
-          <li
-            class="bg-orange"
-          >
-            Contact Alert: Property Under Disrepair (
-            <strong>
-              DIS
-            </strong>
-            )
-          </li>
-        </ul>
-      </div>
-      <div
-        class="govuk-grid-column-one-third"
-      >
-        <div
-          class="work-order-info"
-        >
-          <span
-            class="govuk-!-font-size-14"
-          >
-            Works order
-          </span>
-          <div
-            class="govuk-body-s govuk-!-margin-bottom-2"
-          >
-            <span
+            <a
               class="govuk-!-font-weight-bold"
+              href="/work-orders/10000012/appointment/new"
             >
-              Status: In Progress
-            </span>
-            <br />
-            <span
-              class="govuk-!-font-size-14"
-            >
-              Priority: U - Urgent (5 Working days)
-            </span>
+              Schedule an appointment
+            </a>
           </div>
-          <div
-            class="govuk-body-xs govuk-!-margin-bottom-2"
-          >
-            <span>
-              Raised by Dummy Agent
-            </span>
-            <br />
-            <span>
-              18 Jan 2021, 3:28 pm
-            </span>
-          </div>
-          <div
-            class="govuk-body-xs govuk-!-margin-bottom-2"
-          >
-            <span
-              class="govuk-!-font-weight-bold"
-            >
-              Target: 23 Jan 2021, 6:30 pm
-            </span>
-          </div>
-          <div
-            class="govuk-body-xs govuk-!-margin-bottom-2"
-          >
-            <span>
-              Caller: Jill Smith
-            </span>
-            <br />
-            <span>
-              07700 900999
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="govuk-grid-column-one-third"
-      >
-        <div
-          class="appointment-details"
-        >
-          <span
-            class="govuk-!-font-size-14"
-          >
-            Appointment details
-          </span>
-          <br />
-          <div
-            class="govuk-body-s"
-          />
         </div>
       </div>
     </div>
@@ -665,6 +722,533 @@ exports[`WorkOrderDetails component when logged in as a contractor should render
 `;
 
 exports[`WorkOrderDetails component when logged in as an agent should render properly with a link to cancel work order 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link lbh-back-link"
+      role="button"
+    >
+      Back
+    </a>
+    <div>
+      <h1
+        class="lbh-heading-l display-inline govuk-!-margin-right-6"
+      >
+        Works order: 10000012
+      </h1>
+      <a
+        class="govuk-body-m"
+        href="/work-orders/10000012/cancel"
+      >
+        Cancel Works Order
+      </a>
+    </div>
+    <p
+      class="govuk-body-m"
+    >
+      This is an urgent repair description
+    </p>
+    <div
+      class="govuk-body-s govuk-grid-row"
+    >
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="property-details-main-section"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Dwelling
+          </span>
+          <br />
+          <a
+            href="/properties/00012345"
+          >
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
+            >
+              16 Pitcairn House
+              <br />
+              St Thomass Square
+              <br />
+              <span
+                class="govuk-!-font-size-14"
+              >
+                E9 6PT
+              </span>
+            </div>
+          </a>
+        </div>
+        <ul
+          class="hackney-property-alerts"
+        >
+          <li
+            class="bg-turquoise"
+          >
+            Tenure: Secure
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Address Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Contact Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="work-order-info"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Works order
+          </span>
+          <div
+            class="govuk-body-s govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Status: In Progress
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-size-14"
+            >
+              Priority: U - Urgent (5 Working days)
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Raised by Dummy Agent
+            </span>
+            <br />
+            <span>
+              18 Jan 2021, 3:28 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Target: 23 Jan 2021, 6:30 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Caller: Jill Smith
+            </span>
+            <br />
+            <span>
+              07700 900999
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="appointment-details"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Appointment details
+          </span>
+          <br />
+          <div
+            class="govuk-body-s"
+          >
+            <a
+              class="govuk-!-font-weight-bold"
+              href="/work-orders/10000012/appointment/new"
+            >
+              Schedule an appointment
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WorkOrderDetails component when logged in as an authorisation manager should render properly with a link to cancel work order 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link lbh-back-link"
+      role="button"
+    >
+      Back
+    </a>
+    <div>
+      <h1
+        class="lbh-heading-l display-inline govuk-!-margin-right-6"
+      >
+        Works order: 10000012
+      </h1>
+      <a
+        class="govuk-body-m"
+        href="/work-orders/10000012/cancel"
+      >
+        Cancel Works Order
+      </a>
+    </div>
+    <p
+      class="govuk-body-m"
+    >
+      This is an urgent repair description
+    </p>
+    <div
+      class="govuk-body-s govuk-grid-row"
+    >
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="property-details-main-section"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Dwelling
+          </span>
+          <br />
+          <a
+            href="/properties/00012345"
+          >
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
+            >
+              16 Pitcairn House
+              <br />
+              St Thomass Square
+              <br />
+              <span
+                class="govuk-!-font-size-14"
+              >
+                E9 6PT
+              </span>
+            </div>
+          </a>
+        </div>
+        <ul
+          class="hackney-property-alerts"
+        >
+          <li
+            class="bg-turquoise"
+          >
+            Tenure: Secure
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Address Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Contact Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="work-order-info"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Works order
+          </span>
+          <div
+            class="govuk-body-s govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Status: In Progress
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-size-14"
+            >
+              Priority: U - Urgent (5 Working days)
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Raised by Dummy Agent
+            </span>
+            <br />
+            <span>
+              18 Jan 2021, 3:28 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Target: 23 Jan 2021, 6:30 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Caller: Jill Smith
+            </span>
+            <br />
+            <span>
+              07700 900999
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="appointment-details"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Appointment details
+          </span>
+          <br />
+          <div
+            class="govuk-body-s"
+          >
+            <a
+              class="govuk-!-font-weight-bold"
+              href="/work-orders/10000012/appointment/new"
+            >
+              Schedule an appointment
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WorkOrderDetails component when logged in as an authorisation manager should render with a link to authorise a new work order when status is authorisation pending approval 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link lbh-back-link"
+      role="button"
+    >
+      Back
+    </a>
+    <div>
+      <h1
+        class="lbh-heading-l display-inline govuk-!-margin-right-6"
+      >
+        Works order: 10000012
+      </h1>
+      <a
+        class="govuk-body-m"
+        href="/repairs/jobs/10000012/authorisation"
+      >
+        Authorise Works Order
+      </a>
+      <a
+        class="govuk-body-m"
+        href="/work-orders/10000012/cancel"
+      >
+        Cancel Works Order
+      </a>
+    </div>
+    <p
+      class="govuk-body-m"
+    >
+      This is an urgent repair description
+    </p>
+    <div
+      class="govuk-body-s govuk-grid-row"
+    >
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="property-details-main-section"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Dwelling
+          </span>
+          <br />
+          <a
+            href="/properties/00012345"
+          >
+            <div
+              class="text-!-green govuk-!-font-weight-bold"
+            >
+              16 Pitcairn House
+              <br />
+              St Thomass Square
+              <br />
+              <span
+                class="govuk-!-font-size-14"
+              >
+                E9 6PT
+              </span>
+            </div>
+          </a>
+        </div>
+        <ul
+          class="hackney-property-alerts"
+        >
+          <li
+            class="bg-turquoise"
+          >
+            Tenure: Secure
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Address Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+          <li
+            class="bg-orange"
+          >
+            Contact Alert: Property Under Disrepair (
+            <strong>
+              DIS
+            </strong>
+            )
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="work-order-info"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Works order
+          </span>
+          <div
+            class="govuk-body-s govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Status: Authorisation Pending Approval
+            </span>
+            <br />
+            <span
+              class="govuk-!-font-size-14"
+            >
+              Priority: U - Urgent (5 Working days)
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Raised by Dummy Agent
+            </span>
+            <br />
+            <span>
+              18 Jan 2021, 3:28 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span
+              class="govuk-!-font-weight-bold"
+            >
+              Target: 23 Jan 2021, 6:30 pm
+            </span>
+          </div>
+          <div
+            class="govuk-body-xs govuk-!-margin-bottom-2"
+          >
+            <span>
+              Caller: Jill Smith
+            </span>
+            <br />
+            <span>
+              07700 900999
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-grid-column-one-third"
+      >
+        <div
+          class="appointment-details"
+        >
+          <span
+            class="govuk-!-font-size-14"
+          >
+            Appointment details
+          </span>
+          <br />
+          <div
+            class="govuk-body-s"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WorkOrderDetails component when logged in as an authorisation manager should render without a link to authorise a new work order when status is not authorisation pending approval 1`] = `
 <DocumentFragment>
   <div>
     <a

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import UserContext from '../components/UserContext/UserContext'
 import { useContext } from 'react'
 import {
   AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
 } from '../utils/user'
@@ -19,7 +20,15 @@ const Home = ({ query }) => {
     }
   } else {
     if (Object.entries(query).length === 0) {
-      return <JobView pageNumber={1} />
+      if (user.hasAuthorisationManagerPermissions) {
+        // Default filter selected for Authorisation Pending Approval work orders
+        return <JobView pageNumber={1} query={{ StatusCode: '1010' }} />
+      } else if (user.hasContractorManagerPermissions) {
+        // Default filter selected for Variation Pending Approval work orders
+        return <JobView pageNumber={1} query={{ StatusCode: '90' }} />
+      } else {
+        return <JobView pageNumber={1} />
+      }
     } else {
       return <JobView query={query} />
     }
@@ -36,6 +45,11 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-Home.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE]
+Home.permittedRoles = [
+  AGENT_ROLE,
+  CONTRACTOR_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+]
 
 export default Home

--- a/src/pages/logout.js
+++ b/src/pages/logout.js
@@ -1,6 +1,7 @@
 import { deleteSession } from '../utils/GoogleAuth'
 import {
   AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
 } from '../utils/user'
@@ -12,6 +13,11 @@ export const getServerSideProps = async ({ res }) => {
   return { props: {} }
 }
 
-Logout.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE]
+Logout.permittedRoles = [
+  AGENT_ROLE,
+  CONTRACTOR_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+]
 
 export default Logout

--- a/src/pages/properties/[id]/index.js
+++ b/src/pages/properties/[id]/index.js
@@ -1,5 +1,9 @@
 import PropertyView from '../../../components/Property/PropertyView'
-import { AGENT_ROLE, CONTRACT_MANAGER_ROLE } from '../../../utils/user'
+import {
+  AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+  CONTRACT_MANAGER_ROLE,
+} from '../../../utils/user'
 
 const PropertyPage = ({ query }) => {
   return <PropertyView propertyReference={query.id} />
@@ -15,6 +19,10 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-PropertyPage.permittedRoles = [AGENT_ROLE, CONTRACT_MANAGER_ROLE]
+PropertyPage.permittedRoles = [
+  AGENT_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+]
 
 export default PropertyPage

--- a/src/pages/repairs/jobs/[id]/authorisation.js
+++ b/src/pages/repairs/jobs/[id]/authorisation.js
@@ -1,4 +1,4 @@
-import { CONTRACT_MANAGER_ROLE } from '../../../../utils/user'
+import { AUTHORISATION_MANAGER_ROLE } from '../../../../utils/user'
 import AuthorisationView from '../../../../components/WorkOrder/Authorisation/AuthorisationView'
 
 const AuthorisationPage = ({ query }) => {
@@ -14,6 +14,6 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-AuthorisationPage.permittedRoles = [CONTRACT_MANAGER_ROLE]
+AuthorisationPage.permittedRoles = [AUTHORISATION_MANAGER_ROLE]
 
 export default AuthorisationPage

--- a/src/pages/repairs/jobs/[id]/variation-authorisation.js
+++ b/src/pages/repairs/jobs/[id]/variation-authorisation.js
@@ -1,0 +1,19 @@
+import { CONTRACT_MANAGER_ROLE } from '../../../../utils/user'
+import VariationAuthorisationView from '../../../../components/WorkOrder/Authorisation/VariationAuthorisationView'
+
+const VariationAuthorisationPage = ({ query }) => {
+  return <VariationAuthorisationView workOrderReference={query.id} />
+}
+export const getServerSideProps = async (ctx) => {
+  const { query } = ctx
+
+  return {
+    props: {
+      query,
+    },
+  }
+}
+
+VariationAuthorisationPage.permittedRoles = [CONTRACT_MANAGER_ROLE]
+
+export default VariationAuthorisationPage

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,6 +1,7 @@
 import Search from '../components/Search/Search'
 import {
   AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
 } from '../utils/user'
@@ -23,6 +24,11 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-SearchPage.permittedRoles = [AGENT_ROLE, CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE]
+SearchPage.permittedRoles = [
+  AGENT_ROLE,
+  CONTRACTOR_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+]
 
 export default SearchPage

--- a/src/pages/work-orders/[id]/appointment/new.js
+++ b/src/pages/work-orders/[id]/appointment/new.js
@@ -1,4 +1,8 @@
-import { AGENT_ROLE, CONTRACT_MANAGER_ROLE } from 'src/utils/user'
+import {
+  AGENT_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+} from 'src/utils/user'
 import AppointmentView from '../../../../components/WorkOrder/Appointment/AppointmentView'
 
 const AppointmentPage = ({ query }) => {
@@ -14,6 +18,10 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-AppointmentPage.permittedRoles = [AGENT_ROLE, CONTRACT_MANAGER_ROLE]
+AppointmentPage.permittedRoles = [
+  AGENT_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+]
 
 export default AppointmentPage

--- a/src/pages/work-orders/[id]/cancel.js
+++ b/src/pages/work-orders/[id]/cancel.js
@@ -1,5 +1,5 @@
 import CancelWorkOrderView from '../../../components/WorkOrder/CancelWorkOrder/CancelWorkOrderView'
-import { AGENT_ROLE } from '../../../utils/user'
+import { AGENT_ROLE, AUTHORISATION_MANAGER_ROLE } from '../../../utils/user'
 
 const CancelWorkOrderPage = ({ query }) => {
   return <CancelWorkOrderView workOrderReference={query.id} />
@@ -15,6 +15,6 @@ export const getServerSideProps = async (ctx) => {
   }
 }
 
-CancelWorkOrderPage.permittedRoles = [AGENT_ROLE]
+CancelWorkOrderPage.permittedRoles = [AGENT_ROLE, AUTHORISATION_MANAGER_ROLE]
 
 export default CancelWorkOrderPage

--- a/src/pages/work-orders/[id]/index.js
+++ b/src/pages/work-orders/[id]/index.js
@@ -3,6 +3,7 @@ import {
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 } from '../../../utils/user'
 
 const WorkOrderPage = ({ query }) => {
@@ -23,6 +24,7 @@ WorkOrderPage.permittedRoles = [
   AGENT_ROLE,
   CONTRACTOR_ROLE,
   CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
 ]
 
 export default WorkOrderPage

--- a/src/styles/components/work-orders.scss
+++ b/src/styles/components/work-orders.scss
@@ -49,6 +49,14 @@
     .status-pending-approval {
       background-color: repairs-hub-colour('status-waiting');
     }
+    .status-variation-pending-approval {
+      background-color: repairs-hub-colour('status-waiting');
+      white-space: normal;
+    }
+    .status-authorisation-pending-approval {
+      background-color: repairs-hub-colour('status-waiting');
+      white-space: normal;
+    }
     .status-variation-approved {
       background-color: repairs-hub-colour('status-approved');
     }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -17,6 +17,10 @@
   display: inline;
 }
 
+.text-align-center {
+  text-align: center;
+}
+
 .min-height-100 {
   min-height: 100px;
 }

--- a/src/utils/hact/job-status-update/authorisation.js
+++ b/src/utils/hact/job-status-update/authorisation.js
@@ -1,12 +1,37 @@
-export const buildAuthorisationApprovedFormData = (workOrderReference) => {
+export const buildVariationAuthorisationApprovedFormData = (
+  workOrderReference
+) => {
   return {
     relatedWorkOrderReference: {
       id: workOrderReference,
     },
     // 100-20 Additional work approved by operative.
     // Additional work approved: the additional work required has been approved by the supervisor/repairs team
-
     typeCode: '100-20',
+  }
+}
+
+export const buildVariationAuthorisationRejectedFormData = (
+  formData,
+  workOrderReference
+) => {
+  return {
+    relatedWorkOrderReference: {
+      id: workOrderReference,
+    },
+    comments: `Variation rejected: ${formData.note}`,
+    // Custom code 125 for variation rejected
+    typeCode: '125',
+  }
+}
+
+export const buildAuthorisationApprovedFormData = (workOrderReference) => {
+  return {
+    relatedWorkOrderReference: {
+      id: workOrderReference,
+    },
+    // Custom code 23 for authorisation approved
+    typeCode: '23',
   }
 }
 
@@ -18,10 +43,8 @@ export const buildAuthorisationRejectedFormData = (
     relatedWorkOrderReference: {
       id: workOrderReference,
     },
-    comments: `Variation rejected: ${formData.note}`,
-
-    //custome code for variation rejected is 125
-
-    typeCode: '125',
+    comments: `Authorisation rejected: ${formData.note}`,
+    // Custom code 22 for authorisation rejected
+    typeCode: '22',
   }
 }

--- a/src/utils/hact/job-status-update/authorisation.test.js
+++ b/src/utils/hact/job-status-update/authorisation.test.js
@@ -1,43 +1,89 @@
 import {
+  buildVariationAuthorisationApprovedFormData,
+  buildVariationAuthorisationRejectedFormData,
   buildAuthorisationApprovedFormData,
   buildAuthorisationRejectedFormData,
 } from './authorisation'
 
-describe('buildAuthorisationApprovedFormData', () => {
-  const workOrderReference = '00012345'
-  it('builds the UpdateJob form data to post to the Repairs API', () => {
-    const authorisationJobFormData = {
-      relatedWorkOrderReference: {
-        id: '00012345',
-      },
-      typeCode: '100-20',
-    }
+const workOrderReference = '00012345'
 
-    const response = buildAuthorisationApprovedFormData(workOrderReference)
+describe('Authorisation for a variation request', () => {
+  describe('buildVariationAuthorisationApprovedFormData', () => {
+    it('builds the UpdateJob form data to post to the Repairs API', () => {
+      const authorisationJobFormData = {
+        relatedWorkOrderReference: {
+          id: '00012345',
+        },
+        typeCode: '100-20',
+      }
 
-    expect(response).toEqual(authorisationJobFormData)
+      const response = buildVariationAuthorisationApprovedFormData(
+        workOrderReference
+      )
+
+      expect(response).toEqual(authorisationJobFormData)
+    })
+  })
+
+  describe('buildVariationAuthorisationRejectedFormData', () => {
+    it('builds the UpdateJob form data to post to the Repairs API', () => {
+      const formData = {
+        note: 'Can not approve it',
+      }
+      const authorisationJobFormData = {
+        relatedWorkOrderReference: {
+          id: '00012345',
+        },
+        comments: 'Variation rejected: Can not approve it',
+        typeCode: '125',
+      }
+
+      const response = buildVariationAuthorisationRejectedFormData(
+        formData,
+        workOrderReference
+      )
+
+      expect(response).toEqual(authorisationJobFormData)
+    })
   })
 })
 
-describe('buildAuthorisationRejectedFormData', () => {
-  const workOrderReference = '00012345'
-  const formData = {
-    note: 'Can not approve it',
-  }
-  it('builds the UpdateJob form data to post to the Repairs API', () => {
-    const authorisationJobFormData = {
-      relatedWorkOrderReference: {
-        id: '00012345',
-      },
-      comments: 'Variation rejected: Can not approve it',
-      typeCode: '125',
+describe('Authorisation for a new work order', () => {
+  describe('buildAuthorisationApprovedFormData', () => {
+    it('builds the approved authorisation request for the JobStatusUpdate endpoint in the Repairs API', () => {
+      const authorisationJobFormData = {
+        relatedWorkOrderReference: {
+          id: '00012345',
+        },
+        typeCode: '23',
+      }
+
+      const response = buildAuthorisationApprovedFormData(workOrderReference)
+
+      expect(response).toEqual(authorisationJobFormData)
+    })
+  })
+
+  describe('buildAuthorisationRejectedFormData', () => {
+    const formData = {
+      note: 'This is far too expensive!',
     }
 
-    const response = buildAuthorisationRejectedFormData(
-      formData,
-      workOrderReference
-    )
+    it('builds the approved authorisation request for the JobStatusUpdate endpoint in the Repairs API', () => {
+      const authorisationJobFormData = {
+        relatedWorkOrderReference: {
+          id: '00012345',
+        },
+        comments: 'Authorisation rejected: This is far too expensive!',
+        typeCode: '22',
+      }
 
-    expect(response).toEqual(authorisationJobFormData)
+      const response = buildAuthorisationRejectedFormData(
+        formData,
+        workOrderReference
+      )
+
+      expect(response).toEqual(authorisationJobFormData)
+    })
   })
 })

--- a/src/utils/status-codes.js
+++ b/src/utils/status-codes.js
@@ -1,0 +1,14 @@
+export const STATUS_AUTHORISATION_PENDING_APPROVAL = {
+  code: 1010,
+  description: 'Authorisation Pending Approval',
+}
+
+export const STATUS_CANCELLED = {
+  code: 30,
+  description: 'Work Cancelled',
+}
+
+export const STATUS_VARIATION_PENDING_APPROVAL = {
+  code: 90,
+  description: 'Variation Pending Approval',
+}

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -1,11 +1,13 @@
 export const AGENT_ROLE = 'agent'
 export const CONTRACTOR_ROLE = 'contractor'
 export const CONTRACT_MANAGER_ROLE = 'contract_manager'
+export const AUTHORISATION_MANAGER_ROLE = 'authorisation_manager'
 
 export const buildUser = (name, email, authServiceGroups) => {
   const {
     CONTRACT_MANAGERS_GOOGLE_GROUPNAME,
     AGENTS_GOOGLE_GROUPNAME,
+    AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME,
   } = process.env
 
   const CONTRACTORS_GOOGLE_GROUPNAME_REGEX =
@@ -19,6 +21,8 @@ export const buildUser = (name, email, authServiceGroups) => {
         return AGENT_ROLE
       } else if (groupName === CONTRACT_MANAGERS_GOOGLE_GROUPNAME) {
         return CONTRACT_MANAGER_ROLE
+      } else if (groupName === AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME) {
+        return AUTHORISATION_MANAGER_ROLE
       } else if (isContractorGroupName(groupName)) {
         return CONTRACTOR_ROLE
       }
@@ -34,6 +38,7 @@ export const buildUser = (name, email, authServiceGroups) => {
     (groupName) =>
       groupName === AGENTS_GOOGLE_GROUPNAME ||
       groupName === CONTRACT_MANAGERS_GOOGLE_GROUPNAME ||
+      groupName === AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME ||
       isContractorGroupName(groupName)
   )
 
@@ -48,6 +53,7 @@ export const buildUser = (name, email, authServiceGroups) => {
     hasAgentPermissions: hasRole(AGENT_ROLE),
     hasContractorPermissions: hasRole(CONTRACTOR_ROLE),
     hasContractManagerPermissions: hasRole(CONTRACT_MANAGER_ROLE),
+    hasAuthorisationManagerPermissions: hasRole(AUTHORISATION_MANAGER_ROLE),
     hasAnyPermissions: roles.length > 0,
   }
 }


### PR DESCRIPTION
### Description of change

Add authorisation management workflow 
- Add success page for high cost authorisations 
- Introduce new user group: 'Authorisation manager'. This user will approve/reject work orders that have been raised over that user's raise limit. 
- Upon authorisation approval the work order goes back to status: 'In Progress'. 
- Upon authorisation rejection the work order goes back to status: 'Work Cancelled'

https://trello.com/c/X5DsnOfB/94-as-an-rcc-agent-i-am-notified-that-a-repair-raised-has-been-sent-for-high-cost-authorisation-so-i-know-to-inform-a-manage-to-app
https://trello.com/c/JKN5qAJb/90-as-a-manager-i-can-see-that-a-request-is-pending-authorisation-so-i-know-which-repairs-to-approve
https://trello.com/c/flDnYmBB/95-work-orders-authorisation-approved-change-to-in-progress-to-be-discussed-with-users
https://trello.com/c/czpoyRAx/97-as-a-manager-authorisation-rejected-changes-the-status-to-cancelled-so-that-the-work-order-is-cancelled-and-work-doesnt-go-ahead

![Screenshot 2021-04-28 at 13 44 06](https://user-images.githubusercontent.com/34001723/116420257-ba769a00-a835-11eb-91ec-dfff041ac0b7.png)
![Screenshot 2021-04-28 at 13 44 59](https://user-images.githubusercontent.com/34001723/116420400-d7ab6880-a835-11eb-9123-54d6a3f1061f.png)
![Screenshot 2021-04-28 at 13 45 26](https://user-images.githubusercontent.com/34001723/116420438-e134d080-a835-11eb-9ea4-8d9cdfd0ef48.png)
![Screenshot 2021-04-28 at 13 46 05](https://user-images.githubusercontent.com/34001723/116420446-e1cd6700-a835-11eb-856d-67a105018be7.png)
![Screenshot 2021-04-28 at 13 45 34](https://user-images.githubusercontent.com/34001723/116420974-5accbe80-a836-11eb-9eb2-0d2f9ca83b95.png)

