### PR TITLE
Add colour for no access status

### DIFF
--- a/src/styles/components/work-orders.scss
+++ b/src/styles/components/work-orders.scss
@@ -63,6 +63,10 @@
         background-color: repairs-hub-colour('danger');
         color: repairs-hub-colour('white');
       }
+      &--status-no-access {
+        background-color: repairs-hub-colour('grey');
+        color: repairs-hub-colour('black');
+      }
     }
   }
 }


### PR DESCRIPTION
### Description of change

Add grey colour for work orders with no access status

### Story Link

https://www.pivotaltracker.com/story/show/178315029

### Screenshot

![Screenshot 2021-06-17 at 13 14 53](https://user-images.githubusercontent.com/7561969/122395791-3f954a00-cf6f-11eb-8f55-e4c5c783cc30.jpg)
