### PR TITLE
Update Node runtime to 14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ git clone git@github.com:LBHackney-IT/repairs-hub-frontend.git
 
 ## Building the project for local development
 
-The app needs Node 12, if you have [NVM](https://github.com/nvm-sh/nvm) installed just run `nvm use` in your terminal.
+The app needs Node 14, if you have [NVM](https://github.com/nvm-sh/nvm) installed just run `nvm use` in your terminal.
 
 ### Setup
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: '2'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   timeout: 10
   region: eu-west-2
   stage: ${opt:stage}


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/

Brings our deployed builds in line with the runtime used in test builds.

This avoids potential issues with builds passing on test but the deployed feature not working due to dependencies on functionality in Node > 12. See [Slack discussion](https://ubxd.slack.com/archives/G01F4LM3GJ1/p1611232748007400).
