### PR TITLE
Return the Repairs API error message for 404 responses if present

### DIFF
--- a/src/pages/api/[...path].test.js
+++ b/src/pages/api/[...path].test.js
@@ -75,7 +75,7 @@ describe('/api/[...path]', () => {
 
         axios.mockImplementationOnce(() =>
           Promise.reject({
-            response: { status: HttpStatus.NOT_FOUND },
+            response: { status: HttpStatus.NOT_FOUND, data: 'error message' },
           })
         )
 
@@ -93,7 +93,7 @@ describe('/api/[...path]', () => {
 
         expect(res._getStatusCode()).toBe(HttpStatus.NOT_FOUND)
         expect(JSON.parse(res._getData())).toEqual({
-          message: 'Resource not found',
+          message: 'error message',
         })
       })
 

--- a/src/utils/service-api-client.js
+++ b/src/utils/service-api-client.js
@@ -93,7 +93,7 @@ export const authoriseServiceAPIRequest = (callBack) => {
         errorResponse?.status === HttpStatus.NOT_FOUND
           ? res
               .status(HttpStatus.NOT_FOUND)
-              .json({ message: `Resource not found` })
+              .json({ message: errorResponse?.data || 'Resource not found' })
           : // Return the actual error status and message from the service API
             res
               .status(errorResponse?.status)


### PR DESCRIPTION
The frontend was showing the generic 'Resource not found' error when the error message from the service API would have been more helpful.