### PR TITLE
Display filter by contractor when a contractor group contains many contractor options

### DIFF
--- a/cypress/integration/work-orders/filter.spec.js
+++ b/cypress/integration/work-orders/filter.spec.js
@@ -627,6 +627,13 @@ describe('Filter work orders', () => {
     beforeEach(() => {
       cy.loginWithContractorRole()
 
+      cy.fixture('filter/work-order.json')
+        .then((filters) => {
+          filters.Contractors.splice(1, 3)
+        })
+        .as('workOrderFilters')
+      cy.route('GET', `api/filter/WorkOrder`, '@workOrderFilters')
+
       cy.visit(`${Cypress.env('HOST')}/`)
     })
 

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -29,12 +29,7 @@ const WorkOrdersFilter = ({
   }
 
   const showContractorFilters = () => {
-    return (
-      user &&
-      (user.hasContractManagerPermissions ||
-        user.hasAuthorisationManagerPermissions ||
-        user.roles.filter((role) => role == 'contractor').length > 1)
-    )
+    return filters.Contractors.length > 1
   }
 
   const showAllCheckboxes = (e, filterType) => {

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
@@ -87,22 +87,6 @@ describe('WorkOrdersFilter component', () => {
     clearFilters: jest.fn(),
   }
 
-  describe('when logged in as a contractor with one contractor role', () => {
-    it('should render properly without filter by contractor and no authorisation pending approval status', () => {
-      const { asFragment } = render(
-        <UserContext.Provider value={{ user: contractor }}>
-          <WorkOrdersFilter
-            filters={props.filters}
-            loading={props.loading}
-            register={props.register}
-            clearFilters={props.clearFilters}
-          />
-        </UserContext.Provider>
-      )
-      expect(asFragment()).toMatchSnapshot()
-    })
-  })
-
   describe('when logged in as a contractor with more than one contractor role', () => {
     it('should render properly with filter by contractor (only groups they belong to) and no authorisation pending approval status', () => {
       const { asFragment } = render(
@@ -139,6 +123,30 @@ describe('WorkOrdersFilter component', () => {
     it('should render properly with all filter options', () => {
       const { asFragment } = render(
         <UserContext.Provider value={{ user: authorisationManager }}>
+          <WorkOrdersFilter
+            filters={props.filters}
+            loading={props.loading}
+            register={props.register}
+            clearFilters={props.clearFilters}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when logged in as a contractor with one contractor role', () => {
+    it('should render properly without filter by contractor and no authorisation pending approval status', () => {
+      // Return one contractor option
+      props.filters.Contractors = [
+        {
+          key: 'AVP',
+          description: 'Avonline Network (A) Ltd',
+        },
+      ]
+
+      const { asFragment } = render(
+        <UserContext.Provider value={{ user: contractor }}>
           <WorkOrdersFilter
             filters={props.filters}
             loading={props.loading}


### PR DESCRIPTION
### Description of change

Display filter by contractor when a contractor group contains many contractor options
- DLO contractor group is associated with several contractors
- When the API returns more than one result from the contractors filter we show filter by contractor

The API will return just a single contractor filter option when that user is part of one contractor group that isn't the DLO. If they are in the DLO then we get a full list of associated contractors with this. Therefore the frontend just needs to check whether we get more than one option in this contractor filters array and display if so.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/178315089
