### PR TITLE
Add filter by contractor for contractors in more than one contractor group

### DIFF
--- a/cypress/integration/work-orders/filter.spec.js
+++ b/cypress/integration/work-orders/filter.spec.js
@@ -623,7 +623,7 @@ describe('Filter work orders', () => {
     })
   })
 
-  context('When logged in as a contractor', () => {
+  context('When logged in as a contractor in one contractor group', () => {
     beforeEach(() => {
       cy.loginWithContractorRole()
 
@@ -706,4 +706,91 @@ describe('Filter work orders', () => {
       cy.get('[data-ref=10000030]')
     })
   })
+
+  context(
+    'When logged in as a contractor in more than one contractor group',
+    () => {
+      beforeEach(() => {
+        cy.loginWithMultipleContractorRole()
+
+        cy.visit(`${Cypress.env('HOST')}/`)
+      })
+
+      it('Lists all filtering options and displays contractors filter', () => {
+        // Contractor filter options
+        cy.get('#contractor-filters').should('exist')
+        cy.get('.govuk-checkboxes')
+          .find('[name="ContractorReference.AVP"]')
+          .should('exist')
+        cy.get('.govuk-checkboxes')
+          .find('[name="ContractorReference.PCL"]')
+          .should('exist')
+        cy.get('.govuk-checkboxes')
+          .find('[name="ContractorReference.SCC"]')
+          .should('exist')
+
+        // Status filter options (none selected by default)
+        cy.get('.govuk-checkboxes')
+          .find('[name="StatusCode.50"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="StatusCode.90"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="StatusCode.80"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="StatusCode.30"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="StatusCode.1010"]')
+          .should('not.exist')
+        cy.get('.govuk-checkboxes')
+          .find('[name="StatusCode.1080"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="StatusCode.1090"]')
+          .should('not.be.checked')
+        // Priority filter options
+        cy.get('.govuk-checkboxes')
+          .find('[name="Priorities.1"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="Priorities.2"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="Priorities.3"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="Priorities.4"]')
+          .should('not.be.checked')
+        // Trade filter options (none selected by default)
+        cy.get('.govuk-checkboxes')
+          .find('[name="TradeCodes.AD"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="TradeCodes.CA"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="TradeCodes.CP"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="TradeCodes.DE"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="TradeCodes.EL"]')
+          .should('not.be.checked')
+        cy.get('.govuk-checkboxes')
+          .find('[name="TradeCodes.PL"]')
+          .should('not.be.checked')
+
+        // Expect all work orders to be displayed
+        cy.get('[data-ref=10000040]')
+        cy.get('[data-ref=10000035]')
+        cy.get('[data-ref=10000036]')
+        cy.get('[data-ref=10000037]')
+        cy.get('[data-ref=10000030]')
+      })
+    }
+  )
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,6 +46,15 @@ Cypress.Commands.add('loginWithContractorRole', () => {
   cy.visit(host)
 })
 
+Cypress.Commands.add('loginWithMultipleContractorRole', () => {
+  const gssoTestKey = Cypress.env('GSSO_TEST_KEY_MULTIPLE_CONTRACTOR')
+
+  cy.getCookies().should('be.empty')
+  cy.setCookie('hackneyToken', gssoTestKey)
+  cy.getCookie('hackneyToken').should('have.property', 'value', gssoTestKey)
+  cy.visit(host)
+})
+
 Cypress.Commands.add('loginWithContractManagerRole', () => {
   const gssoTestKey = Cypress.env('GSSO_TEST_KEY_CONTRACT_MANAGER')
 

--- a/factories/multiple_contractor.js
+++ b/factories/multiple_contractor.js
@@ -1,0 +1,15 @@
+import { Factory } from 'fishery'
+
+export const multipleContractorUserFactory = Factory.define(() => ({
+  name: 'Multiple Contractor',
+  email: 'a.multiple-contractor@hackney.gov.uk',
+  roles: ['contractor', 'contractor'],
+  hasRole: true,
+  hasAgentPermissions: false,
+  hasContractorPermissions: true,
+  hasContractManagerPermissions: false,
+  hasAuthorisationManagerPermissions: false,
+  hasAnyPermissions: true,
+}))
+
+export const multipleContractor = multipleContractorUserFactory.build()

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -28,6 +28,15 @@ const WorkOrdersFilter = ({
     }
   }
 
+  const showContractorFilters = () => {
+    return (
+      user &&
+      (user.hasContractManagerPermissions ||
+        user.hasAuthorisationManagerPermissions ||
+        user.roles.filter((role) => role == 'contractor').length > 1)
+    )
+  }
+
   const showAllCheckboxes = (e, filterType) => {
     e.preventDefault()
 
@@ -72,41 +81,39 @@ const WorkOrdersFilter = ({
           </div>
         </div>
 
-        {user &&
-          (user.hasContractManagerPermissions ||
-            user.hasAuthorisationManagerPermissions) && (
-            <div className="border-bottom-grey">
-              <fieldset className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2">
-                <legend className="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-padding-top-3">
-                  Contractor
-                </legend>
+        {showContractorFilters() && (
+          <div className="border-bottom-grey">
+            <fieldset className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2">
+              <legend className="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-padding-top-3">
+                Contractor
+              </legend>
 
-                <div
-                  className="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
-                  id="contractor-filters"
-                >
-                  {filters.Contractors.map((contractor, index) => (
-                    <Checkbox
-                      className="govuk-!-margin-0"
-                      key={index}
-                      name={`ContractorReference.${contractor.key}`}
-                      label={contractor.description}
-                      register={register}
-                      checked={appliedFilters?.ContractorReference?.includes(
-                        contractor.key
-                      )}
-                      hidden={index >= CHECKBOX_NUMBER}
-                    />
-                  ))}
-                </div>
-              </fieldset>
+              <div
+                className="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+                id="contractor-filters"
+              >
+                {filters.Contractors.map((contractor, index) => (
+                  <Checkbox
+                    className="govuk-!-margin-0"
+                    key={index}
+                    name={`ContractorReference.${contractor.key}`}
+                    label={contractor.description}
+                    register={register}
+                    checked={appliedFilters?.ContractorReference?.includes(
+                      contractor.key
+                    )}
+                    hidden={index >= CHECKBOX_NUMBER}
+                  />
+                ))}
+              </div>
+            </fieldset>
 
-              {showAllCheckboxesHtml(
-                filters.Contractors.length,
-                'contractor-filters'
-              )}
-            </div>
-          )}
+            {showAllCheckboxesHtml(
+              filters.Contractors.length,
+              'contractor-filters'
+            )}
+          </div>
+        )}
 
         <div className="border-bottom-grey">
           <fieldset className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2">

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
@@ -4,6 +4,7 @@ import WorkOrdersFilter from './WorkOrdersFilter'
 import { contractor } from 'factories/contractor'
 import { contractManager } from 'factories/contract_manager'
 import { authorisationManager } from 'factories/authorisation_manager'
+import { multipleContractor } from 'factories/multiple_contractor'
 
 describe('WorkOrdersFilter component', () => {
   const props = {
@@ -86,10 +87,26 @@ describe('WorkOrdersFilter component', () => {
     clearFilters: jest.fn(),
   }
 
-  describe('when logged in as a contractor', () => {
+  describe('when logged in as a contractor with one contractor role', () => {
     it('should render properly without filter by contractor and no authorisation pending approval status', () => {
       const { asFragment } = render(
         <UserContext.Provider value={{ user: contractor }}>
+          <WorkOrdersFilter
+            filters={props.filters}
+            loading={props.loading}
+            register={props.register}
+            clearFilters={props.clearFilters}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when logged in as a contractor with more than one contractor role', () => {
+    it('should render properly with filter by contractor (only groups they belong to) and no authorisation pending approval status', () => {
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user: multipleContractor }}>
           <WorkOrdersFilter
             filters={props.filters}
             loading={props.loading}

--- a/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
+++ b/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
@@ -394,7 +394,385 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
 </DocumentFragment>
 `;
 
-exports[`WorkOrdersFilter component when logged in as a contractor should render properly without filter by contractor and no authorisation pending approval status 1`] = `
+exports[`WorkOrdersFilter component when logged in as a contractor with more than one contractor role should render properly with filter by contractor (only groups they belong to) and no authorisation pending approval status 1`] = `
+<DocumentFragment>
+  <section
+    class="lbh-collapsible"
+  >
+    <div
+      aria-expanded="true"
+      class="lbh-collapsible__button filter-collapsible"
+    >
+      <h2
+        class="lbh-heading-h2 lbh-collapsible__heading"
+      >
+        Filters
+      </h2>
+      <svg
+        height="10"
+        viewBox="0 0 17 10"
+        width="17"
+      >
+        <path
+          d="M2 1.5L8.5 7.5L15 1.5"
+          stroke-width="3"
+        />
+      </svg>
+    </div>
+    <div
+      class="lbh-collapsible__content govuk-!-margin-0"
+    >
+      <div
+        class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
+      >
+        <div
+          class="govuk-!-padding-left-2"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Apply filters
+          </button>
+          <div>
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Clear filters
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-padding-top-3"
+            >
+              Contractor
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="contractor-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.AVP"
+                  name="ContractorReference.AVP"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.AVP"
+                >
+                  Avonline Network (A) Ltd
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.PCL"
+                  name="ContractorReference.PCL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.PCL"
+                >
+                  Purdy Contracts (P) Ltd
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="ContractorReference.SCC"
+                  name="ContractorReference.SCC"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="ContractorReference.SCC"
+                >
+                  Alphatrack (S) Systems Lt
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Status
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="status-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.80"
+                  name="StatusCode.80"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.80"
+                >
+                  In Progress
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.50"
+                  name="StatusCode.50"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.50"
+                >
+                  Complete
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.30"
+                  name="StatusCode.30"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.30"
+                >
+                  Work Cancelled
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.90"
+                  name="StatusCode.90"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.90"
+                >
+                  Variation Pending Approval
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1080"
+                  name="StatusCode.1080"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1080"
+                >
+                  Variation Approved
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1090"
+                  name="StatusCode.1090"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1090"
+                >
+                  Variation Rejected
+                </label>
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-1 status-filters"
+          >
+            <a
+              class="govuk-link"
+              href="#"
+            >
+              Show all 6
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Priority
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="priority-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.I"
+                  name="Priorities.I"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.I"
+                >
+                  Immediate
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="Priorities.E"
+                  name="Priorities.E"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.E"
+                >
+                  Emergency
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Trade
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="trade-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.DE"
+                  name="TradeCodes.DE"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.DE"
+                >
+                  DOOR ENTRY ENGINEER
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.EL"
+                  name="TradeCodes.EL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.EL"
+                >
+                  Electrical
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.GL"
+                  name="TradeCodes.GL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.GL"
+                >
+                  Glazing
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.PL"
+                  name="TradeCodes.PL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.PL"
+                >
+                  Plumbing
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`WorkOrdersFilter component when logged in as a contractor with one contractor role should render properly without filter by contractor and no authorisation pending approval status 1`] = `
 <DocumentFragment>
   <section
     class="lbh-collapsible"


### PR DESCRIPTION
### Description of change

- Add filter by contractor for contractors in more than one contractor group
- The API only returns the contractor options for which the logged in contractor belongs to a group in
- If only part of one contractor group then the contractors filter is not displayed

### Story Link

https://trello.com/c/zM6SuCeP/165-as-a-user-who-is-part-of-multiple-contractors-i-need-to-be-able-filter-jobs-so-that-i-can-only-see-jobs-on-a-particular-contract