### PR TITLE
Trade and contractor filter

### DIFF
--- a/cypress/fixtures/filter/work-order.json
+++ b/cypress/fixtures/filter/work-order.json
@@ -46,5 +46,45 @@
       "key": "1090",
       "description": "Variation Rejected"
     }
+  ],
+  "Trades": [
+    {
+      "key": "AD",
+      "description": "Disabled Adaptions"
+    },
+    {
+      "key": "CA",
+      "description": "Cash Items"
+    },
+    {
+      "key": "CP",
+      "description": "Carpentry and Joinery"
+    },
+    {
+      "key": "DE",
+      "description": "DOOR ENTRY ENGINEER"
+    },
+    {
+      "key": "EL",
+      "description": "Electrical"
+    },
+    {
+      "key": "PL",
+      "description": "Plumbing"
+    }
+  ],
+  "Contractors": [
+    {
+      "key": "AVP",
+      "description": "Avonline Network (A) Ltd"
+    },
+    {
+      "key": "PCL",
+      "description": "Purdy Contracts (P) Ltd"
+    },
+    {
+      "key": "SCC",
+      "description": "Alphatrack (S) Systems Lt"
+    }
   ]
 }

--- a/cypress/fixtures/work-orders/work-orders.json
+++ b/cypress/fixtures/work-orders/work-orders.json
@@ -70,11 +70,11 @@
     "lastUpdated": null,
     "priority": "N - Normal 28 days (21 working days)",
     "property": "315 Banister House  Homerton High Street",
-    "owner": "Alphatrack (S) Systems Lt",
+    "owner": "Purdy Contracts (P) Ltd",
     "description": "An authorisation pending approval repair",
     "propertyReference": "00012345",
-    "tradeCode": "DE",
-    "tradeDescription": "DOOR ENTRY ENGINEER - DE",
+    "tradeCode": "PL",
+    "tradeDescription": "Plumbing",
     "status": "Authorisation Pending Approval"
   }
 ]

--- a/cypress/integration/work-orders/filter.spec.js
+++ b/cypress/integration/work-orders/filter.spec.js
@@ -93,31 +93,39 @@ describe('Filter work orders', () => {
       `api/workOrders/?PageSize=${PAGE_SIZE_CONTRACTORS}&PageNumber=1&Priorities=2`,
       '@emergencyPriorityWork'
     )
+    // Work order with Plumbing and Purdys
+    cy.fixture('work-orders/work-orders.json')
+      .then((workOrders) => {
+        return workOrders.filter(
+          (workOrder) =>
+            workOrder.tradeCode === 'PL' &&
+            workOrder.owner === 'Purdy Contracts (P) Ltd'
+        )
+      })
+      .as('purdyPlumbingWorkOrders')
+    cy.route(
+      'GET',
+      `api/workOrders/?PageSize=${PAGE_SIZE_CONTRACTORS}&PageNumber=1&TradeCodes=PL&ContractorReference=PCL`,
+      '@purdyPlumbingWorkOrders'
+    )
   })
 
-  context('When logged in as a contractor', () => {
+  context('When logged in as a contract manager', () => {
     beforeEach(() => {
-      cy.loginWithContractorRole()
+      cy.loginWithContractManagerRole()
+
       cy.visit(`${Cypress.env('HOST')}/`)
     })
 
-    it('Filters by work order status', () => {
-      // Expect all relevant work orders to be displayed
-      cy.get('[data-ref=10000040]')
-      cy.get('[data-ref=10000035]')
-      cy.get('[data-ref=10000036]')
-      cy.get('[data-ref=10000037]')
-      cy.get('[data-ref=10000030]')
-
-      // Expand filter component
-      cy.get('.govuk-details__summary-text').contains('Filters').click()
+    it('Filter work orders', () => {
       // Status filter options
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.50"]')
         .should('not.be.checked')
+      // Variation pending approval selected by default
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.90"]')
-        .should('not.be.checked')
+        .should('be.checked')
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.80"]')
         .should('not.be.checked')
@@ -130,10 +138,10 @@ describe('Filter work orders', () => {
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.1090"]')
         .should('not.be.checked')
-      // No filter option for authorisation pending approval status
-      cy.get('.govuk-checkboxes')
-        .find('[name="StatusCode.1010"]')
-        .should('not.exist')
+      cy.get('.status-filters').within(() => {
+        cy.contains('Show all 7')
+      })
+
       // Priority filter options
       cy.get('.govuk-checkboxes')
         .find('[name="Priorities.1"]')
@@ -147,6 +155,60 @@ describe('Filter work orders', () => {
       cy.get('.govuk-checkboxes')
         .find('[name="Priorities.4"]')
         .should('not.be.checked')
+      // Contractor filter options
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.AVP"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.PCL"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.SCC"]')
+        .should('not.be.checked')
+      // Trade filter options
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.AD"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.CA"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.CP"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.DE"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.EL"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.PL"]')
+        .should('not.be.checked')
+      cy.get('.trade-filters').within(() => {
+        cy.contains('Show all 6')
+      })
+
+      // Only variation pending approval work orders are displayed
+      cy.get('[data-ref=10000030]').within(() => {
+        cy.contains('Variation Pending Approval')
+      })
+      cy.get('[data-ref=10000037]').should('not.exist')
+      cy.get('[data-ref=10000036]').should('not.exist')
+      cy.get('[data-ref=10000035]').should('not.exist')
+      cy.get('[data-ref=10000040]').should('not.exist')
+      cy.get('[data-ref=10000032]').should('not.exist')
+
+      // Remove variation pending approval filter
+      cy.get('.govuk-checkboxes').find('[name="StatusCode.90"]').uncheck()
+      cy.get('[type="submit"]').contains('Apply filters').click()
+
+      // Expect all work orders to be displayed
+      cy.get('[data-ref=10000040]')
+      cy.get('[data-ref=10000035]')
+      cy.get('[data-ref=10000036]')
+      cy.get('[data-ref=10000037]')
+      cy.get('[data-ref=10000030]')
+      cy.get('[data-ref=10000032]')
 
       // Filter by work order complete
       cy.get('.govuk-checkboxes').find('[name="StatusCode.50"]').check()
@@ -161,6 +223,7 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000030]').should('not.exist')
       cy.get('[data-ref=10000035]').should('not.exist')
       cy.get('[data-ref=10000040]').should('not.exist')
+      cy.get('[data-ref=10000032]').should('not.exist')
 
       cy.url().should('contains', '/?pageNumber=1&StatusCode=50')
 
@@ -209,6 +272,7 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000036]').should('not.exist')
       cy.get('[data-ref=10000035]').should('not.exist')
       cy.get('[data-ref=10000030]').should('not.exist')
+      cy.get('[data-ref=10000032]').should('not.exist')
 
       cy.url().should(
         'contains',
@@ -233,7 +297,6 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000040]').should('not.exist')
 
       // Expect only work complete and Variation Pending Approval filter checkbox to be selected
-      cy.get('.govuk-details__summary-text').contains('Filters').click()
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.50"]')
         .should('be.checked')
@@ -264,6 +327,7 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000035]').should('not.exist')
       cy.get('[data-ref=10000040]').should('not.exist')
       cy.get('[data-ref=10000030]').should('not.exist')
+      cy.get('[data-ref=10000032]').should('not.exist')
 
       cy.url().should('contains', '/?pageNumber=1&StatusCode=30')
 
@@ -282,10 +346,10 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000036]').should('not.exist')
       cy.get('[data-ref=10000035]').should('not.exist')
       cy.get('[data-ref=10000030]').should('not.exist')
+      cy.get('[data-ref=10000032]').should('not.exist')
 
       // Expect only work in progress, Variation Pending Approval and emergency filter checkbox to be selected
       // Status filter options
-      cy.get('.govuk-details__summary-text').contains('Filters').click()
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.50"]')
         .should('not.be.checked')
@@ -331,6 +395,7 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000036]').should('not.exist')
       cy.get('[data-ref=10000035]').should('not.exist')
       cy.get('[data-ref=10000030]').should('not.exist')
+      cy.get('[data-ref=10000032]').should('not.exist')
 
       // Uncheck emergency checkbox and now we should see all the work orders
       cy.get('.govuk-checkboxes').find('[name="Priorities.2"]').uncheck()
@@ -342,13 +407,30 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000036]')
       cy.get('[data-ref=10000037]')
       cy.get('[data-ref=10000030]')
+      cy.get('[data-ref=10000032]')
 
       cy.url().should('contains', '/?pageNumber=1')
+
+      // Filter by trade and contractor
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.PCL"]')
+        .check()
+      cy.get('.trade-filters').within(() => {
+        cy.contains('Show all 6').click()
+      })
+      cy.get('.govuk-checkboxes').find('[name="TradeCodes.PL"]').check()
+      cy.get('[type="submit"]').contains('Apply filters').click()
+
+      // Plumbing trade and Purdy contractor work orders
+      cy.get('[data-ref=10000040]').should('not.exist')
+      cy.get('[data-ref=10000035]').should('not.exist')
+      cy.get('[data-ref=10000036]').should('not.exist')
+      cy.get('[data-ref=10000037]').should('not.exist')
+      cy.get('[data-ref=10000030]').should('not.exist')
+      cy.get('[data-ref=10000032]')
     })
 
     it('Clears all filters', () => {
-      // Expand filter component
-      cy.get('.govuk-details__summary-text').contains('Filters').click()
       // Check a few filter options
       cy.get('.govuk-checkboxes').find('[name="StatusCode.90"]').check()
       cy.get('.govuk-checkboxes').find('[name="StatusCode.80"]').check()
@@ -487,6 +569,48 @@ describe('Filter work orders', () => {
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.1090"]')
         .should('not.be.checked')
+      // Priority filter options
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.1"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.2"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.3"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.4"]')
+        .should('not.be.checked')
+      // Contractor filter options
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.AVP"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.PCL"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.SCC"]')
+        .should('not.be.checked')
+      // Trade filter options
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.AD"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.CA"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.CP"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.DE"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.EL"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.PL"]')
+        .should('not.be.checked')
 
       cy.get('[data-ref=10000032]').within(() => {
         cy.contains('Authorisation Pending Approval')
@@ -499,35 +623,33 @@ describe('Filter work orders', () => {
     })
   })
 
-  context('When logged in as a contract manager', () => {
+  context('When logged in as a contractor', () => {
     beforeEach(() => {
-      cy.loginWithContractManagerRole()
+      cy.loginWithContractorRole()
 
-      // Stub variation pending approval work order (90)
-      cy.fixture('work-orders/work-orders.json')
-        .then((workOrders) => {
-          return workOrders.filter(
-            (workOrder) => workOrder.status === 'Variation Pending Approval'
-          )
-        })
-        .as('variationPendingApproval')
-      cy.route(
-        'GET',
-        `api/workOrders/?PageSize=${PAGE_SIZE_CONTRACTORS}&PageNumber=1&StatusCode=90`,
-        '@variationPendingApproval'
-      )
       cy.visit(`${Cypress.env('HOST')}/`)
     })
 
-    it('Has Variation Pending Approval work order filter selected by default', () => {
-      // Status filter options
+    it('Lists all filtering options with the exception of the contractors filter', () => {
+      // No contractor filter
+      cy.get('#contractor-filters').should('not.exist')
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.AVP"]')
+        .should('not.exist')
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.PCL"]')
+        .should('not.exist')
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.SCC"]')
+        .should('not.exist')
+
+      // Status filter options (none selected by default)
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.50"]')
         .should('not.be.checked')
-      // Variation Pending Approval work order filter selected
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.90"]')
-        .should('be.checked')
+        .should('not.be.checked')
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.80"]')
         .should('not.be.checked')
@@ -536,22 +658,52 @@ describe('Filter work orders', () => {
         .should('not.be.checked')
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.1010"]')
-        .should('not.be.checked')
+        .should('not.exist')
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.1080"]')
         .should('not.be.checked')
       cy.get('.govuk-checkboxes')
         .find('[name="StatusCode.1090"]')
         .should('not.be.checked')
+      // Priority filter options
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.1"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.2"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.3"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="Priorities.4"]')
+        .should('not.be.checked')
+      // Trade filter options (none selected by default)
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.AD"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.CA"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.CP"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.DE"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.EL"]')
+        .should('not.be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.PL"]')
+        .should('not.be.checked')
 
-      cy.get('[data-ref=10000030]').within(() => {
-        cy.contains('Variation Pending Approval')
-      })
-      cy.get('[data-ref=10000040]').should('not.exist')
-      cy.get('[data-ref=10000037]').should('not.exist')
-      cy.get('[data-ref=10000036]').should('not.exist')
-      cy.get('[data-ref=10000035]').should('not.exist')
-      cy.get('[data-ref=10000032]').should('not.exist')
+      // Expect all work orders to be displayed
+      cy.get('[data-ref=10000040]')
+      cy.get('[data-ref=10000035]')
+      cy.get('[data-ref=10000036]')
+      cy.get('[data-ref=10000037]')
+      cy.get('[data-ref=10000030]')
     })
   })
 })

--- a/src/components/Form/Checkbox/Checkbox.js
+++ b/src/components/Form/Checkbox/Checkbox.js
@@ -1,30 +1,33 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
-const Checkbox = ({ label, name, register, error, checked }) => (
+const Checkbox = ({
+  label,
+  name,
+  register,
+  error,
+  checked,
+  className,
+  hidden,
+}) => (
   <div
-    className={cx('govuk-form-group lbh-form-group', {
-      'govuk-form-group--error': error,
+    className={cx(`govuk-checkboxes__item ${className}`, {
+      'govuk-!-display-none': hidden,
     })}
   >
-    <div className="govuk-checkboxes lbh-checkboxes">
-      <div className="govuk-checkboxes__item">
-        <input
-          className="govuk-checkboxes__input"
-          className={cx('govuk-checkboxes__input', {
-            'govuk-input--error': error,
-          })}
-          id={name}
-          name={name}
-          type="checkbox"
-          ref={register}
-          {...(checked && { defaultChecked: checked })}
-        />
-        <label className="govuk-label govuk-checkboxes__label" htmlFor={name}>
-          {label}
-        </label>
-      </div>
-    </div>
+    <input
+      className={cx('govuk-checkboxes__input', {
+        'govuk-input--error': error,
+      })}
+      id={name}
+      name={name}
+      type="checkbox"
+      ref={register}
+      {...(checked && { defaultChecked: checked })}
+    />
+    <label className="govuk-label govuk-checkboxes__label" htmlFor={name}>
+      {label}
+    </label>
   </div>
 )
 

--- a/src/components/Layout/Collapsible/Collapsible.js
+++ b/src/components/Layout/Collapsible/Collapsible.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types'
+import { useState } from 'react'
+
+const Collapsible = ({
+  heading,
+  children,
+  contentMargin,
+  collapsableDivClassName,
+}) => {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <section className="lbh-collapsible">
+      <div
+        aria-expanded={open}
+        className={`lbh-collapsible__button ${collapsableDivClassName}`}
+        onClick={() => setOpen(!open)}
+      >
+        <h2 className="lbh-heading-h2 lbh-collapsible__heading">{heading}</h2>
+        <svg width="17" height="10" viewBox="0 0 17 10">
+          <path d="M2 1.5L8.5 7.5L15 1.5" strokeWidth="3" />
+        </svg>
+      </div>
+      <div
+        className={`lbh-collapsible__content ${contentMargin}`}
+        hidden={!open}
+      >
+        {children}
+      </div>
+    </section>
+  )
+}
+
+Collapsible.propTypes = {
+  heading: PropTypes.string.isRequired,
+  children: PropTypes.object.isRequired,
+  contentMargin: PropTypes.string,
+  collapsableDivClassName: PropTypes.string,
+}
+
+export default Collapsible

--- a/src/components/Layout/Grid/GridColumn.js
+++ b/src/components/Layout/Grid/GridColumn.js
@@ -1,8 +1,12 @@
 import PropTypes from 'prop-types'
 
-const GridColumn = (props) => (
-  <div className={`govuk-grid-column-${props.width}`}>{props.children}</div>
-)
+const GridColumn = (props) => {
+  let className = props.className
+    ? `govuk-grid-column-${props.width} ${props.className}`
+    : `govuk-grid-column-${props.width}`
+
+  return <div className={className}>{props.children}</div>
+}
 
 GridColumn.propTypes = {
   width: PropTypes.string.isRequired,

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -2,9 +2,9 @@ import { useContext } from 'react'
 import PropTypes from 'prop-types'
 import Spinner from '../../Spinner/Spinner'
 import { Checkbox, Button } from '../../Form'
-import { GridColumn, GridRow } from '../../Layout/Grid'
 import UserContext from '../../UserContext/UserContext'
 import { STATUS_AUTHORISATION_PENDING_APPROVAL } from '../../../utils/status-codes'
+import Collapsible from '../../Layout/Collapsible/Collapsible'
 
 const WorkOrdersFilter = ({
   loading,
@@ -14,6 +14,8 @@ const WorkOrdersFilter = ({
   clearFilters,
 }) => {
   const { user } = useContext(UserContext)
+
+  const CHECKBOX_NUMBER = 5
 
   const statusFilterOptions = () => {
     if (user && user.hasContractorPermissions) {
@@ -26,78 +28,190 @@ const WorkOrdersFilter = ({
     }
   }
 
-  return (
-    <details className="govuk-details" data-module="govuk-details">
-      <summary className="govuk-details__summary">
-        <span className="govuk-details__summary-text">Filters</span>
-      </summary>
+  const showAllCheckboxes = (e, filterType) => {
+    e.preventDefault()
 
+    const checkboxes = document.getElementById(filterType)
+
+    checkboxes.childNodes.forEach((checkbox) => {
+      if (checkbox.classList.contains('govuk-!-display-none')) {
+        checkbox.classList.remove('govuk-!-display-none')
+      }
+    })
+
+    document.querySelector(`.${filterType}`).remove()
+  }
+
+  const showAllCheckboxesHtml = (numberOfFilterOptions, filterType) => {
+    if (numberOfFilterOptions > CHECKBOX_NUMBER) {
+      return (
+        <div
+          className={`govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-1 ${filterType}`}
+        >
+          <a
+            href="#"
+            onClick={(e) => showAllCheckboxes(e, filterType)}
+            className="govuk-link"
+          >
+            Show all {numberOfFilterOptions}
+          </a>
+        </div>
+      )
+    }
+  }
+
+  const filterOptionsHtml = () => {
+    return (
+      <div className="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5">
+        <div className="govuk-!-padding-left-2">
+          <Button label="Apply filters" type="submit" />
+          <div>
+            <a className="govuk-link" href="#" onClick={(e) => clearFilters(e)}>
+              Clear filters
+            </a>
+          </div>
+        </div>
+
+        {user &&
+          (user.hasContractManagerPermissions ||
+            user.hasAuthorisationManagerPermissions) && (
+            <div className="border-bottom-grey">
+              <fieldset className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2">
+                <legend className="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-padding-top-3">
+                  Contractor
+                </legend>
+
+                <div
+                  className="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+                  id="contractor-filters"
+                >
+                  {filters.Contractors.map((contractor, index) => (
+                    <Checkbox
+                      className="govuk-!-margin-0"
+                      key={index}
+                      name={`ContractorReference.${contractor.key}`}
+                      label={contractor.description}
+                      register={register}
+                      checked={appliedFilters?.ContractorReference?.includes(
+                        contractor.key
+                      )}
+                      hidden={index >= CHECKBOX_NUMBER}
+                    />
+                  ))}
+                </div>
+              </fieldset>
+
+              {showAllCheckboxesHtml(
+                filters.Contractors.length,
+                'contractor-filters'
+              )}
+            </div>
+          )}
+
+        <div className="border-bottom-grey">
+          <fieldset className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2">
+            <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+              Status
+            </legend>
+
+            <div
+              className="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="status-filters"
+            >
+              {statusFilterOptions().map((status, index) => (
+                <Checkbox
+                  className="govuk-!-margin-0"
+                  key={index}
+                  name={`StatusCode.${status.key}`}
+                  label={status.description}
+                  register={register}
+                  checked={appliedFilters?.StatusCode?.includes(status.key)}
+                  hidden={index >= CHECKBOX_NUMBER}
+                />
+              ))}
+            </div>
+          </fieldset>
+
+          {showAllCheckboxesHtml(
+            statusFilterOptions().length,
+            'status-filters'
+          )}
+        </div>
+
+        <div className="border-bottom-grey">
+          <fieldset className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2">
+            <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+              Priority
+            </legend>
+
+            <div
+              className="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="priority-filters"
+            >
+              {filters.Priority.map((priority, index) => (
+                <Checkbox
+                  className="govuk-!-margin-0"
+                  key={index}
+                  name={`Priorities.${priority.key}`}
+                  label={priority.description}
+                  register={register}
+                  checked={appliedFilters?.Priorities?.includes(priority.key)}
+                  hidden={index >= CHECKBOX_NUMBER}
+                />
+              ))}
+            </div>
+          </fieldset>
+
+          {showAllCheckboxesHtml(filters.Priority.length, 'priority-filters')}
+        </div>
+
+        <div className="border-bottom-grey">
+          <fieldset className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2">
+            <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+              Trade
+            </legend>
+
+            <div
+              className="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="trade-filters"
+            >
+              {filters.Trades.map((trade, index) => (
+                <Checkbox
+                  className="govuk-!-margin-0"
+                  key={index}
+                  name={`TradeCodes.${trade.key}`}
+                  label={trade.description}
+                  register={register}
+                  checked={appliedFilters?.Trades?.includes(trade.key)}
+                  hidden={index >= CHECKBOX_NUMBER}
+                />
+              ))}
+            </div>
+          </fieldset>
+
+          {showAllCheckboxesHtml(filters.Trades.length, 'trade-filters')}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
       {loading ? (
         <Spinner />
       ) : (
         <>
           {filters && (
-            <>
-              <GridRow>
-                <div className="govuk-form-group lbh-form-group">
-                  <GridColumn width="one-half">
-                    <fieldset className="govuk-fieldset">
-                      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
-                        Status
-                      </legend>
-
-                      <div className="govuk-checkboxes">
-                        {statusFilterOptions().map((status, index) => (
-                          <Checkbox
-                            key={index}
-                            name={`StatusCode.${status.key}`}
-                            label={status.description}
-                            register={register}
-                            checked={appliedFilters?.StatusCode?.includes(
-                              status.key
-                            )}
-                          />
-                        ))}
-                      </div>
-                    </fieldset>
-                  </GridColumn>
-
-                  <GridColumn width="one-half">
-                    <fieldset className="govuk-fieldset">
-                      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
-                        Priority
-                      </legend>
-
-                      <div className="govuk-checkboxes">
-                        {filters.Priority.map((priority, index) => (
-                          <Checkbox
-                            key={index}
-                            name={`Priorities.${priority.key}`}
-                            label={priority.description}
-                            register={register}
-                            checked={appliedFilters?.Priorities?.includes(
-                              priority.key
-                            )}
-                          />
-                        ))}
-                      </div>
-                    </fieldset>
-                  </GridColumn>
-                </div>
-              </GridRow>
-              <div>
-                <Button label="Apply filters" type="submit" />
-                <div>
-                  <a href="#" onClick={(e) => clearFilters(e)}>
-                    Clear filters
-                  </a>
-                </div>
-              </div>
-            </>
+            <Collapsible
+              heading="Filters"
+              collapsableDivClassName="filter-collapsible"
+              contentMargin="govuk-!-margin-0"
+              children={filterOptionsHtml()}
+            />
           )}
         </>
       )}
-    </details>
+    </>
   )
 }
 

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
@@ -45,24 +45,56 @@ describe('WorkOrdersFilter component', () => {
           description: 'Variation Rejected',
         },
       ],
+      Trades: [
+        {
+          key: 'DE',
+          description: 'DOOR ENTRY ENGINEER',
+        },
+        {
+          key: 'EL',
+          description: 'Electrical',
+        },
+        {
+          key: 'GL',
+          description: 'Glazing',
+        },
+        {
+          key: 'PL',
+          description: 'Plumbing',
+        },
+      ],
+      Contractors: [
+        {
+          key: 'AVP',
+          description: 'Avonline Network (A) Ltd',
+        },
+        {
+          key: 'PCL',
+          description: 'Purdy Contracts (P) Ltd',
+        },
+        {
+          key: 'SCC',
+          description: 'Alphatrack (S) Systems Lt',
+        },
+      ],
     },
     loading: false,
     register: jest.fn(),
     clearFilters: jest.fn(),
   }
 
-  describe('When logged in as a contract manager', () => {
+  describe('when logged in as a contractor', () => {
     const user = {
       name: 'A Contractor',
       email: 'a.contractor@hackney.gov.uk',
       hasRole: true,
       hasAgentPermissions: false,
-      hasContractorPermissions: false,
-      hasContractManagerPermissions: true,
+      hasContractorPermissions: true,
+      hasContractManagerPermissions: false,
       hasAnyPermissions: true,
     }
 
-    it('should render properly with all filter options', () => {
+    it('should render properly without filter by contractor and no authorisation pending approval status', () => {
       const { asFragment } = render(
         <UserContext.Provider value={{ user }}>
           <WorkOrdersFilter
@@ -77,18 +109,18 @@ describe('WorkOrdersFilter component', () => {
     })
   })
 
-  describe('When logged in as a contractor', () => {
+  describe('when logged in as a contract manager', () => {
     const user = {
-      name: 'A Contractor',
-      email: 'a.contractor@hackney.gov.uk',
+      name: 'A Contract Manager',
+      email: 'a.contract-manager@hackney.gov.uk',
       hasRole: true,
       hasAgentPermissions: false,
-      hasContractorPermissions: true,
-      hasContractManagerPermissions: false,
+      hasContractorPermissions: false,
+      hasContractManagerPermissions: true,
       hasAnyPermissions: true,
     }
 
-    it('should render properly with filter options except authorisation pending approval', () => {
+    it('should render properly with all filter options', () => {
       const { asFragment } = render(
         <UserContext.Provider value={{ user }}>
           <WorkOrdersFilter

--- a/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
+++ b/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
@@ -1,593 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WorkOrdersFilter component When logged in as a contract manager should render properly with all filter options 1`] = `
-<DocumentFragment>
-  <details
-    class="govuk-details"
-    data-module="govuk-details"
-  >
-    <summary
-      class="govuk-details__summary"
-    >
-      <span
-        class="govuk-details__summary-text"
-      >
-        Filters
-      </span>
-    </summary>
-    <div
-      class="govuk-grid-row undefined"
-    >
-      <div
-        class="govuk-form-group lbh-form-group"
-      >
-        <div
-          class="govuk-grid-column-one-half"
-        >
-          <fieldset
-            class="govuk-fieldset"
-          >
-            <legend
-              class="govuk-fieldset__legend govuk-fieldset__legend--m"
-            >
-              Status
-            </legend>
-            <div
-              class="govuk-checkboxes"
-            >
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.80"
-                      name="StatusCode.80"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.80"
-                    >
-                      In Progress
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.50"
-                      name="StatusCode.50"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.50"
-                    >
-                      Complete
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.30"
-                      name="StatusCode.30"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.30"
-                    >
-                      Work Cancelled
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1010"
-                      name="StatusCode.1010"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1010"
-                    >
-                      Authorisation Pending Approval
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.90"
-                      name="StatusCode.90"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.90"
-                    >
-                      Variation Pending Approval
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1080"
-                      name="StatusCode.1080"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1080"
-                    >
-                      Variation Approved
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1090"
-                      name="StatusCode.1090"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1090"
-                    >
-                      Variation Rejected
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-        <div
-          class="govuk-grid-column-one-half"
-        >
-          <fieldset
-            class="govuk-fieldset"
-          >
-            <legend
-              class="govuk-fieldset__legend govuk-fieldset__legend--m"
-            >
-              Priority
-            </legend>
-            <div
-              class="govuk-checkboxes"
-            >
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="Priorities.I"
-                      name="Priorities.I"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="Priorities.I"
-                    >
-                      Immediate
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="Priorities.E"
-                      name="Priorities.E"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="Priorities.E"
-                    >
-                      Emergency
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-      </div>
-    </div>
-    <div>
-      <button
-        class="govuk-button lbh-button"
-        data-module="govuk-button"
-        type="submit"
-      >
-        Apply filters
-      </button>
-      <div>
-        <a
-          href="#"
-        >
-          Clear filters
-        </a>
-      </div>
-    </div>
-  </details>
-</DocumentFragment>
-`;
-
-exports[`WorkOrdersFilter component When logged in as a contractor should render properly with filter options except authorisation pending approval 1`] = `
-<DocumentFragment>
-  <details
-    class="govuk-details"
-    data-module="govuk-details"
-  >
-    <summary
-      class="govuk-details__summary"
-    >
-      <span
-        class="govuk-details__summary-text"
-      >
-        Filters
-      </span>
-    </summary>
-    <div
-      class="govuk-grid-row undefined"
-    >
-      <div
-        class="govuk-form-group lbh-form-group"
-      >
-        <div
-          class="govuk-grid-column-one-half"
-        >
-          <fieldset
-            class="govuk-fieldset"
-          >
-            <legend
-              class="govuk-fieldset__legend govuk-fieldset__legend--m"
-            >
-              Status
-            </legend>
-            <div
-              class="govuk-checkboxes"
-            >
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.80"
-                      name="StatusCode.80"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.80"
-                    >
-                      In Progress
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.50"
-                      name="StatusCode.50"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.50"
-                    >
-                      Complete
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.30"
-                      name="StatusCode.30"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.30"
-                    >
-                      Work Cancelled
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.90"
-                      name="StatusCode.90"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.90"
-                    >
-                      Variation Pending Approval
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1080"
-                      name="StatusCode.1080"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1080"
-                    >
-                      Variation Approved
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1090"
-                      name="StatusCode.1090"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1090"
-                    >
-                      Variation Rejected
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-        <div
-          class="govuk-grid-column-one-half"
-        >
-          <fieldset
-            class="govuk-fieldset"
-          >
-            <legend
-              class="govuk-fieldset__legend govuk-fieldset__legend--m"
-            >
-              Priority
-            </legend>
-            <div
-              class="govuk-checkboxes"
-            >
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="Priorities.I"
-                      name="Priorities.I"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="Priorities.I"
-                    >
-                      Immediate
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="govuk-form-group lbh-form-group"
-              >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
-                >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="Priorities.E"
-                      name="Priorities.E"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="Priorities.E"
-                    >
-                      Emergency
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-      </div>
-    </div>
-    <div>
-      <button
-        class="govuk-button lbh-button"
-        data-module="govuk-button"
-        type="submit"
-      >
-        Apply filters
-      </button>
-      <div>
-        <a
-          href="#"
-        >
-          Clear filters
-        </a>
-      </div>
-    </div>
-  </details>
-</DocumentFragment>
-`;
-
 exports[`WorkOrdersFilter component When logged in as an authorisation manager should render properly with all filter options 1`] = `
 <DocumentFragment>
-  <details
-    class="govuk-details"
-    data-module="govuk-details"
+  <section
+    class="lbh-collapsible"
   >
-    <summary
-      class="govuk-details__summary"
+    <div
+      aria-expanded="true"
+      class="lbh-collapsible__button filter-collapsible"
     >
-      <span
-        class="govuk-details__summary-text"
+      <h2
+        class="lbh-heading-h2 lbh-collapsible__heading"
       >
         Filters
-      </span>
-    </summary>
+      </h2>
+      <svg
+        height="10"
+        viewBox="0 0 17 10"
+        width="17"
+      >
+        <path
+          d="M2 1.5L8.5 7.5L15 1.5"
+          stroke-width="3"
+        />
+      </svg>
+    </div>
     <div
-      class="govuk-grid-row undefined"
+      class="lbh-collapsible__content govuk-!-margin-0"
     >
       <div
-        class="govuk-form-group lbh-form-group"
+        class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
       >
         <div
-          class="govuk-grid-column-one-half"
+          class="govuk-!-padding-left-2"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Apply filters
+          </button>
+          <div>
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Clear filters
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
         >
           <fieldset
-            class="govuk-fieldset"
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-padding-top-3"
+            >
+              Contractor
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="contractor-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.AVP"
+                  name="ContractorReference.AVP"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.AVP"
+                >
+                  Avonline Network (A) Ltd
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.PCL"
+                  name="ContractorReference.PCL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.PCL"
+                >
+                  Purdy Contracts (P) Ltd
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.SCC"
+                  name="ContractorReference.SCC"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.SCC"
+                >
+                  Alphatrack (S) Systems Lt
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
           >
             <legend
               class="govuk-fieldset__legend govuk-fieldset__legend--m"
@@ -595,184 +128,139 @@ exports[`WorkOrdersFilter component When logged in as an authorisation manager s
               Status
             </legend>
             <div
-              class="govuk-checkboxes"
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="status-filters"
             >
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.80"
+                  name="StatusCode.80"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.80"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.80"
-                      name="StatusCode.80"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.80"
-                    >
-                      In Progress
-                    </label>
-                  </div>
-                </div>
+                  In Progress
+                </label>
               </div>
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.50"
+                  name="StatusCode.50"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.50"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.50"
-                      name="StatusCode.50"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.50"
-                    >
-                      Complete
-                    </label>
-                  </div>
-                </div>
+                  Complete
+                </label>
               </div>
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.30"
+                  name="StatusCode.30"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.30"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.30"
-                      name="StatusCode.30"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.30"
-                    >
-                      Work Cancelled
-                    </label>
-                  </div>
-                </div>
+                  Work Cancelled
+                </label>
               </div>
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1010"
+                  name="StatusCode.1010"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1010"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1010"
-                      name="StatusCode.1010"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1010"
-                    >
-                      Authorisation Pending Approval
-                    </label>
-                  </div>
-                </div>
+                  Authorisation Pending Approval
+                </label>
               </div>
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.90"
+                  name="StatusCode.90"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.90"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.90"
-                      name="StatusCode.90"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.90"
-                    >
-                      Variation Pending Approval
-                    </label>
-                  </div>
-                </div>
+                  Variation Pending Approval
+                </label>
               </div>
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1080"
+                  name="StatusCode.1080"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1080"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1080"
-                      name="StatusCode.1080"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1080"
-                    >
-                      Variation Approved
-                    </label>
-                  </div>
-                </div>
+                  Variation Approved
+                </label>
               </div>
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1090"
+                  name="StatusCode.1090"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1090"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="StatusCode.1090"
-                      name="StatusCode.1090"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="StatusCode.1090"
-                    >
-                      Variation Rejected
-                    </label>
-                  </div>
-                </div>
+                  Variation Rejected
+                </label>
               </div>
             </div>
           </fieldset>
+          <div
+            class="govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-1 status-filters"
+          >
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Show all 7
+            </a>
+          </div>
         </div>
         <div
-          class="govuk-grid-column-one-half"
+          class="border-bottom-grey"
         >
           <fieldset
-            class="govuk-fieldset"
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
           >
             <legend
               class="govuk-fieldset__legend govuk-fieldset__legend--m"
@@ -780,77 +268,834 @@ exports[`WorkOrdersFilter component When logged in as an authorisation manager s
               Priority
             </legend>
             <div
-              class="govuk-checkboxes"
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="priority-filters"
             >
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.I"
+                  name="Priorities.I"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.I"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="Priorities.I"
-                      name="Priorities.I"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="Priorities.I"
-                    >
-                      Immediate
-                    </label>
-                  </div>
-                </div>
+                  Immediate
+                </label>
               </div>
               <div
-                class="govuk-form-group lbh-form-group"
+                class="govuk-checkboxes__item govuk-!-margin-0"
               >
-                <div
-                  class="govuk-checkboxes lbh-checkboxes"
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.E"
+                  name="Priorities.E"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.E"
                 >
-                  <div
-                    class="govuk-checkboxes__item"
-                  >
-                    <input
-                      class="govuk-checkboxes__input"
-                      id="Priorities.E"
-                      name="Priorities.E"
-                      type="checkbox"
-                    />
-                    <label
-                      class="govuk-label govuk-checkboxes__label"
-                      for="Priorities.E"
-                    >
-                      Emergency
-                    </label>
-                  </div>
-                </div>
+                  Emergency
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Trade
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="trade-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.DE"
+                  name="TradeCodes.DE"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.DE"
+                >
+                  DOOR ENTRY ENGINEER
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.EL"
+                  name="TradeCodes.EL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.EL"
+                >
+                  Electrical
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.GL"
+                  name="TradeCodes.GL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.GL"
+                >
+                  Glazing
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.PL"
+                  name="TradeCodes.PL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.PL"
+                >
+                  Plumbing
+                </label>
               </div>
             </div>
           </fieldset>
         </div>
       </div>
     </div>
-    <div>
-      <button
-        class="govuk-button lbh-button"
-        data-module="govuk-button"
-        type="submit"
+  </section>
+</DocumentFragment>
+`;
+
+exports[`WorkOrdersFilter component when logged in as a contract manager should render properly with all filter options 1`] = `
+<DocumentFragment>
+  <section
+    class="lbh-collapsible"
+  >
+    <div
+      aria-expanded="true"
+      class="lbh-collapsible__button filter-collapsible"
+    >
+      <h2
+        class="lbh-heading-h2 lbh-collapsible__heading"
       >
-        Apply filters
-      </button>
-      <div>
-        <a
-          href="#"
+        Filters
+      </h2>
+      <svg
+        height="10"
+        viewBox="0 0 17 10"
+        width="17"
+      >
+        <path
+          d="M2 1.5L8.5 7.5L15 1.5"
+          stroke-width="3"
+        />
+      </svg>
+    </div>
+    <div
+      class="lbh-collapsible__content govuk-!-margin-0"
+    >
+      <div
+        class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
+      >
+        <div
+          class="govuk-!-padding-left-2"
         >
-          Clear filters
-        </a>
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Apply filters
+          </button>
+          <div>
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Clear filters
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-padding-top-3"
+            >
+              Contractor
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="contractor-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.AVP"
+                  name="ContractorReference.AVP"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.AVP"
+                >
+                  Avonline Network (A) Ltd
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.PCL"
+                  name="ContractorReference.PCL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.PCL"
+                >
+                  Purdy Contracts (P) Ltd
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.SCC"
+                  name="ContractorReference.SCC"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.SCC"
+                >
+                  Alphatrack (S) Systems Lt
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Status
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="status-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.80"
+                  name="StatusCode.80"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.80"
+                >
+                  In Progress
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.50"
+                  name="StatusCode.50"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.50"
+                >
+                  Complete
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.30"
+                  name="StatusCode.30"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.30"
+                >
+                  Work Cancelled
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1010"
+                  name="StatusCode.1010"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1010"
+                >
+                  Authorisation Pending Approval
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.90"
+                  name="StatusCode.90"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.90"
+                >
+                  Variation Pending Approval
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1080"
+                  name="StatusCode.1080"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1080"
+                >
+                  Variation Approved
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1090"
+                  name="StatusCode.1090"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1090"
+                >
+                  Variation Rejected
+                </label>
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-1 status-filters"
+          >
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Show all 7
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Priority
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="priority-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.I"
+                  name="Priorities.I"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.I"
+                >
+                  Immediate
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.E"
+                  name="Priorities.E"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.E"
+                >
+                  Emergency
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Trade
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="trade-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.DE"
+                  name="TradeCodes.DE"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.DE"
+                >
+                  DOOR ENTRY ENGINEER
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.EL"
+                  name="TradeCodes.EL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.EL"
+                >
+                  Electrical
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.GL"
+                  name="TradeCodes.GL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.GL"
+                >
+                  Glazing
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.PL"
+                  name="TradeCodes.PL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.PL"
+                >
+                  Plumbing
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
       </div>
     </div>
-  </details>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`WorkOrdersFilter component when logged in as a contractor should render properly without filter by contractor and no authorisation pending approval status 1`] = `
+<DocumentFragment>
+  <section
+    class="lbh-collapsible"
+  >
+    <div
+      aria-expanded="true"
+      class="lbh-collapsible__button filter-collapsible"
+    >
+      <h2
+        class="lbh-heading-h2 lbh-collapsible__heading"
+      >
+        Filters
+      </h2>
+      <svg
+        height="10"
+        viewBox="0 0 17 10"
+        width="17"
+      >
+        <path
+          d="M2 1.5L8.5 7.5L15 1.5"
+          stroke-width="3"
+        />
+      </svg>
+    </div>
+    <div
+      class="lbh-collapsible__content govuk-!-margin-0"
+    >
+      <div
+        class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
+      >
+        <div
+          class="govuk-!-padding-left-2"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Apply filters
+          </button>
+          <div>
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Clear filters
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Status
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="status-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.80"
+                  name="StatusCode.80"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.80"
+                >
+                  In Progress
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.50"
+                  name="StatusCode.50"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.50"
+                >
+                  Complete
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.30"
+                  name="StatusCode.30"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.30"
+                >
+                  Work Cancelled
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.90"
+                  name="StatusCode.90"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.90"
+                >
+                  Variation Pending Approval
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1080"
+                  name="StatusCode.1080"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1080"
+                >
+                  Variation Approved
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1090"
+                  name="StatusCode.1090"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1090"
+                >
+                  Variation Rejected
+                </label>
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-1 status-filters"
+          >
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Show all 6
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Priority
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="priority-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.I"
+                  name="Priorities.I"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.I"
+                >
+                  Immediate
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.E"
+                  name="Priorities.E"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.E"
+                >
+                  Emergency
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Trade
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="trade-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.DE"
+                  name="TradeCodes.DE"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.DE"
+                >
+                  DOOR ENTRY ENGINEER
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.EL"
+                  name="TradeCodes.EL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.EL"
+                >
+                  Electrical
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.GL"
+                  name="TradeCodes.GL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.GL"
+                >
+                  Glazing
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.PL"
+                  name="TradeCodes.PL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.PL"
+                >
+                  Plumbing
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </section>
 </DocumentFragment>
 `;

--- a/src/components/WorkOrders/WorkOrdersView.js
+++ b/src/components/WorkOrders/WorkOrdersView.js
@@ -6,6 +6,7 @@ import Spinner from '../Spinner/Spinner'
 import ErrorMessage from '../Errors/ErrorMessage/ErrorMessage'
 import WorkOrdersFilterView from './Filter/WorkOrdersFilterView'
 import { setFilterOptions } from '../../utils/helpers/filter'
+import { GridColumn, GridRow } from '../Layout/Grid'
 
 const WorkOrdersView = ({ query }) => {
   const router = useRouter()
@@ -71,34 +72,47 @@ const WorkOrdersView = ({ query }) => {
         pageNumber: pageNumber,
         ...(filters?.StatusCode && { StatusCode: filters.StatusCode }),
         ...(filters?.Priorities && { Priorities: filters.Priorities }),
+        ...(filters?.TradeCodes && { TradeCodes: filters.TradeCodes }),
+        ...(filters?.ContractorReference && {
+          ContractorReference: filters.ContractorReference,
+        }),
       },
     })
   }
 
   return (
     <>
-      <WorkOrdersFilterView
-        onFilterSubmit={onFilterSubmit}
-        appliedFilters={queryParams}
-        clearFilters={clearFilters}
-      />
+      <GridRow>
+        <GridColumn
+          width="one-third"
+          className="filter-container govuk-!-padding-0"
+        >
+          <WorkOrdersFilterView
+            onFilterSubmit={onFilterSubmit}
+            appliedFilters={queryParams}
+            clearFilters={clearFilters}
+          />
+        </GridColumn>
 
-      {loading ? (
-        <Spinner />
-      ) : (
-        <>
-          {workOrders && (
+        <GridColumn width="two-thirds">
+          {loading ? (
+            <Spinner />
+          ) : (
             <>
-              <WorkOrdersTable
-                workOrders={workOrders}
-                pageNumber={pageNumber}
-                handlePageClick={handlePageClick}
-              />
+              {workOrders && (
+                <>
+                  <WorkOrdersTable
+                    workOrders={workOrders}
+                    pageNumber={pageNumber}
+                    handlePageClick={handlePageClick}
+                  />
+                </>
+              )}
+              {error && <ErrorMessage label={error} />}
             </>
           )}
-          {error && <ErrorMessage label={error} />}
-        </>
-      )}
+        </GridColumn>
+      </GridRow>
     </>
   )
 }

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -1,5 +1,6 @@
 $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
+
 @import 'node_modules/lbh-frontend/lbh/all';
 @import 'govuk-frontend/govuk/all';
 
@@ -17,3 +18,4 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
 @import 'components/notes';
 @import 'components/pagination';
 @import 'components/appointments';
+@import 'components/filter';

--- a/src/styles/components/filter.scss
+++ b/src/styles/components/filter.scss
@@ -1,0 +1,17 @@
+.filter-collapsible {
+  background-color: #b1b4b6;
+  padding: 10px 20px;
+  width: auto;
+  margin: 0;
+}
+.filter-options {
+  box-shadow: inset 0 0 0 1px #b1b4b6;
+  margin-top: 0;
+}
+
+@media screen and (max-width: 1024px) {
+  .filter-container {
+    width: 100%;
+    margin: 0 0 5px;
+  }
+}

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -31,3 +31,6 @@
 .border-top-black {
   border-top: 2px solid black;
 }
+.border-bottom-grey {
+  border-bottom: 2px solid lbh-colour('lbh-border');
+}

--- a/src/utils/frontend-api-client/work-orders.js
+++ b/src/utils/frontend-api-client/work-orders.js
@@ -11,6 +11,10 @@ export const getWorkOrders = async (pageNumber = 1, options) => {
       PageNumber: pageNumber,
       ...(options.StatusCode && { StatusCode: options.StatusCode }),
       ...(options.Priorities && { Priorities: options.Priorities }),
+      ...(options.TradeCodes && { TradeCodes: options.TradeCodes }),
+      ...(options.ContractorReference && {
+        ContractorReference: options.ContractorReference,
+      }),
     },
     paramsSerializer: paramsSerializer,
   })

--- a/src/utils/frontend-api-client/work-orders.test.js
+++ b/src/utils/frontend-api-client/work-orders.test.js
@@ -27,7 +27,7 @@ describe('getWorkOrder', () => {
 })
 
 describe('getWorkOrders', () => {
-  it('calls the Next JS API', async () => {
+  it('calls the Next JS API with a status filter', async () => {
     const responseData = { data: 'test' }
 
     mockAxios.get.mockImplementationOnce(() =>
@@ -42,6 +42,37 @@ describe('getWorkOrders', () => {
     expect(mockAxios.get).toHaveBeenCalledTimes(1)
     expect(mockAxios.get).toHaveBeenCalledWith('/api/workOrders/', {
       params: { PageNumber: 1, PageSize: 10, StatusCode: [90, 50] },
+      paramsSerializer: paramsSerializer,
+    })
+  })
+
+  it('calls the Next JS API with multiple filter parameters', async () => {
+    const responseData = { data: 'test' }
+
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: responseData,
+      })
+    )
+
+    const response = await getWorkOrders(1, {
+      StatusCode: [90, 50],
+      Priorities: [1, 2],
+      TradeCodes: ['PL'],
+      ContractorReference: 'PCL',
+    })
+
+    expect(response).toEqual(responseData)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith('/api/workOrders/', {
+      params: {
+        PageNumber: 1,
+        PageSize: 10,
+        StatusCode: [90, 50],
+        Priorities: [1, 2],
+        TradeCodes: ['PL'],
+        ContractorReference: 'PCL',
+      },
       paramsSerializer: paramsSerializer,
     })
   })


### PR DESCRIPTION
### Description of change

- Filter by contractor and trade
- Update design to move filters to the left side of the dashboard  on 1024px+ screen
- Don't show filter by contractor for contractors
- Limit filter options to 5 as a default, and add "show all" action to load the rest of the options

https://trello.com/c/Sz1YAGrE/115-as-a-contract-manager-i-can-filter-my-dashboard-by-trade-and-contractor-so-that-i-can-easily-find-jobs-to-approve

### **FILTERS WITH WORK ORDERS**
![Screenshot 2021-05-11 at 10 42 09](https://user-images.githubusercontent.com/34001723/117848515-4b5c6500-b27b-11eb-8250-72f5e5339979.png)

### **FILTERS FOR Contract Manager / Authorisation Manager**
![Screenshot 2021-05-11 at 10 44 45](https://user-images.githubusercontent.com/34001723/117848520-4bf4fb80-b27b-11eb-89e2-aac04086f6c3.png)

### **FILTERS FOR Contractor (not contractors filter)**
![Screenshot 2021-05-11 at 16 59 47](https://user-images.githubusercontent.com/34001723/117848521-4bf4fb80-b27b-11eb-922e-f5eab8159c7c.png)

### **MOBILE VIEW (FILTERS AT TOP)**
![Screenshot 2021-05-10 at 18 01 46](https://user-images.githubusercontent.com/34001723/117848853-9c6c5900-b27b-11eb-8951-f0dc197b1b2c.png)

### **CLOSED COLLAPSIBLE FOR FILTERS**
![Screenshot 2021-05-11 at 17 12 20](https://user-images.githubusercontent.com/34001723/117849404-2e746180-b27c-11eb-9cdb-c7fe4150262d.png)
