### PR TITLE
Fix fragile update work order spec

### DIFF
--- a/cypress/integration/work-order/update-work-order.spec.js
+++ b/cypress/integration/work-order/update-work-order.spec.js
@@ -137,29 +137,27 @@ describe('Contractor update a job', () => {
 
     cy.get('#repair-request-form').within(() => {
       // Enter multiple invalid SOR codes
-      cy.get('input[id="rateScheduleItems[0][code]"]').type('fakecode').blur()
-      cy.get('[type="submit"]').contains('Next').click()
-      cy.wait('@sorCodeNotFound')
+      cy.get('input[id="rateScheduleItems[0][code]"]').type('fakecode')
       cy.get(
         'div[id="rateScheduleItems[0][code]-form-group"] .govuk-error-message'
       ).within(() => {
         cy.contains('SOR code is not valid')
       })
+      cy.get('[type="submit"]').contains('Next').click()
+      cy.wait('@sorCodeNotFound')
       cy.get('[data-error-id="error-0"]').within(() => {
         cy.contains('Could not find SOR code: FAKECODE')
       })
 
       cy.contains('+ Add another SOR code').click()
-      cy.get('input[id="rateScheduleItems[1][code]"]')
-        .type('anotherfakecode')
-        .blur()
-      cy.wait('@sorCodeNotFound')
-      cy.get('[type="submit"]').contains('Next').click()
+      cy.get('input[id="rateScheduleItems[1][code]"]').type('anotherfakecode')
       cy.get(
         'div[id="rateScheduleItems[1][code]-form-group"] .govuk-error-message'
       ).within(() => {
         cy.contains('SOR code is not valid')
       })
+      cy.get('[type="submit"]').contains('Next').click()
+      cy.wait('@sorCodeNotFound')
       cy.get('[data-error-id="error-0"]').within(() => {
         cy.contains('Could not find SOR code: FAKECODE')
       })


### PR DESCRIPTION
Blurring the input triggers a load of SOR codes from the API and causes a spinner to appear losing our validation message. By not blurring we keep the error message and then clicking 'Next' allows us to get the 'Could not find SOR code' message.