### PR TITLE
Fix auth manager repair raises

### DIFF
--- a/src/components/Property/Contacts/Contacts.js
+++ b/src/components/Property/Contacts/Contacts.js
@@ -2,9 +2,19 @@ import PropTypes from 'prop-types'
 import WarningText from '../../Template/WarningText'
 import ContactsTable from './ContactsTable'
 
+const warningText = (contacts) => {
+  if (contacts.length < 1) {
+    return 'No contact details available for this property'
+  } else if (contacts[0] === 'REMOVED') {
+    return 'You are not permitted to view contact details'
+  }
+}
+
 const Contacts = ({ contacts }) => {
-  return contacts.length < 1 ? (
-    <WarningText text="No contact details available for this property" />
+  const text = warningText(contacts)
+
+  return text ? (
+    <WarningText text={text} />
   ) : (
     <ContactsTable contacts={contacts} />
   )

--- a/src/pages/api/properties/[id].js
+++ b/src/pages/api/properties/[id].js
@@ -22,6 +22,6 @@ export default authoriseServiceAPIRequest(async (req, res, user) => {
   ) {
     res.status(HttpStatus.OK).json(data)
   } else {
-    res.status(HttpStatus.OK).json({ ...data, contacts: '[REMOVED]' })
+    res.status(HttpStatus.OK).json({ ...data, contacts: ['REMOVED'] })
   }
 })

--- a/src/pages/api/properties/[id].js
+++ b/src/pages/api/properties/[id].js
@@ -1,5 +1,9 @@
 import * as HttpStatus from 'http-status-codes'
-import { AGENT_ROLE, CONTRACT_MANAGER_ROLE } from '../../../utils/user'
+import {
+  AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+  CONTRACT_MANAGER_ROLE,
+} from '../../../utils/user'
 import {
   serviceAPIRequest,
   authoriseServiceAPIRequest,
@@ -11,7 +15,11 @@ export default authoriseServiceAPIRequest(async (req, res, user) => {
   const data = await serviceAPIRequest(req)
 
   // redact contact information for contractor responses
-  if (user.hasRole(AGENT_ROLE) || user.hasRole(CONTRACT_MANAGER_ROLE)) {
+  if (
+    user.hasRole(AGENT_ROLE) ||
+    user.hasRole(CONTRACT_MANAGER_ROLE) ||
+    user.hasRole(AUTHORISATION_MANAGER_ROLE)
+  ) {
     res.status(HttpStatus.OK).json(data)
   } else {
     res.status(HttpStatus.OK).json({ ...data, contacts: '[REMOVED]' })

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -13,6 +13,7 @@ const {
   GSSO_TOKEN_NAME,
   AGENTS_GOOGLE_GROUPNAME,
   REPAIRS_SERVICE_API_KEY,
+  AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME,
 } = process.env
 
 describe('GET /api/properties/[id] contact information redaction', () => {
@@ -51,6 +52,65 @@ describe('GET /api/properties/[id] contact information redaction', () => {
         name: 'name',
         email: 'name@example.com',
         groups: [AGENTS_GOOGLE_GROUPNAME],
+      },
+      HACKNEY_JWT_SECRET
+    )
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+    }
+
+    test('the response can include full contact information', async () => {
+      const req = createRequest({
+        method: 'get',
+        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
+        query: {
+          id: '1',
+        },
+        params: {},
+      })
+
+      const res = createResponse()
+
+      await propertiesEndpoint(req, res)
+
+      expect(axios).toHaveBeenCalledTimes(1)
+      expect(axios).toHaveBeenCalledWith({
+        method: 'get',
+        headers,
+        url: `${REPAIRS_SERVICE_API_URL}/properties/1`,
+        params: {},
+        paramsSerializer: paramsSerializer,
+        data: {},
+      })
+
+      const parsedData = JSON.parse(res._getData())
+
+      expect(parsedData['contacts']).toEqual({
+        contacts: [
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('when the cookie is for an authorisation manager', () => {
+    const signedCookie = jsonwebtoken.sign(
+      {
+        name: 'name',
+        email: 'name@example.com',
+        groups: [AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME],
       },
       HACKNEY_JWT_SECRET
     )

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -205,7 +205,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData['contacts']).toEqual('[REMOVED]')
+      expect(parsedData['contacts']).toEqual(['REMOVED'])
     })
   })
 })


### PR DESCRIPTION
Permit auth managers to raise repairs. 

This was implicitly being blocked by redacting the contact information for this user. 

It was done in such a way that the frontend couldn't interpret the API response. This PR also includes logic to reduce the chance of this falling over in the future.