### PR TITLE
Remove warnings and refactor TmoName component

### DIFF
--- a/src/components/Property/TmoName.js
+++ b/src/components/Property/TmoName.js
@@ -1,18 +1,11 @@
 import PropTypes from 'prop-types'
 
-const TmoName = ({ tmoName }) => {
-  let tmoToShow = (tmoName) => {
-    if (tmoName) {
-      return <li className="bg-orange">TMO: {tmoName}</li>
-    } else {
-      return ''
-    }
-  }
-  return <>{tmoToShow(tmoName)}</>
-}
+const TmoName = ({ tmoName }) => (
+  <>{tmoName && <li className="bg-orange">TMO: {tmoName}</li>}</>
+)
 
 TmoName.propTypes = {
-  tmoName: PropTypes.string.isRequired,
+  tmoName: PropTypes.string,
 }
 
 export default TmoName


### PR DESCRIPTION
### Description of change

Remove warnings and refactor `TmoName` component

```
Warning: Failed prop type: The prop `tmoName` is marked as required in `TmoName`, but its value is `undefined`.
```