### PR TITLE
Do not allow authorisation approval if higher than spend limit

### DIFF
--- a/cypress/fixtures/work-orders/high-cost-task.json
+++ b/cypress/fixtures/work-orders/high-cost-task.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "64440433-68db-49a7-a589-f37f3cd5ac54",
+    "code": "MWP5R005",
+    "description": "REPAIR STEEL DOOR",
+    "dateAdded": "2021-05-20T14:06:46.179519Z",
+    "quantity": 5,
+    "cost": 203.04,
+    "status": "Unknown",
+    "original": true,
+    "originalQuantity": 5
+  }
+]

--- a/cypress/fixtures/work-orders/high-cost-variation-task.json
+++ b/cypress/fixtures/work-orders/high-cost-variation-task.json
@@ -1,0 +1,16 @@
+{
+  "notes": "Variation reason: It's a big job!",
+  "tasks": [
+    {
+      "id": "a10db47a-04f0-4cff-9e2c-8d81b6bb2d7b",
+      "code": "49000001",
+      "description": "1 Pound Cash Item for use if",
+      "unitCost": 1,
+      "originalQuantity": 50,
+      "currentQuantity": 251,
+      "variedQuantity": 200000
+    }
+  ],
+  "authorName": "Mr Contractor",
+  "variationDate": "2021-04-22T09:46:35.713889Z"
+}

--- a/cypress/integration/work-order/authorisation.spec.js
+++ b/cypress/integration/work-order/authorisation.spec.js
@@ -13,12 +13,21 @@ describe('Authorisation workflow for a work order', () => {
     cy.fixture('work-orders/status-authorisation-pending-approval.json').as(
       'workOrder'
     )
+    cy.fixture('work-orders/task.json').as('task')
+    cy.route('GET', 'api/workOrders/10000012/tasks', '@task').as(
+      'tasks-and-sors-request'
+    )
     cy.route('GET', 'api/workOrders/10000012', '@workOrder')
     cy.route({
       method: 'POST',
       url: '/api/jobStatusUpdate',
       response: '',
     }).as('apiCheck')
+
+    cy.fixture('hub-user/user.json').then((user) => {
+      user.raiseLimit = 1000
+      cy.intercept('GET', 'api/hub-user', user)
+    })
 
     // Visit work order page
     cy.visit(`${Cypress.env('HOST')}/work-orders/10000012`)
@@ -131,6 +140,49 @@ describe('Authorisation workflow for a work order', () => {
 
       cy.get('.govuk-grid-column-one-third').within(() => {
         cy.contains('a', 'Authorisation').should('not.exist')
+      })
+    })
+
+    it('Can not authorise (approve) works order if over raise spend limit', () => {
+      cy.fixture('work-orders/high-cost-task.json').as('high-cost-task')
+      cy.route('GET', 'api/workOrders/10000012/tasks', '@high-cost-task').as(
+        'tasks-and-sors-request'
+      )
+
+      cy.visit(`${Cypress.env('HOST')}/work-orders/10000012/authorisation`)
+
+      cy.contains('Authorisation request: 10000012')
+      cy.contains('This job requires your authorisation')
+
+      // Warning text as work order is above user's raise limit (£1000)
+      cy.get('.govuk-warning-text.lbh-warning-text').within(() => {
+        cy.contains(
+          'Work order is over your raise limit of £1000, please contact a manager to approve. You can still reject the authorisation request however'
+        )
+      })
+
+      cy.get('[type="radio"]').contains('Approve request').should('not.exist')
+      cy.get('[type="radio"]').check('Reject request')
+      cy.get('#note').type('Rejecting!')
+      cy.get('[type="submit"]').contains('Submit').click()
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should('deep.equal', {
+          relatedWorkOrderReference: {
+            id: '10000012',
+          },
+          comments: 'Authorisation rejected: Rejecting!',
+          typeCode: '22',
+        })
+
+      // Confirmation screen
+      cy.get('.lbh-page-announcement').within(() => {
+        cy.get('.lbh-announcement__content').within(() => {
+          cy.contains(
+            'You have rejected the authorisation request for work order 10000012'
+          )
+        })
       })
     })
   })

--- a/src/components/WorkOrder/Authorisation/AuthorisationView.js
+++ b/src/components/WorkOrder/Authorisation/AuthorisationView.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import Link from 'next/link'
 import Spinner from '../../Spinner/Spinner'
@@ -7,18 +7,28 @@ import ErrorMessage from '../../Errors/ErrorMessage/ErrorMessage'
 import BackButton from '../../Layout/BackButton/BackButton'
 import Radios from '../../Form/Radios/Radios'
 import SuccessPage from '../../SuccessPage/SuccessPage'
+import WarningText from '../../Template/WarningText'
 import { TextArea, PrimarySubmitButton } from '../../Form'
 import { postJobStatusUpdate } from '../../../utils/frontend-api-client/job-status-update'
+import { getTasksAndSors } from '../../../utils/frontend-api-client/work-orders/[id]/tasks'
+import { getCurrentUser } from '../../../utils/frontend-api-client/hub-user'
 import {
   buildAuthorisationApprovedFormData,
   buildAuthorisationRejectedFormData,
 } from '../../../utils/hact/job-status-update/authorisation'
+import { calculateTotalCost } from '../../../utils/helpers/calculations'
 
 const AuthorisationView = ({ workOrderReference }) => {
   const [error, setError] = useState()
   const [loading, setLoading] = useState(false)
   const [formSuccess, setFormSuccess] = useState(false)
   const [authorisationApproved, setAuthorisationApproved] = useState(true)
+  const [raiseSpendLimit, setRaiseSpendLimit] = useState()
+  const [overSpendLimit, setOverSpendLimit] = useState()
+  const [formActions, setFormActions] = useState([
+    'Approve request',
+    'Reject request',
+  ])
   const { handleSubmit, register, errors } = useForm({
     mode: 'onChange',
   })
@@ -55,6 +65,37 @@ const AuthorisationView = ({ workOrderReference }) => {
       : setAuthorisationApproved(true)
   }
 
+  const requestTasksAndSors = async (workOrderReference) => {
+    setError(null)
+
+    try {
+      const tasksAndSors = await getTasksAndSors(workOrderReference)
+      const user = await getCurrentUser()
+
+      setRaiseSpendLimit(parseFloat(user.raiseLimit))
+
+      const totalCost = calculateTotalCost(tasksAndSors, 'cost', 'quantity')
+
+      if (totalCost.toFixed(2) > parseFloat(user.raiseLimit)) {
+        setOverSpendLimit(true)
+        setFormActions(['Reject request'])
+      }
+    } catch (e) {
+      console.error('An error has occured:', e.response)
+      setError(
+        `Oops an error occurred with error status: ${e.response?.status}`
+      )
+    }
+
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    setLoading(true)
+
+    requestTasksAndSors(workOrderReference)
+  }, [])
+
   return (
     <>
       {loading ? (
@@ -72,11 +113,18 @@ const AuthorisationView = ({ workOrderReference }) => {
               </Link>
               <br></br>
               <br></br>
+
+              {overSpendLimit && (
+                <WarningText
+                  text={`Work order is over your raise limit of £${raiseSpendLimit}, please contact a manager to approve. You can still reject the authorisation request however.`}
+                />
+              )}
+
               <form role="form" onSubmit={handleSubmit(onSubmitForm)}>
                 <Radios
                   label="This job requires your authorisation"
                   name="options"
-                  options={['Approve request', 'Reject request']}
+                  options={formActions}
                   onChange={displayNotes}
                   register={register({
                     required: 'Please select a process',

--- a/src/components/WorkOrder/Authorisation/VariationAuthorisationSummary.js
+++ b/src/components/WorkOrder/Authorisation/VariationAuthorisationSummary.js
@@ -3,11 +3,14 @@ import cx from 'classnames'
 import {
   calculateCostBeforeVariation,
   calculateChangeInCost,
-  calculateTotalVariedCost,
 } from '../../../utils/helpers/calculations'
 import { longDateToStr } from '../../../utils/date'
 
-const VariationAuthorisationSummary = ({ variationTasks, originalSors }) => {
+const VariationAuthorisationSummary = ({
+  variationTasks,
+  originalSors,
+  totalCostAfterVariation,
+}) => {
   const COST_BEFORE_VARIATION = 'Cost before variation'
   const TOTAL_VARIED_COST = 'Total cost after variation'
   const CHANGE_IN_COST = 'Change in cost'
@@ -39,7 +42,7 @@ const VariationAuthorisationSummary = ({ variationTasks, originalSors }) => {
   }
   const totalVaried = {
     description: TOTAL_VARIED_COST,
-    cost: calculateTotalVariedCost(variationTasks.tasks),
+    cost: totalCostAfterVariation,
   }
 
   //show cost breakdown

--- a/src/components/WorkOrder/Authorisation/VariationAuthorisationSummary.test.js
+++ b/src/components/WorkOrder/Authorisation/VariationAuthorisationSummary.test.js
@@ -42,12 +42,14 @@ describe('VariationAuthorisationSummary component', () => {
         originalQuantity: 1,
       },
     ],
+    totalCostAfterVariation: 16038.0,
   }
   it('should render properly', () => {
     const { asFragment } = render(
       <VariationAuthorisationSummary
         variationTasks={props.variationTasks}
         originalSors={props.originalSors}
+        totalCostAfterVariation={props.totalCostAfterVariation}
       />
     )
     expect(asFragment()).toMatchSnapshot()


### PR DESCRIPTION
- Hide approval option when the variation / authorisation request is higher than vary and raise spend limit respectively
- Allow rejection of a variation / authorisation
- Display warning text that the cost is higher than relevant spend limit, with actual figure, when cost exceeds this limit

### Description of change

A brief description of the change, with enough context for the reviewer to be able to understand why we're making this change.

### Story Link

https://trello.com/c/sru8bGQ4/203-as-an-authorisation-manager-i-can-approve-high-cost-authorisations-up-to-my-raise-spend-limit
https://trello.com/c/KVFQq9BN/202-as-a-contract-manager-i-can-approve-work-orders-pending-variation-up-to-my-vary-limit

![Screenshot 2021-05-21 at 13 45 41](https://user-images.githubusercontent.com/34001723/119140049-a2142c80-ba3b-11eb-9989-bbc24aaf5e11.png)
![Screenshot 2021-05-21 at 13 51 07](https://user-images.githubusercontent.com/34001723/119140053-a3455980-ba3b-11eb-85e6-a8ed18cbd7a5.png)

