### PR TITLE
Respect operative working hours in target time calculations (part 1)

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -31,16 +31,6 @@ export const convertToDateFormat = (string) => {
   return convertDate(dateAsString)
 }
 
-export const calculateNewDateTimeFromDate = (date, hours) => {
-  if (!hours) {
-    console.error('No argument given, hours must be supplied')
-    return null
-  }
-
-  // let currentDateTime = new Date()
-  return new Date(date.getTime() + hours * 3600000)
-}
-
 export const shortDayName = (date) => {
   return date.toLocaleDateString('en-GB', { weekday: 'short' })
 }

--- a/src/utils/date.test.js
+++ b/src/utils/date.test.js
@@ -1,10 +1,8 @@
-import MockDate from 'mockdate'
 import {
   convertDate,
   dateToStr,
   sortObjectsByDateKey,
   convertToDateFormat,
-  calculateNewDateTimeFromDate,
   shortDayName,
   shortDate,
   monthDay,
@@ -116,17 +114,6 @@ describe('convertToDateFormat', () => {
 
     expect(convertToDateFormat(stringToFormat)).toEqual(
       new Date('2021-01-20T12:12:00.00')
-    )
-  })
-})
-
-describe('calculateNewDateTimeFromDate', () => {
-  // 2021-01-14T18:16:20.986Z
-  MockDate.set(1610648180986)
-
-  it('should calculate the date time given number of hours', () => {
-    expect(calculateNewDateTimeFromDate(new Date(), 24)).toEqual(
-      new Date('2021-01-15T18:16:20.986Z')
     )
   })
 })

--- a/src/utils/hact/schedule-repair/raise-repair-form.js
+++ b/src/utils/hact/schedule-repair/raise-repair-form.js
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { priorityCodeCompletionTimes } from '../helpers/priority-codes'
-import { calculateNewDateTimeFromDate } from '../../date'
+import { calculateCompletionDateTime } from '../../helpers/completionDateTimes'
 
 export const buildScheduleRepairFormData = (formData) => {
   return {
@@ -13,9 +13,8 @@ export const buildScheduleRepairFormData = (formData) => {
     priority: {
       priorityCode: Number.parseInt(formData.priorityCode),
       priorityDescription: formData.priorityDescription,
-      requiredCompletionDateTime: calculateNewDateTimeFromDate(
-        new Date(),
-        priorityCodeCompletionTimes[formData.priorityCode].numberOfHours
+      requiredCompletionDateTime: calculateCompletionDateTime(
+        formData.priorityCode
       ),
       numberOfDays:
         priorityCodeCompletionTimes[formData.priorityCode].numberOfDays,

--- a/src/utils/hact/schedule-repair/raise-repair-form.test.js
+++ b/src/utils/hact/schedule-repair/raise-repair-form.test.js
@@ -37,8 +37,7 @@ describe('buildRaiseRepairFormData', () => {
   }
 
   it('builds the ScheduleRepair form data to post to the Repairs API', async () => {
-    // 2021-01-14T18:16:20.986Z
-    MockDate.set(1610648180986)
+    MockDate.set(new Date('Thu Jan 14 2021 18:16:20Z'))
 
     const scheduleRepairFormData = {
       reference: [
@@ -50,7 +49,7 @@ describe('buildRaiseRepairFormData', () => {
       priority: {
         priorityCode: 3,
         priorityDescription: '4 [U] URGENT',
-        requiredCompletionDateTime: new Date('2021-01-19T18:16:20.986Z'),
+        requiredCompletionDateTime: new Date('Thu Jan 21 2021 18:16:20Z'),
         numberOfDays: 5,
       },
       workClass: {

--- a/src/utils/helpers/completionDateTimes.js
+++ b/src/utils/helpers/completionDateTimes.js
@@ -1,0 +1,40 @@
+import { priorityCodeCompletionTimes } from '../hact/helpers/priority-codes'
+import add from 'date-fns/add'
+
+const WEEKEND_DAYS = [0, 6]
+
+const isWorkingDay = (date) => !WEEKEND_DAYS.includes(date.getDay())
+
+const dateAfterCountWorkingDays = (startDate, targetWorkingDaysCount) => {
+  var workingDaysCount = 0
+  var calendarDaysCount = 0
+
+  while (workingDaysCount < targetWorkingDaysCount) {
+    calendarDaysCount += 1
+
+    const date = add(startDate, { days: calendarDaysCount })
+
+    if (isWorkingDay(date)) {
+      workingDaysCount += 1
+    }
+  }
+
+  // Return the start date plus however many calendar days we looped over to satisfy
+  // the required number of working days.
+  return add(startDate, { days: calendarDaysCount })
+}
+
+export const calculateCompletionDateTime = (priorityCode) => {
+  const {
+    numberOfHours: completionTargetHours,
+    numberOfDays: completionTargetWorkingDays,
+  } = priorityCodeCompletionTimes[priorityCode]
+
+  const now = new Date()
+
+  if (completionTargetWorkingDays < 1) {
+    return new Date(now.setHours(now.getHours() + completionTargetHours))
+  } else {
+    return dateAfterCountWorkingDays(now, completionTargetWorkingDays)
+  }
+}

--- a/src/utils/helpers/completionDateTimes.test.js
+++ b/src/utils/helpers/completionDateTimes.test.js
@@ -1,0 +1,171 @@
+import { calculateCompletionDateTime } from './completionDateTimes'
+import MockDate from 'mockdate'
+
+describe('calculateCompletionDateTime', () => {
+  describe('when the priority code represents an immediate order', () => {
+    // 2 hours
+    const priorityCode = 1
+
+    const dateTime = new Date('Monday 28 June 2021 17:00:00Z')
+
+    beforeEach(() => {
+      MockDate.set(dateTime)
+    })
+
+    afterEach(() => {
+      MockDate.reset()
+    })
+
+    it('adds the configured number of hours to set the target time', () => {
+      const expectedDateTime = new Date(
+        dateTime.setHours(dateTime.getHours() + 2)
+      )
+
+      expect(calculateCompletionDateTime(priorityCode)).toEqual(
+        expectedDateTime
+      )
+    })
+
+    xdescribe('and the works order is created on a non-working day', () => {})
+  })
+
+  describe('when the priority code represents an emergency order', () => {
+    // 1 working day
+    const priorityCode = 2
+
+    describe('and the day of order creation and the day following it are working days', () => {
+      const dateTime = new Date('Wednesday 30 June 2021 08:00:00Z')
+
+      beforeEach(() => {
+        MockDate.set(dateTime)
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('sets the target time for the same time on the configured number of working days from now', () => {
+        expect(calculateCompletionDateTime(priorityCode)).toEqual(
+          new Date('Thursday 1 July 2021 08:00:00Z')
+        )
+      })
+    })
+
+    describe('and the day of order creation is on a Friday before a subsequent, regular working week', () => {
+      const dateTime = new Date('Friday 2 July 2021 19:00:00Z')
+
+      beforeEach(() => {
+        MockDate.set(dateTime)
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('sets the target time for the same time on the configured number of working days from now', () => {
+        const expectedDateTime = new Date('Monday 5 July 2021 19:00:00Z')
+
+        expect(calculateCompletionDateTime(priorityCode)).toEqual(
+          expectedDateTime
+        )
+      })
+    })
+
+    xdescribe('and the works order is created on a non-working day', () => {})
+    xdescribe('and the works order is created when there are imminent bank holidays', () => {})
+  })
+
+  describe('when the priority code represents an urgent order', () => {
+    // 5 working days
+    const priorityCode = 3
+
+    describe('and the day of order creation is a working day with no imminent bank holidays', () => {
+      const dateTime = new Date('Wednesday 7 July 2021 19:00:00Z')
+
+      beforeEach(() => {
+        MockDate.set(dateTime)
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('sets the target time for the same time on the configured number of working days from now', () => {
+        expect(calculateCompletionDateTime(priorityCode)).toEqual(
+          new Date('Wednesday 14 July 2021 19:00:00Z')
+        )
+      })
+    })
+
+    describe('and the day of order creation is a working day near the end of a year', () => {
+      // This fictional scenario currently includes NO bank holidays for the current, simple implementation
+      // and instead focuses on getting dates around the year boundary correct
+
+      const dateTime = new Date('Wednesday 29 December 2021 12:00:00Z')
+
+      beforeEach(() => {
+        MockDate.set(dateTime)
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('sets the target time for the same time on the configured number of working days from now', () => {
+        expect(calculateCompletionDateTime(priorityCode)).toEqual(
+          new Date('Wednesday 5 January 2022 12:00:00Z')
+        )
+      })
+    })
+
+    xdescribe('and the works order is created on a non-working day', () => {})
+    xdescribe('and the works order is created when there are imminent bank holidays', () => {})
+  })
+
+  describe('when the priority code represents a normal order', () => {
+    // 21 working days
+    const priorityCode = 4
+
+    describe('and the day of order creation is a working day with no imminent bank holidays', () => {
+      const dateTime = new Date('Tuesday 1 June 2021 19:00:00Z')
+
+      beforeEach(() => {
+        MockDate.set(dateTime)
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('sets the target time for the same time on the configured number of working days from now', () => {
+        expect(calculateCompletionDateTime(priorityCode)).toEqual(
+          new Date('Wednesday 30 June 2021 19:00:00Z')
+        )
+      })
+    })
+
+    describe('and the day of order creation is a working day near the end of a year', () => {
+      // This fictional scenario currently includes NO bank holidays for the current, simple implementation
+      // and instead focuses on getting dates around the year boundary correct
+
+      const dateTime = new Date('Wednesday 29 December 2021 12:00:00Z')
+
+      beforeEach(() => {
+        MockDate.set(dateTime)
+      })
+
+      afterEach(() => {
+        MockDate.reset()
+      })
+
+      it('sets the target time for the same time on the configured number of working days from now', () => {
+        expect(calculateCompletionDateTime(priorityCode)).toEqual(
+          new Date('Thursday 27 January 2022 12:00:00Z')
+        )
+      })
+    })
+
+    xdescribe('and the works order is created on a non-working day', () => {})
+    xdescribe('and the works order is created when there are imminent bank holidays', () => {})
+  })
+})


### PR DESCRIPTION
### Description of change

Enhance the calculation we use to generate the `requiredCompletionDateTime` field when posting a new works order so that it does not try to set a target during a weekend.

The `numberOfDays` field in our [config file](https://github.com/LBHackney-IT/repairs-hub-frontend/blob/develop/src/utils/hact/helpers/priority-codes.js) relates to the number of working days instead of calendar days. 

This PR is a step towards a full implementation of that - it does not define behaviour for the following scenarios:

1. A work order raised before imminent bank holidays
2. A work order raised on a non working day (weekend or bank holiday)

There are some test descriptions added for these but they are set to pending.

These will be addressed in a future PR.

### Story Link

https://trello.com/c/j5tgNsSd/21-respect-contractor-working-hours-when-calculating-target-dates