### PR TITLE
Halve expiry time for DRS session ID

### DIFF
--- a/src/utils/frontend-api-client/users/schedulerSession.js
+++ b/src/utils/frontend-api-client/users/schedulerSession.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import Cookies from 'universal-cookie'
 
-const TWELVE_HOURS_IN_SECONDS = 60 * 60 * 12
+const SIX_HOURS_IN_SECONDS = 60 * 60 * 6
 
 export const getOrCreateSchedulerSessionId = async () => {
   const cookies = new Cookies()
@@ -18,7 +18,7 @@ export const getOrCreateSchedulerSessionId = async () => {
       schedulerSessionId,
       {
         path: '/',
-        maxAge: TWELVE_HOURS_IN_SECONDS,
+        maxAge: SIX_HOURS_IN_SECONDS,
       }
     )
   }


### PR DESCRIPTION
Attempt at hotfix for https://hackit-lbh.slack.com/archives/C017N5GA8P8/p1624013386479100

The DRS documentation and response object doesn't seem to give us an explicit expiry time, but we're seeing occasional invalid credentials messages which could be due to the session expiring.

> A sessionId is returned which is used as authentication on all following calls to the web service for that day i.e. a session id will persist for a given date and time range.