### PR TITLE
Do not show Authorisation Pending Approval filter for contractors

### DIFF
--- a/cypress/integration/work-orders/filter.spec.js
+++ b/cypress/integration/work-orders/filter.spec.js
@@ -102,7 +102,7 @@ describe('Filter work orders', () => {
     })
 
     it('Filters by work order status', () => {
-      // Expect all work orders to be displayed
+      // Expect all relevant work orders to be displayed
       cy.get('[data-ref=10000040]')
       cy.get('[data-ref=10000035]')
       cy.get('[data-ref=10000036]')
@@ -130,6 +130,10 @@ describe('Filter work orders', () => {
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.1090"]')
         .should('not.be.checked')
+      // No filter option for authorisation pending approval status
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.1010"]')
+        .should('not.exist')
       // Priority filter options
       cy.get('.govuk-checkboxes')
         .find('[name="Priorities.1"]')
@@ -473,6 +477,7 @@ describe('Filter work orders', () => {
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.30"]')
         .should('not.be.checked')
+      // Authorisation Pending Approval work order filter selected
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.1010"]')
         .should('be.checked')
@@ -491,6 +496,62 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000036]').should('not.exist')
       cy.get('[data-ref=10000035]').should('not.exist')
       cy.get('[data-ref=10000030]').should('not.exist')
+    })
+  })
+
+  context('When logged in as a contract manager', () => {
+    beforeEach(() => {
+      cy.loginWithContractManagerRole()
+
+      // Stub variation pending approval work order (90)
+      cy.fixture('work-orders/work-orders.json')
+        .then((workOrders) => {
+          return workOrders.filter(
+            (workOrder) => workOrder.status === 'Variation Pending Approval'
+          )
+        })
+        .as('variationPendingApproval')
+      cy.route(
+        'GET',
+        `api/workOrders/?PageSize=${PAGE_SIZE_CONTRACTORS}&PageNumber=1&StatusCode=90`,
+        '@variationPendingApproval'
+      )
+      cy.visit(`${Cypress.env('HOST')}/`)
+    })
+
+    it('Has Variation Pending Approval work order filter selected by default', () => {
+      // Status filter options
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.50"]')
+        .should('not.be.checked')
+      // Variation Pending Approval work order filter selected
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.90"]')
+        .should('be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.80"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.30"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.1010"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.1080"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="StatusCode.1090"]')
+        .should('not.be.checked')
+
+      cy.get('[data-ref=10000030]').within(() => {
+        cy.contains('Variation Pending Approval')
+      })
+      cy.get('[data-ref=10000040]').should('not.exist')
+      cy.get('[data-ref=10000037]').should('not.exist')
+      cy.get('[data-ref=10000036]').should('not.exist')
+      cy.get('[data-ref=10000035]').should('not.exist')
+      cy.get('[data-ref=10000032]').should('not.exist')
     })
   })
 })

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -1,7 +1,10 @@
+import { useContext } from 'react'
 import PropTypes from 'prop-types'
 import Spinner from '../../Spinner/Spinner'
 import { Checkbox, Button } from '../../Form'
 import { GridColumn, GridRow } from '../../Layout/Grid'
+import UserContext from '../../UserContext/UserContext'
+import { STATUS_AUTHORISATION_PENDING_APPROVAL } from '../../../utils/status-codes'
 
 const WorkOrdersFilter = ({
   loading,
@@ -10,6 +13,19 @@ const WorkOrdersFilter = ({
   appliedFilters,
   clearFilters,
 }) => {
+  const { user } = useContext(UserContext)
+
+  const statusFilterOptions = () => {
+    if (user && user.hasContractorPermissions) {
+      return filters.Status.filter(
+        (status) =>
+          status.key !== STATUS_AUTHORISATION_PENDING_APPROVAL.code.toString()
+      )
+    } else {
+      return filters.Status
+    }
+  }
+
   return (
     <details className="govuk-details" data-module="govuk-details">
       <summary className="govuk-details__summary">
@@ -31,7 +47,7 @@ const WorkOrdersFilter = ({
                       </legend>
 
                       <div className="govuk-checkboxes">
-                        {filters.Status.map((status, index) => (
+                        {statusFilterOptions().map((status, index) => (
                           <Checkbox
                             key={index}
                             name={`StatusCode.${status.key}`}

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import UserContext from '../../UserContext/UserContext'
 import WorkOrdersFilter from './WorkOrdersFilter'
 
 describe('WorkOrdersFilter component', () => {
@@ -27,6 +28,22 @@ describe('WorkOrdersFilter component', () => {
           key: '30',
           description: 'Work Cancelled',
         },
+        {
+          key: '1010',
+          description: 'Authorisation Pending Approval',
+        },
+        {
+          key: '90',
+          description: 'Variation Pending Approval',
+        },
+        {
+          key: '1080',
+          description: 'Variation Approved',
+        },
+        {
+          key: '1090',
+          description: 'Variation Rejected',
+        },
       ],
     },
     loading: false,
@@ -34,15 +51,82 @@ describe('WorkOrdersFilter component', () => {
     clearFilters: jest.fn(),
   }
 
-  it('should render properly', () => {
-    const { asFragment } = render(
-      <WorkOrdersFilter
-        filters={props.filters}
-        loading={props.loading}
-        register={props.register}
-        clearFilters={props.clearFilters}
-      />
-    )
-    expect(asFragment()).toMatchSnapshot()
+  describe('When logged in as a contract manager', () => {
+    const user = {
+      name: 'A Contractor',
+      email: 'a.contractor@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: false,
+      hasContractManagerPermissions: true,
+      hasAnyPermissions: true,
+    }
+
+    it('should render properly with all filter options', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrdersFilter
+            filters={props.filters}
+            loading={props.loading}
+            register={props.register}
+            clearFilters={props.clearFilters}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('When logged in as a contractor', () => {
+    const user = {
+      name: 'A Contractor',
+      email: 'a.contractor@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: true,
+      hasContractManagerPermissions: false,
+      hasAnyPermissions: true,
+    }
+
+    it('should render properly with filter options except authorisation pending approval', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrdersFilter
+            filters={props.filters}
+            loading={props.loading}
+            register={props.register}
+            clearFilters={props.clearFilters}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('When logged in as an authorisation manager', () => {
+    const user = {
+      name: 'An Authorisation Manager',
+      email: 'an.authorisation-manager@hackney.gov.uk',
+      hasRole: true,
+      hasAgentPermissions: false,
+      hasContractorPermissions: false,
+      hasContractManagerPermissions: false,
+      hasAuthorisationManagerPermissions: true,
+      hasAnyPermissions: true,
+    }
+
+    it('should render properly with all filter options', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user }}>
+          <WorkOrdersFilter
+            filters={props.filters}
+            loading={props.loading}
+            register={props.register}
+            clearFilters={props.clearFilters}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
   })
 })

--- a/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
+++ b/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WorkOrdersFilter component should render properly 1`] = `
+exports[`WorkOrdersFilter component When logged in as a contract manager should render properly with all filter options 1`] = `
 <DocumentFragment>
   <details
     class="govuk-details"
@@ -103,6 +103,664 @@ exports[`WorkOrdersFilter component should render properly 1`] = `
                       for="StatusCode.30"
                     >
                       Work Cancelled
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1010"
+                      name="StatusCode.1010"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1010"
+                    >
+                      Authorisation Pending Approval
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.90"
+                      name="StatusCode.90"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.90"
+                    >
+                      Variation Pending Approval
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1080"
+                      name="StatusCode.1080"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1080"
+                    >
+                      Variation Approved
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1090"
+                      name="StatusCode.1090"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1090"
+                    >
+                      Variation Rejected
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="govuk-grid-column-one-half"
+        >
+          <fieldset
+            class="govuk-fieldset"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Priority
+            </legend>
+            <div
+              class="govuk-checkboxes"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="Priorities.I"
+                      name="Priorities.I"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="Priorities.I"
+                    >
+                      Immediate
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="Priorities.E"
+                      name="Priorities.E"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="Priorities.E"
+                    >
+                      Emergency
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="govuk-button lbh-button"
+        data-module="govuk-button"
+        type="submit"
+      >
+        Apply filters
+      </button>
+      <div>
+        <a
+          href="#"
+        >
+          Clear filters
+        </a>
+      </div>
+    </div>
+  </details>
+</DocumentFragment>
+`;
+
+exports[`WorkOrdersFilter component When logged in as a contractor should render properly with filter options except authorisation pending approval 1`] = `
+<DocumentFragment>
+  <details
+    class="govuk-details"
+    data-module="govuk-details"
+  >
+    <summary
+      class="govuk-details__summary"
+    >
+      <span
+        class="govuk-details__summary-text"
+      >
+        Filters
+      </span>
+    </summary>
+    <div
+      class="govuk-grid-row undefined"
+    >
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <div
+          class="govuk-grid-column-one-half"
+        >
+          <fieldset
+            class="govuk-fieldset"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Status
+            </legend>
+            <div
+              class="govuk-checkboxes"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.80"
+                      name="StatusCode.80"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.80"
+                    >
+                      In Progress
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.50"
+                      name="StatusCode.50"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.50"
+                    >
+                      Complete
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.30"
+                      name="StatusCode.30"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.30"
+                    >
+                      Work Cancelled
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.90"
+                      name="StatusCode.90"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.90"
+                    >
+                      Variation Pending Approval
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1080"
+                      name="StatusCode.1080"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1080"
+                    >
+                      Variation Approved
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1090"
+                      name="StatusCode.1090"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1090"
+                    >
+                      Variation Rejected
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="govuk-grid-column-one-half"
+        >
+          <fieldset
+            class="govuk-fieldset"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Priority
+            </legend>
+            <div
+              class="govuk-checkboxes"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="Priorities.I"
+                      name="Priorities.I"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="Priorities.I"
+                    >
+                      Immediate
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="Priorities.E"
+                      name="Priorities.E"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="Priorities.E"
+                    >
+                      Emergency
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="govuk-button lbh-button"
+        data-module="govuk-button"
+        type="submit"
+      >
+        Apply filters
+      </button>
+      <div>
+        <a
+          href="#"
+        >
+          Clear filters
+        </a>
+      </div>
+    </div>
+  </details>
+</DocumentFragment>
+`;
+
+exports[`WorkOrdersFilter component When logged in as an authorisation manager should render properly with all filter options 1`] = `
+<DocumentFragment>
+  <details
+    class="govuk-details"
+    data-module="govuk-details"
+  >
+    <summary
+      class="govuk-details__summary"
+    >
+      <span
+        class="govuk-details__summary-text"
+      >
+        Filters
+      </span>
+    </summary>
+    <div
+      class="govuk-grid-row undefined"
+    >
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <div
+          class="govuk-grid-column-one-half"
+        >
+          <fieldset
+            class="govuk-fieldset"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Status
+            </legend>
+            <div
+              class="govuk-checkboxes"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.80"
+                      name="StatusCode.80"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.80"
+                    >
+                      In Progress
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.50"
+                      name="StatusCode.50"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.50"
+                    >
+                      Complete
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.30"
+                      name="StatusCode.30"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.30"
+                    >
+                      Work Cancelled
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1010"
+                      name="StatusCode.1010"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1010"
+                    >
+                      Authorisation Pending Approval
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.90"
+                      name="StatusCode.90"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.90"
+                    >
+                      Variation Pending Approval
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1080"
+                      name="StatusCode.1080"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1080"
+                    >
+                      Variation Approved
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="govuk-form-group lbh-form-group"
+              >
+                <div
+                  class="govuk-checkboxes lbh-checkboxes"
+                >
+                  <div
+                    class="govuk-checkboxes__item"
+                  >
+                    <input
+                      class="govuk-checkboxes__input"
+                      id="StatusCode.1090"
+                      name="StatusCode.1090"
+                      type="checkbox"
+                    />
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      for="StatusCode.1090"
+                    >
+                      Variation Rejected
                     </label>
                   </div>
                 </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,7 +23,7 @@ const Home = ({ query }) => {
       if (user.hasAuthorisationManagerPermissions) {
         // Default filter selected for Authorisation Pending Approval work orders
         return <WorkOrdersView pageNumber={1} query={{ StatusCode: '1010' }} />
-      } else if (user.hasContractorManagerPermissions) {
+      } else if (user.hasContractManagerPermissions) {
         // Default filter selected for Variation Pending Approval work orders
         return <WorkOrdersView pageNumber={1} query={{ StatusCode: '90' }} />
       } else {


### PR DESCRIPTION
### Description of change

https://trello.com/c/2Jo9A9A7/147-as-a-contractor-i-cant-see-works-thats-are-pending-authorisation-so-i-dont-complete-the-work-until-its-approved

- When logged in as a contractor, the API scopes the work orders to not include those with Authorisation Pending Approval.
- We just need to hide the filter option on the frontend
