### PR TITLE
Fixes for DRS Web Booking Manager session management

### DIFF
--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -42,6 +42,8 @@ const RaiseRepairFormView = ({ propertyReference }) => {
   const [currentUser, setCurrentUser] = useState()
   const router = useRouter()
 
+  const TWELVE_HOURS_IN_SECONDS = 60 * 60 * 12
+
   const onFormSubmit = async (formData) => {
     setLoading(true)
 
@@ -71,6 +73,7 @@ const RaiseRepairFormView = ({ propertyReference }) => {
             schedulerSessionId,
             {
               path: '/',
+              maxAge: TWELVE_HOURS_IN_SECONDS,
             }
           )
         }

--- a/src/pages/logout.js
+++ b/src/pages/logout.js
@@ -20,7 +20,11 @@ export const getServerSideProps = async ({ req, res }) => {
   }
 
   deleteSessions(res, {
-    additionalCookieNames: [process.env.NEXT_PUBLIC_DRS_SESSION_COOKIE_NAME],
+    additionalCookies: {
+      [process.env.NEXT_PUBLIC_DRS_SESSION_COOKIE_NAME]: {
+        path: '/',
+      },
+    },
   })
 
   return { props: {} }

--- a/src/utils/GoogleAuth.js
+++ b/src/utils/GoogleAuth.js
@@ -27,22 +27,28 @@ export const redirectToAcessDenied = (res) => {
   res.end()
 }
 
-export const deleteSessions = (
-  res,
-  options = { additionalCookieNames: [] }
-) => {
-  let { additionalCookieNames } = options
+export const deleteSessions = (res, options = { additionalCookies: {} }) => {
+  let { additionalCookies } = options
 
-  const cookiesForDeletion = [GSSO_TOKEN_NAME, ...additionalCookieNames].map(
+  const googleAuthCookie = {
+    [GSSO_TOKEN_NAME]: {
+      domain: '.hackney.gov.uk',
+      path: '/',
+    },
+  }
+
+  const cookiesForDeletion = { ...googleAuthCookie, ...additionalCookies }
+
+  const serializedCookies = Object.keys(cookiesForDeletion).map(
     (cookieName) => {
       return cookie.serialize(cookieName, null, {
         maxAge: -1,
-        domain: '.hackney.gov.uk',
+        ...cookiesForDeletion[cookieName],
       })
     }
   )
 
-  res.setHeader('Set-Cookie', cookiesForDeletion)
+  res.setHeader('Set-Cookie', serializedCookies)
 
   redirectToLogin(res)
 }

--- a/src/utils/GoogleAuth.test.js
+++ b/src/utils/GoogleAuth.test.js
@@ -1,4 +1,4 @@
-import { isAuthorised } from './GoogleAuth'
+import { isAuthorised, deleteSessions } from './GoogleAuth'
 import jsonwebtoken from 'jsonwebtoken'
 import { createRequest, createResponse } from 'node-mocks-http'
 
@@ -35,6 +35,28 @@ describe('isAuthorised', () => {
         hasContractorPermissions: false,
         hasAnyPermissions: true,
       })
+    })
+  })
+})
+
+describe('deleteSessions', () => {
+  describe('expires the auth session along with other supplied sessions', () => {
+    const res = createResponse()
+
+    test('returns a user object with relevant fields and permissions', () => {
+      deleteSessions(res, {
+        additionalCookies: {
+          'another-cookie': { domain: 'repairs-hub.hackney.gov.uk', path: '/' },
+        },
+      })
+
+      expect(res.getHeaders()['set-cookie']).toContain(
+        `${GSSO_TOKEN_NAME}=null; Max-Age=-1; Domain=.hackney.gov.uk; Path=/`
+      )
+
+      expect(res.getHeaders()['set-cookie']).toContain(
+        'another-cookie=null; Max-Age=-1; Domain=repairs-hub.hackney.gov.uk; Path=/'
+      )
     })
   })
 })


### PR DESCRIPTION
Ensure session cookie deletion happens and set expiry to 12 hours.

Relates to [this Trello card](https://trello.com/c/Heey60Xw/6-allow-agents-to-book-dlo-appointments-without-entering-drs-web-booking-manager-route).