### PR TITLE
Prompt to open web booking manager only for lower priority DLO orders

### DIFF
--- a/cypress/integration/raise-repair/e2e-flow.spec.js
+++ b/cypress/integration/raise-repair/e2e-flow.spec.js
@@ -413,47 +413,172 @@ describe('Schedule appointment form', () => {
       }).as('schedulerSession')
     })
 
-    it('Shows a success page instead of the calendar with a link to the external scheduler', () => {
-      cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
-      cy.get('.lbh-heading-h2')
-        .contains('Raise a repair on this dwelling')
-        .click()
+    describe('and the priority is Normal (N)', () => {
+      it('Shows a success page instead of the calendar with a link to the external scheduler', () => {
+        cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+        cy.get('.lbh-heading-h2')
+          .contains('Raise a repair on this dwelling')
+          .click()
 
-      cy.get('#repair-request-form').within(() => {
-        cy.get('#trade').type('Plumbing - PL')
-        cy.get('#contractor').select('HH General Building Repair - H01')
+        cy.get('#repair-request-form').within(() => {
+          cy.get('#trade').type('Plumbing - PL')
+          cy.get('#contractor').select('HH General Building Repair - H01')
 
-        cy.get('select[id="rateScheduleItems[0][code]"]').select(
-          'DES5R005 - Normal call outs'
+          cy.get('select[id="rateScheduleItems[0][code]"]').select(
+            'DES5R005 - Normal call outs'
+          )
+
+          cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
+          cy.get('#priorityDescription').select('5 [N] NORMAL')
+          cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
+          cy.get('#callerName').type('NA', { force: true })
+          cy.get('#contactNumber')
+            .clear({ force: true })
+            .type('NA', { force: true })
+          cy.get('[type="submit"]')
+            .contains('Create works order')
+            .click({ force: true })
+        })
+
+        cy.contains('Repair works order created')
+
+        cy.contains('Please open DRS to book an appointment')
+        cy.contains('a', 'open DRS').should(
+          'have.attr',
+          'href',
+          'https://scheduler.example.hackney.gov.uk?bookingId=1&sessionId=SCHEDULER_SESSION_ID'
         )
+        cy.contains('a', 'open DRS').should('have.attr', 'target', '_blank')
 
-        cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-        cy.get('#priorityDescription').select('5 [N] NORMAL')
-        cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
-        cy.get('#callerName').type('NA', { force: true })
-        cy.get('#contactNumber')
-          .clear({ force: true })
-          .type('NA', { force: true })
-        cy.get('[type="submit"]')
-          .contains('Create works order')
-          .click({ force: true })
+        cy.getCookie(Cypress.env('NEXT_PUBLIC_DRS_SESSION_COOKIE_NAME')).should(
+          'have.property',
+          'value',
+          'SCHEDULER_SESSION_ID'
+        )
       })
+    })
 
-      cy.contains('Repair works order created')
+    describe('and the priority is Urgent (U)', () => {
+      it('Shows a success page instead of the calendar with a link to the external scheduler', () => {
+        cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+        cy.get('.lbh-heading-h2')
+          .contains('Raise a repair on this dwelling')
+          .click()
 
-      cy.contains('Please open DRS to book an appointment')
-      cy.contains('a', 'open DRS').should(
-        'have.attr',
-        'href',
-        'https://scheduler.example.hackney.gov.uk?bookingId=1&sessionId=SCHEDULER_SESSION_ID'
-      )
-      cy.contains('a', 'open DRS').should('have.attr', 'target', '_blank')
+        cy.get('#repair-request-form').within(() => {
+          cy.get('#trade').type('Plumbing - PL')
+          cy.get('#contractor').select('HH General Building Repair - H01')
 
-      cy.getCookie(Cypress.env('NEXT_PUBLIC_DRS_SESSION_COOKIE_NAME')).should(
-        'have.property',
-        'value',
-        'SCHEDULER_SESSION_ID'
-      )
+          cy.get('select[id="rateScheduleItems[0][code]"]').select(
+            'DES5R006 - Urgent call outs'
+          )
+
+          cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
+          cy.get('#priorityDescription').select('4 [U] URGENT')
+          cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
+          cy.get('#callerName').type('NA', { force: true })
+          cy.get('#contactNumber')
+            .clear({ force: true })
+            .type('NA', { force: true })
+          cy.get('[type="submit"]')
+            .contains('Create works order')
+            .click({ force: true })
+        })
+
+        cy.contains('Repair works order created')
+
+        cy.contains('Please open DRS to book an appointment')
+        cy.contains('a', 'open DRS').should(
+          'have.attr',
+          'href',
+          'https://scheduler.example.hackney.gov.uk?bookingId=1&sessionId=SCHEDULER_SESSION_ID'
+        )
+        cy.contains('a', 'open DRS').should('have.attr', 'target', '_blank')
+
+        cy.getCookie(Cypress.env('NEXT_PUBLIC_DRS_SESSION_COOKIE_NAME')).should(
+          'have.property',
+          'value',
+          'SCHEDULER_SESSION_ID'
+        )
+      })
+    })
+
+    describe('and the priority is Immediate (I)', () => {
+      it('Shows a success page instead of the calendar with no link to the external scheduler but text informing that the repair has been sent directly to the planners', () => {
+        cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+        cy.get('.lbh-heading-h2')
+          .contains('Raise a repair on this dwelling')
+          .click()
+
+        cy.get('#repair-request-form').within(() => {
+          cy.get('#trade').type('Plumbing - PL')
+          cy.get('#contractor').select('HH General Building Repair - H01')
+
+          cy.get('select[id="rateScheduleItems[0][code]"]').select(
+            'DES5R003 - Immediate call outs'
+          )
+
+          cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
+          cy.get('#priorityDescription').select('1 [I] IMMEDIATE')
+          cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
+          cy.get('#callerName').type('NA', { force: true })
+          cy.get('#contactNumber')
+            .clear({ force: true })
+            .type('NA', { force: true })
+          cy.get('[type="submit"]')
+            .contains('Create works order')
+            .click({ force: true })
+        })
+
+        cy.contains('Repair works order created')
+
+        cy.contains('Please open DRS to book an appointment').should(
+          'not.exist'
+        )
+        cy.contains('a', 'open DRS').should('not.exist')
+        cy.contains(
+          'Emergency and immediate DLO repairs are sent directly to the Planners. An appointment does not need to be booked.'
+        )
+      })
+    })
+
+    describe('and the priority is Emergency (E)', () => {
+      it('Shows a success page instead of the calendar with no link to the external scheduler but text informing that the repair has been sent directly to the planners', () => {
+        cy.visit(`${Cypress.env('HOST')}/properties/00012345`)
+        cy.get('.lbh-heading-h2')
+          .contains('Raise a repair on this dwelling')
+          .click()
+
+        cy.get('#repair-request-form').within(() => {
+          cy.get('#trade').type('Plumbing - PL')
+          cy.get('#contractor').select('HH General Building Repair - H01')
+
+          cy.get('select[id="rateScheduleItems[0][code]"]').select(
+            'DES5R004 - Emergency call out'
+          )
+
+          cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
+          cy.get('#priorityDescription').select('2 [E] EMERGENCY')
+          cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
+          cy.get('#callerName').type('NA', { force: true })
+          cy.get('#contactNumber')
+            .clear({ force: true })
+            .type('NA', { force: true })
+          cy.get('[type="submit"]')
+            .contains('Create works order')
+            .click({ force: true })
+        })
+
+        cy.contains('Repair works order created')
+
+        cy.contains('Please open DRS to book an appointment').should(
+          'not.exist'
+        )
+        cy.contains('a', 'open DRS').should('not.exist')
+        cy.contains(
+          'Emergency and immediate DLO repairs are sent directly to the Planners. An appointment does not need to be booked.'
+        )
+      })
     })
 
     describe('and the user already has a session cookie for the scheduler', () => {

--- a/src/components/SuccessPage/SuccessPage.js
+++ b/src/components/SuccessPage/SuccessPage.js
@@ -43,6 +43,17 @@ const SuccessPage = ({ ...props }) => {
           </li>
         )}
 
+        {props.immediateOrEmergencyDloRepairText && (
+          <li>
+            <p>
+              <strong>
+                Emergency and immediate DLO repairs are sent directly to the
+                Planners. An appointment does not need to be booked.
+              </strong>
+            </p>
+          </li>
+        )}
+
         {props.workOrderReference && (
           <li>
             <Link href={`/work-orders/${props.workOrderReference}`}>

--- a/src/components/SuccessPage/SuccessPage.test.js
+++ b/src/components/SuccessPage/SuccessPage.test.js
@@ -71,5 +71,16 @@ describe('SuccessPage component', () => {
         expect(asFragment()).toMatchSnapshot()
       })
     })
+
+    describe('With Emergency and Immediate DLO repairs text', () => {
+      it('should render text that Emergency and immediate DLO repairs are sent directly to the Planners', () => {
+        const testProps = {
+          ...props,
+          immediateOrEmergencyDloRepairText: true,
+        }
+        const { asFragment } = render(<SuccessPage {...testProps} />)
+        expect(asFragment()).toMatchSnapshot()
+      })
+    })
   })
 })

--- a/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
+++ b/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
@@ -170,6 +170,73 @@ exports[`SuccessPage component Raising a repair High cost (over raise limit) aut
 </DocumentFragment>
 `;
 
+exports[`SuccessPage component Raising a repair With Emergency and Immediate DLO repairs text should render text that Emergency and immediate DLO repairs are sent directly to the Planners 1`] = `
+<DocumentFragment>
+  <div>
+    <section
+      class="text-align-center lbh-page-announcement"
+    >
+      <div
+        class="lbh-announcement__content"
+      >
+        <h2>
+          Repair works order created
+        </h2>
+        <p>
+          Works order number
+        </p>
+        <strong
+          class="govuk-!-font-size-24"
+        >
+          10000012
+        </strong>
+      </div>
+    </section>
+    <ul
+      class="lbh-list lbh-!-margin-top-9"
+    >
+      <li>
+        <p>
+          <strong>
+            Emergency and immediate DLO repairs are sent directly to the Planners. An appointment does not need to be booked.
+          </strong>
+        </p>
+      </li>
+      <li>
+        <a
+          class="lbh-link"
+          href="/work-orders/10000012"
+        >
+          <strong>
+            View work order
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          class="lbh-link"
+          href="/properties/12345678"
+        >
+          <strong>
+            Back to 12 Random Lane
+          </strong>
+        </a>
+      </li>
+      <li>
+        <a
+          class="lbh-link"
+          href="/"
+        >
+          <strong>
+            Start a new search
+          </strong>
+        </a>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SuccessPage component Raising a repair With an external scheduler URL should render text with a link to schedule externally 1`] = `
 <DocumentFragment>
   <div>


### PR DESCRIPTION
### Description of change

- Following the creation of an immediate or emergency priority order which is for the DLO, I do not see a link to open DRS. Instead I see a message: 'Emergency and immediate DLO repairs are sent directly to the Planners. An appointment does not need to be booked.'
- Following the creation of an urgent or normal priority order which is for the DLO, I see a link to open DRS web booking manager.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/178469195

![Screenshot 2021-06-15 at 12 15 27](https://user-images.githubusercontent.com/34001723/122053134-61ab9280-cdde-11eb-85da-410a72fe4b8c.png)
