### PR TITLE
Respect operative working hours when calculating target dates (part 3)

### DIFF
--- a/src/utils/hact/schedule-repair/raise-repair-form.test.js
+++ b/src/utils/hact/schedule-repair/raise-repair-form.test.js
@@ -1,6 +1,14 @@
 import MockDate from 'mockdate'
 import { buildScheduleRepairFormData } from './raise-repair-form'
 
+const mockBankHolidays = jest.fn()
+
+jest.mock('../../helpers/bank-holidays', () => ({
+  get bankHolidays() {
+    return mockBankHolidays()
+  },
+}))
+
 jest.mock('uuid', () => {
   return {
     v4: jest.fn(() => 'aa757643-cf89-4247-a42c-8a035182feqd'),
@@ -39,6 +47,18 @@ describe('buildRaiseRepairFormData', () => {
   it('builds the ScheduleRepair form data to post to the Repairs API', async () => {
     MockDate.set(new Date('Thu Jan 14 2021 18:16:20Z'))
 
+    // set the following Monday as a bank holiday
+    mockBankHolidays.mockReturnValue({
+      'england-and-wales': {
+        division: 'england-and-wales',
+        events: [
+          {
+            date: '2021-01-19',
+          },
+        ],
+      },
+    })
+
     const scheduleRepairFormData = {
       reference: [
         {
@@ -49,7 +69,7 @@ describe('buildRaiseRepairFormData', () => {
       priority: {
         priorityCode: 3,
         priorityDescription: '4 [U] URGENT',
-        requiredCompletionDateTime: new Date('Thu Jan 21 2021 18:16:20Z'),
+        requiredCompletionDateTime: new Date('Friday Jan 22 2021 18:16:20Z'),
         numberOfDays: 5,
       },
       workClass: {

--- a/src/utils/helpers/bank-holidays.js
+++ b/src/utils/helpers/bank-holidays.js
@@ -1,0 +1,109 @@
+export const bankHolidays = {
+  'england-and-wales': {
+    division: 'england-and-wales',
+    events: [
+      {
+        title: 'New Year’s Day',
+        date: '2021-01-01',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Good Friday',
+        date: '2021-04-02',
+        notes: '',
+        bunting: false,
+      },
+      {
+        title: 'Easter Monday',
+        date: '2021-04-05',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Early May bank holiday',
+        date: '2021-05-03',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Spring bank holiday',
+        date: '2021-05-31',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Summer bank holiday',
+        date: '2021-08-30',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Christmas Day',
+        date: '2021-12-27',
+        notes: 'Substitute day',
+        bunting: true,
+      },
+      {
+        title: 'Boxing Day',
+        date: '2021-12-28',
+        notes: 'Substitute day',
+        bunting: true,
+      },
+      {
+        title: 'New Year’s Day',
+        date: '2022-01-03',
+        notes: 'Substitute day',
+        bunting: true,
+      },
+      {
+        title: 'Good Friday',
+        date: '2022-04-15',
+        notes: '',
+        bunting: false,
+      },
+      {
+        title: 'Easter Monday',
+        date: '2022-04-18',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Early May bank holiday',
+        date: '2022-05-02',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Spring bank holiday',
+        date: '2022-06-02',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Platinum Jubilee bank holiday',
+        date: '2022-06-03',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Summer bank holiday',
+        date: '2022-08-29',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Boxing Day',
+        date: '2022-12-26',
+        notes: '',
+        bunting: true,
+      },
+      {
+        title: 'Christmas Day',
+        date: '2022-12-27',
+        notes: 'Substitute day',
+        bunting: true,
+      },
+    ],
+  },
+}

--- a/src/utils/helpers/completionDateTimes.js
+++ b/src/utils/helpers/completionDateTimes.js
@@ -1,7 +1,17 @@
 import { priorityCodeCompletionTimes } from '../hact/helpers/priority-codes'
-import { isSaturday, addDays, subDays, isWeekend } from 'date-fns'
+import { isSaturday, addDays, subDays, isWeekend, format } from 'date-fns'
+import { bankHolidays } from './bank-holidays'
 
-const isWorkingDay = (date) => !isWeekend(date)
+export const isBankHoliday = (date) => {
+  const formattedDate = format(date, 'yyyy-MM-dd')
+  const englandWalesBankHolidays = bankHolidays['england-and-wales']['events']
+
+  return englandWalesBankHolidays.some(
+    (bankHoliday) => formattedDate === bankHoliday.date
+  )
+}
+
+const isNonWorkingDay = (date) => isWeekend(date) || isBankHoliday(date)
 
 // Returns supplied start date plus however many calendar days we loop over to satisfy
 // the required number of working days.
@@ -14,7 +24,7 @@ const dateAfterCountWorkingDays = (startDate, targetWorkingDaysCount) => {
 
     const date = addDays(startDate, calendarDaysCount)
 
-    if (isWorkingDay(date)) {
+    if (!isNonWorkingDay(date)) {
       workingDaysCount += 1
     }
   }


### PR DESCRIPTION
### Description of change

Use a hardcoded set of bank holidays as an initial implementation of bank holiday detection.

A later iteration is planned to detect bank holidays using an external data source (i.e. GOV UK Bank Holidays API).

### Story Link

[Trello card](https://trello.com/c/j5tgNsSd/21-respect-contractor-working-hours-when-calculating-target-dates)

