### PR TITLE
More UI changes

### DIFF
--- a/cypress/integration/raise-repair/e2e-flow.spec.js
+++ b/cypress/integration/raise-repair/e2e-flow.spec.js
@@ -218,7 +218,7 @@ describe('Schedule appointment form', () => {
         cy.get('.lbh-page-announcement__title').contains(
           'Repair works order created'
         )
-        cy.get('.lbh-announcement__content').within(() => {
+        cy.get('.lbh-page-announcement__content').within(() => {
           cy.contains('Works order number')
           cy.contains('10102030')
         })

--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -526,7 +526,7 @@ describe('Raise repair form', () => {
       cy.get('.lbh-page-announcement__title').contains(
         'Repair works order created'
       )
-      cy.get('.lbh-announcement__content').within(() => {
+      cy.get('.lbh-page-announcement__content').within(() => {
         cy.contains('Works order number')
         cy.contains('10102030')
       })
@@ -646,7 +646,7 @@ describe('Raise repair form', () => {
       cy.get('.lbh-page-announcement__title').contains(
         'Repair works order created'
       )
-      cy.get('.lbh-announcement__content').within(() => {
+      cy.get('.lbh-page-announcement__content').within(() => {
         cy.contains('Works order number')
         cy.contains('10102030')
       })

--- a/cypress/integration/search/search-for-property-or-work-order.spec.js
+++ b/cypress/integration/search/search-for-property-or-work-order.spec.js
@@ -26,9 +26,9 @@ describe('Search by work order reference, postcode or address', () => {
         })
 
         it('checks the heading', () => {
-          cy.get('.lbh-heading-h4').contains(
-            'We found 2 matching results for: e9 6pt'
-          )
+          cy.get('.govuk-table').within(() => {
+            cy.contains('caption', 'We found 2 matching results for: e9 6pt')
+          })
         })
 
         it('checks the table', () => {
@@ -65,10 +65,10 @@ describe('Search by work order reference, postcode or address', () => {
           cy.get('[type="submit"]').contains('Search').click()
         })
 
-        it('checks the heading', () => {
-          cy.get('.lbh-heading-h4').contains(
-            'We found 2 matching results for: pitcairn'
-          )
+        it.only('checks the heading', () => {
+          cy.get('.govuk-table').within(() => {
+            cy.contains('caption', 'We found 2 matching results for: pitcairn')
+          })
 
           // Run lighthouse audit for accessibility report
           cy.audit()

--- a/cypress/integration/work-order/authorisation.spec.js
+++ b/cypress/integration/work-order/authorisation.spec.js
@@ -79,10 +79,12 @@ describe('Authorisation workflow for a work order', () => {
 
       // Confirmation screen
       cy.get('.lbh-page-announcement').within(() => {
-        cy.get('.lbh-announcement__content').within(() => {
-          cy.contains(
-            'You have rejected the authorisation request for work order 10000012'
-          )
+        cy.get('.lbh-page-announcement__title').contains(
+          'You have rejected the authorisation request'
+        )
+        cy.get('.lbh-page-announcement__content').within(() => {
+          cy.contains('Works order number')
+          cy.contains('10000012')
         })
       })
 
@@ -128,10 +130,12 @@ describe('Authorisation workflow for a work order', () => {
 
       // Confirmation screen
       cy.get('.lbh-page-announcement').within(() => {
-        cy.get('.lbh-announcement__content').within(() => {
-          cy.contains(
-            'You have approved the authorisation request for work order 10000012'
-          )
+        cy.get('.lbh-page-announcement__title').contains(
+          'You have approved the authorisation request'
+        )
+        cy.get('.lbh-page-announcement__content').within(() => {
+          cy.contains('Works order number')
+          cy.contains('10000012')
         })
       })
 
@@ -195,10 +199,12 @@ describe('Authorisation workflow for a work order', () => {
 
       // Confirmation screen
       cy.get('.lbh-page-announcement').within(() => {
-        cy.get('.lbh-announcement__content').within(() => {
-          cy.contains(
-            'You have rejected the authorisation request for work order 10000012'
-          )
+        cy.get('.lbh-page-announcement__title').contains(
+          'You have rejected the authorisation request'
+        )
+        cy.get('.lbh-page-announcement__content').within(() => {
+          cy.contains('Works order number')
+          cy.contains('10000012')
         })
       })
     })

--- a/cypress/integration/work-order/variation-authorisation.spec.js
+++ b/cypress/integration/work-order/variation-authorisation.spec.js
@@ -81,7 +81,16 @@ describe('Contract manager can authorise variation', () => {
         typeCode: '125',
       })
 
-    cy.contains('You have rejected a variation for work order 10000012')
+    // Confirmation screen
+    cy.get('.lbh-page-announcement').within(() => {
+      cy.get('.lbh-page-announcement__title').contains(
+        'You have rejected a variation'
+      )
+      cy.get('.lbh-page-announcement__content').within(() => {
+        cy.contains('Works order number')
+        cy.contains('10000012')
+      })
+    })
   })
 
   it('Approves job variation', () => {
@@ -117,7 +126,16 @@ describe('Contract manager can authorise variation', () => {
         typeCode: '100-20',
       })
 
-    cy.contains('You have approved a variation for work order 10000012')
+    // Confirmation screen
+    cy.get('.lbh-page-announcement').within(() => {
+      cy.get('.lbh-page-announcement__title').contains(
+        'You have approved a variation'
+      )
+      cy.get('.lbh-page-announcement__content').within(() => {
+        cy.contains('Works order number')
+        cy.contains('10000012')
+      })
+    })
   })
 
   // summary page and calculation
@@ -245,7 +263,16 @@ describe('Contract manager can authorise variation', () => {
         typeCode: '125',
       })
 
-    cy.contains('You have rejected a variation for work order 10000012')
+    // Confirmation screen
+    cy.get('.lbh-page-announcement').within(() => {
+      cy.get('.lbh-page-announcement__title').contains(
+        'You have rejected a variation'
+      )
+      cy.get('.lbh-page-announcement__content').within(() => {
+        cy.contains('Works order number')
+        cy.contains('10000012')
+      })
+    })
   })
 
   //collapsible

--- a/src/components/Properties/PropertiesTable.js
+++ b/src/components/Properties/PropertiesTable.js
@@ -6,11 +6,10 @@ const PropertiesTable = ({ properties, query }) => (
   <div>
     <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
 
-    <h4 className="lbh-heading-h4">
-      We found {properties.length} matching results for: {decodeURI(query)}
-    </h4>
-
     <Table className="govuk-!-margin-top-5">
+      <caption className="govuk-table__caption lbh-heading-h3 lbh-table__caption">
+        We found {properties.length} matching results for: {decodeURI(query)}
+      </caption>
       <THead>
         <TR className="lbh-body">
           <TH scope="col">Address</TH>

--- a/src/components/Properties/__snapshots__/PropertiesTable.test.js.snap
+++ b/src/components/Properties/__snapshots__/PropertiesTable.test.js.snap
@@ -6,14 +6,14 @@ exports[`PropertiesTable component should render properly 1`] = `
     <hr
       class="govuk-section-break govuk-section-break--l govuk-section-break--visible"
     />
-    <h4
-      class="lbh-heading-h4"
-    >
-      We found 2 matching results for: E9 6PT
-    </h4>
     <table
       class="govuk-table lbh-table govuk-!-margin-top-5"
     >
+      <caption
+        class="govuk-table__caption lbh-heading-h3 lbh-table__caption"
+      >
+        We found 2 matching results for: E9 6PT
+      </caption>
       <thead
         class="govuk-table__head"
       >

--- a/src/components/Property/RaiseRepair/RaiseRepairFormView.js
+++ b/src/components/Property/RaiseRepair/RaiseRepairFormView.js
@@ -147,7 +147,6 @@ const RaiseRepairFormView = ({ propertyReference }) => {
                 shortAddress={property.address.shortAddress}
                 text={'Repair works order created'}
                 showSearchLink={true}
-                isRaiseRepairSuccess={true}
                 authorisationPendingApproval={authorisationPendingApproval}
                 externalSchedulerLink={
                   externallyManagedAppointment &&

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -90,7 +90,7 @@ const Search = ({ query }) => {
           <form>
             <label className="govuk-label lbh-label">{searchLabelText}</label>
             <input
-              className="govuk-input lbh-input govuk-input--width-10 focus-colour"
+              className="govuk-input lbh-input govuk-input--width-10"
               id="input-search"
               name="search-name"
               type="text"

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -21,7 +21,7 @@ exports[`Search component when logged in as a contract manager should render pro
             Search by work order reference, postcode or address
           </label>
           <input
-            class="govuk-input lbh-input govuk-input--width-10 focus-colour"
+            class="govuk-input lbh-input govuk-input--width-10"
             id="input-search"
             name="search-name"
             type="text"
@@ -66,7 +66,7 @@ exports[`Search component when logged in as a contractor should render properly 
             Search by work order reference
           </label>
           <input
-            class="govuk-input lbh-input govuk-input--width-10 focus-colour"
+            class="govuk-input lbh-input govuk-input--width-10"
             id="input-search"
             name="search-name"
             type="text"
@@ -111,7 +111,7 @@ exports[`Search component when logged in as an agent should render properly 1`] 
             Search by work order reference, postcode or address
           </label>
           <input
-            class="govuk-input lbh-input govuk-input--width-10 focus-colour"
+            class="govuk-input lbh-input govuk-input--width-10"
             id="input-search"
             name="search-name"
             type="text"
@@ -156,7 +156,7 @@ exports[`Search component when logged in as an authorisation manager should rend
             Search by work order reference, postcode or address
           </label>
           <input
-            class="govuk-input lbh-input govuk-input--width-10 focus-colour"
+            class="govuk-input lbh-input govuk-input--width-10"
             id="input-search"
             name="search-name"
             type="text"

--- a/src/components/SuccessPage/SuccessPage.js
+++ b/src/components/SuccessPage/SuccessPage.js
@@ -5,26 +5,15 @@ import WarningText from '../Template/WarningText'
 const SuccessPage = ({ ...props }) => {
   return (
     <>
-      {props.isRaiseRepairSuccess ? (
-        <section className="text-align-center lbh-page-announcement">
-          <h3 className="lbh-page-announcement__title">{props.text}</h3>
-          <div className="lbh-announcement__content">
-            <p>Works order number</p>
-            <strong className="govuk-!-font-size-24">
-              {props.workOrderReference}
-            </strong>
-          </div>
-        </section>
-      ) : (
-        <section className="text-align-center lbh-page-announcement">
-          <div className="lbh-announcement__content">
-            <p>
-              {props.text}{' '}
-              <strong>work order {props.workOrderReference}</strong>
-            </p>
-          </div>
-        </section>
-      )}
+      <section className="text-align-center lbh-page-announcement">
+        <h3 className="lbh-page-announcement__title">{props.text}</h3>
+        <div className="lbh-page-announcement__content">
+          <p>Works order number</p>
+          <strong className="govuk-!-font-size-24">
+            {props.workOrderReference}
+          </strong>
+        </div>
+      </section>
 
       {props.authorisationPendingApproval && (
         <WarningText
@@ -103,7 +92,6 @@ const SuccessPage = ({ ...props }) => {
 SuccessPage.propTypes = {
   workOrderReference: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
-  isRaiseRepairSuccess: PropTypes.bool,
   showDashboardLink: PropTypes.bool,
   shortAddress: PropTypes.string,
   showSearchLink: PropTypes.bool,

--- a/src/components/SuccessPage/SuccessPage.js
+++ b/src/components/SuccessPage/SuccessPage.js
@@ -1,19 +1,15 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import WarningText from '../Template/WarningText'
+import PageAnnouncement from '../Template/PageAnnouncement'
 
 const SuccessPage = ({ ...props }) => {
   return (
     <>
-      <section className="text-align-center lbh-page-announcement">
-        <h3 className="lbh-page-announcement__title">{props.text}</h3>
-        <div className="lbh-page-announcement__content">
-          <p>Works order number</p>
-          <strong className="govuk-!-font-size-24">
-            {props.workOrderReference}
-          </strong>
-        </div>
-      </section>
+      <PageAnnouncement
+        title={props.text}
+        workOrderReference={props.workOrderReference}
+      />
 
       {props.authorisationPendingApproval && (
         <WarningText

--- a/src/components/SuccessPage/SuccessPage.test.js
+++ b/src/components/SuccessPage/SuccessPage.test.js
@@ -13,7 +13,7 @@ describe('SuccessPage component', () => {
         const { asFragment } = render(
           <SuccessPage
             workOrderReference={props.workOrderReference}
-            text="You have approved a variation for"
+            text="You have approved a variation"
             showDashboardLink={props.showDashboardLink}
           />
         )
@@ -26,7 +26,7 @@ describe('SuccessPage component', () => {
         const { asFragment } = render(
           <SuccessPage
             workOrderReference={props.workOrderReference}
-            text="You have rejected a variation for"
+            text="You have rejected a variation"
             showDashboardLink={props.showDashboardLink}
           />
         )
@@ -42,7 +42,6 @@ describe('SuccessPage component', () => {
       propertyReference: '12345678',
       shortAddress: '12 Random Lane',
       showSearchLink: true,
-      isRaiseRepairSuccess: true,
     }
 
     describe('High cost (over raise limit) authorisation', () => {

--- a/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
+++ b/src/components/SuccessPage/__snapshots__/SuccessPage.test.js.snap
@@ -5,15 +5,22 @@ exports[`SuccessPage component Approving / Rejecting a work order when variation
   <section
     class="text-align-center lbh-page-announcement"
   >
+    <h3
+      class="lbh-page-announcement__title"
+    >
+      You have approved a variation
+    </h3>
     <div
-      class="lbh-announcement__content"
+      class="lbh-page-announcement__content"
     >
       <p>
-        You have approved a variation for 
-        <strong>
-          work order 10000012
-        </strong>
+        Works order number
       </p>
+      <strong
+        class="govuk-!-font-size-24"
+      >
+        10000012
+      </strong>
     </div>
   </section>
   <ul
@@ -48,15 +55,22 @@ exports[`SuccessPage component Approving / Rejecting a work order when variation
   <section
     class="text-align-center lbh-page-announcement"
   >
+    <h3
+      class="lbh-page-announcement__title"
+    >
+      You have rejected a variation
+    </h3>
     <div
-      class="lbh-announcement__content"
+      class="lbh-page-announcement__content"
     >
       <p>
-        You have rejected a variation for 
-        <strong>
-          work order 10000012
-        </strong>
+        Works order number
       </p>
+      <strong
+        class="govuk-!-font-size-24"
+      >
+        10000012
+      </strong>
     </div>
   </section>
   <ul
@@ -97,7 +111,7 @@ exports[`SuccessPage component Raising a repair High cost (over raise limit) aut
       Repair works order created
     </h3>
     <div
-      class="lbh-announcement__content"
+      class="lbh-page-announcement__content"
     >
       <p>
         Works order number
@@ -177,7 +191,7 @@ exports[`SuccessPage component Raising a repair With Emergency and Immediate DLO
       Repair works order created
     </h3>
     <div
-      class="lbh-announcement__content"
+      class="lbh-page-announcement__content"
     >
       <p>
         Works order number
@@ -244,7 +258,7 @@ exports[`SuccessPage component Raising a repair With an external scheduler URL s
       Repair works order created
     </h3>
     <div
-      class="lbh-announcement__content"
+      class="lbh-page-announcement__content"
     >
       <p>
         Works order number
@@ -304,7 +318,7 @@ exports[`SuccessPage component Raising a repair Within raise limit should render
       Repair works order created
     </h3>
     <div
-      class="lbh-announcement__content"
+      class="lbh-page-announcement__content"
     >
       <p>
         Works order number

--- a/src/components/Tabs/VariationSummaryTab.js
+++ b/src/components/Tabs/VariationSummaryTab.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import { useState, useEffect, useContext } from 'react'
+import Link from 'next/link'
 import UserContext from '../UserContext/UserContext'
 import Spinner from '../Spinner/Spinner'
 import ErrorMessage from '../Errors/ErrorMessage/ErrorMessage'
@@ -73,12 +74,11 @@ const VariationSummaryTab = ({ workOrderReference }) => {
     if (user.roles.includes('contract_manager')) {
       return (
         <div className="display-inline">
-          <a
-            className="lbh-link"
+          <Link
             href={`/work-orders/${workOrderReference}/variation-authorisation`}
           >
-            Variation Authorisation
-          </a>
+            <a className="lbh-link">Variation Authorisation</a>
+          </Link>
         </div>
       )
     }

--- a/src/components/Template/PageAnnouncement.js
+++ b/src/components/Template/PageAnnouncement.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types'
+
+export const PageAnnouncement = (props) => (
+  <section className="text-align-center lbh-page-announcement">
+    <h3 className="lbh-page-announcement__title">{props.title}</h3>
+    <div className="lbh-page-announcement__content">
+      <p>Works order number</p>
+      <strong className="govuk-!-font-size-24">
+        {props.workOrderReference}
+      </strong>
+    </div>
+  </section>
+)
+
+PageAnnouncement.propTypes = {
+  title: PropTypes.string.isRequired,
+  workOrderReference: PropTypes.string.isRequired,
+}
+
+export default PageAnnouncement

--- a/src/components/WorkOrder/Authorisation/AuthorisationView.js
+++ b/src/components/WorkOrder/Authorisation/AuthorisationView.js
@@ -151,8 +151,8 @@ const AuthorisationView = ({ workOrderReference }) => {
               workOrderReference={workOrderReference}
               text={
                 authorisationApproved
-                  ? 'You have approved the authorisation request for'
-                  : 'You have rejected the authorisation request for'
+                  ? 'You have approved the authorisation request'
+                  : 'You have rejected the authorisation request'
               }
               showDashboardLink={true}
             />

--- a/src/components/WorkOrder/Authorisation/VariationAuthorisationSummary.js
+++ b/src/components/WorkOrder/Authorisation/VariationAuthorisationSummary.js
@@ -89,52 +89,68 @@ const VariationAuthorisationSummary = ({
 
   const updatedSORsToShow = () => {
     return (
-      <Table className="lbh-table updated-tasks-table">
-        <THead>
-          <TR>
-            <TH scope="col">SOR Status</TH>
-            <TH scope="col">SOR code</TH>
-            <TH scope="col" type="numeric">
-              Unit Cost
-            </TH>
-            <TH scope="col" type="numeric">
-              Quantity
-            </TH>
-            <TH scope="col" type="numeric">
-              Cost
-            </TH>
-            <TH scope="col" type="numeric">
-              Varied quantity
-            </TH>
-            <TH scope="col" type="numeric">
-              Varied Cost
-            </TH>
-          </TR>
-        </THead>
+      <>
+        <p className="lbh-body">Updated by: {variationTasks.authorName} </p>
+        <p className="lbh-body">
+          {longDateToStr(variationTasks.variationDate)}{' '}
+        </p>
+        <div className="lbh-stat">
+          <span className="lbh-stat__caption">{variationTasks.notes}</span>
+        </div>
 
-        <TBody>
-          {variationTasks.tasks
-            ? variationTasks.tasks.map((task, index) => (
-                <TR index={index} key={index}>
-                  <TD>
-                    <Status status={sorStatus(task)} />
-                  </TD>
-                  <TD>
-                    {task.code}
-                    <p>{task.description}</p>
-                  </TD>
-                  <TD type="numeric">£{getCost(task)}</TD>
-                  <TD type="numeric">{task.currentQuantity}</TD>
-                  <TD type="numeric">
-                    £{getCost(task) * task.currentQuantity}
-                  </TD>
-                  <TD type="numeric">{task.variedQuantity}</TD>
-                  <TD type="numeric">£{getCost(task) * task.variedQuantity}</TD>
-                </TR>
-              ))
-            : ''}
-        </TBody>
-      </Table>
+        <Table className="lbh-table updated-tasks-table">
+          <THead>
+            <TR>
+              <TH scope="col">SOR Status</TH>
+              <TH scope="col">SOR code</TH>
+              <TH scope="col" type="numeric">
+                Unit Cost
+              </TH>
+              <TH scope="col" type="numeric">
+                Quantity
+              </TH>
+              <TH scope="col" type="numeric">
+                Cost
+              </TH>
+              <TH scope="col" type="numeric">
+                Varied quantity
+              </TH>
+              <TH scope="col" type="numeric">
+                Varied Cost
+              </TH>
+            </TR>
+          </THead>
+
+          <TBody>
+            {variationTasks.tasks
+              ? variationTasks.tasks.map((task, index) => (
+                  <TR index={index} key={index}>
+                    <TD>
+                      <Status status={sorStatus(task)} />
+                    </TD>
+                    <TD>
+                      {task.code}
+                      <p>{task.description}</p>
+                    </TD>
+                    <TD type="numeric">£{getCost(task)}</TD>
+                    <TD type="numeric">{task.currentQuantity}</TD>
+                    <TD type="numeric">
+                      £{getCost(task) * task.currentQuantity}
+                    </TD>
+                    <TD type="numeric">{task.variedQuantity}</TD>
+                    <TD type="numeric">
+                      £{getCost(task) * task.variedQuantity}
+                    </TD>
+                  </TR>
+                ))
+              : ''}
+          </TBody>
+        </Table>
+
+        <Table className="lbh-table calculated-cost">
+          <TBody>{variationTasks.tasks ? showCostBreakdown() : ''}</TBody>
+        </Table>
+      </>
     )
   }
 
@@ -175,27 +191,14 @@ const VariationAuthorisationSummary = ({
       <Collapsible
         heading="Original SORs"
         collapsableDivClassName="original-sors"
-      >
-        {originalSORsToShow()}
-      </Collapsible>
+        children={originalSORsToShow()}
+      />
 
       <Collapsible
         heading="Updated Tasks SORs"
         collapsableDivClassName="updated-sors"
-      >
-        <p className="lbh-body">Updated by: {variationTasks.authorName} </p>
-        <p className="lbh-body">
-          {longDateToStr(variationTasks.variationDate)}{' '}
-        </p>
-        <div className="lbh-stat">
-          <span className="lbh-stat__caption">{variationTasks.notes}</span>
-        </div>
-        {updatedSORsToShow()}
-
-        <Table className="lbh-table calculated-cost">
-          <TBody>{variationTasks.tasks ? showCostBreakdown() : ''}</TBody>
-        </Table>
-      </Collapsible>
+        children={updatedSORsToShow()}
+      />
     </>
   )
 }

--- a/src/components/WorkOrder/Authorisation/VariationAuthorisationView.js
+++ b/src/components/WorkOrder/Authorisation/VariationAuthorisationView.js
@@ -104,8 +104,8 @@ const VariationAuthorisationView = ({ workOrderReference }) => {
 
   const addConfirmationText = () => {
     variationApproved
-      ? setConfirmationPageMessage('You have approved a variation for')
-      : setConfirmationPageMessage('You have rejected a variation for')
+      ? setConfirmationPageMessage('You have approved a variation')
+      : setConfirmationPageMessage('You have rejected a variation')
   }
 
   const makePostRequest = async (formData) => {

--- a/src/components/WorkOrder/WorkOrderInfo.js
+++ b/src/components/WorkOrder/WorkOrderInfo.js
@@ -13,7 +13,7 @@ const WorkOrderInfo = ({ workOrder }) => {
         </span>
         <br></br>
         {workOrder.priorityCode === IMMEDIATE_PRIORITY_CODE ? (
-          <span className="text-danger govuk-!-font-size-14">
+          <span className="text-dark-red govuk-!-font-size-14">
             Priority: {workOrder.priority}
           </span>
         ) : (

--- a/src/components/WorkOrder/__snapshots__/WorkOrderInfo.test.js.snap
+++ b/src/components/WorkOrder/__snapshots__/WorkOrderInfo.test.js.snap
@@ -80,7 +80,7 @@ exports[`WorkOrderInfo component when the work order is immediate priority inclu
       </span>
       <br />
       <span
-        class="text-danger govuk-!-font-size-14"
+        class="text-dark-red govuk-!-font-size-14"
       >
         Priority: some priority text
       </span>

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -1,6 +1,6 @@
 $repairs-hub-colours: (
   'orange': lbh-colour('lbh-f04'),
-  'danger': lbh-colour('lbh-f02'),
+  'dark-red': lbh-colour('lbh-f02'),
   'white': lbh-colour('lbh-white'),
   'black': lbh-colour('lbh-black'),
   'dark-grey': lbh-colour('lbh-grey-1'),
@@ -33,8 +33,8 @@ $repairs-hub-colours: (
     color: repairs-hub-colour('black');
   }
 
-  &-danger {
-    color: repairs-hub-colour('danger');
+  &-dark-red {
+    color: repairs-hub-colour('dark-red');
   }
 
   &-\!-white {

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -1,7 +1,7 @@
 $repairs-hub-colours: (
   'housing-1': #005f61,
   'housing-3': #2dccd3,
-  'warning': #ffa300,
+  'orange': lbh-colour('lbh-f04'),
   'danger': lbh-colour('lbh-f02'),
   'white': lbh-colour('lbh-white'),
   'black': lbh-colour('lbh-black'),
@@ -37,10 +37,6 @@ $repairs-hub-colours: (
 
   &-black {
     color: repairs-hub-colour('black');
-  }
-
-  &-warning {
-    color: repairs-hub-colour('warning');
   }
 
   &-danger {

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -1,5 +1,4 @@
 $repairs-hub-colours: (
-  'housing-1': #005f61,
   'orange': lbh-colour('lbh-f04'),
   'danger': lbh-colour('lbh-f02'),
   'white': lbh-colour('lbh-white'),

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -6,14 +6,11 @@ $repairs-hub-colours: (
   'dark-grey': lbh-colour('lbh-grey-1'),
   'grey': lbh-colour('lbh-grey-2'),
   'light-grey': lbh-colour('lbh-grey-3'),
+  'lighter-grey': lbh-colour('lbh-panel'),
   'yellow': lbh-colour('lbh-h04'),
   'dark-green': lbh-colour('lbh-a01'),
+  'light-green': lbh-colour('lbh-primary-disabled'),
   'blue': lbh-colour('lbh-link'),
-  'calendar-current': #6895c6,
-  'calendar-selected': #b2cce2,
-  'calendar-border': #e2e4e6,
-  'calendar-divider': #c7c8ca,
-  'calendar-month': #7d8287,
 );
 
 @function repairs-hub-colour($colour) {

--- a/src/styles/colours.scss
+++ b/src/styles/colours.scss
@@ -1,6 +1,5 @@
 $repairs-hub-colours: (
   'housing-1': #005f61,
-  'housing-3': #2dccd3,
   'orange': lbh-colour('lbh-f04'),
   'danger': lbh-colour('lbh-f02'),
   'white': lbh-colour('lbh-white'),
@@ -20,10 +19,6 @@ $repairs-hub-colours: (
 
 @function repairs-hub-colour($colour) {
   @return map-get($repairs-hub-colours, quote($colour));
-}
-
-.focus-colour:focus {
-  outline: 3px solid repairs-hub-colour('housing-3') !important;
 }
 
 .text {

--- a/src/styles/components/appointments.scss
+++ b/src/styles/components/appointments.scss
@@ -5,7 +5,7 @@ $calendar-cell-width--desktop: 100px;
 .appointment-calendar {
   table {
     border-collapse: collapse;
-    border: 1px solid repairs-hub-colour('calendar-border');
+    border: 1px solid repairs-hub-colour('lighter-grey');
     margin: 0 0 10px 0;
 
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCI+PHBhdGggZmlsbD0iI2Y3ZjdmNyIgZD0iTTAgMGgxMHYxMEgweiIvPjxwYXRoIGQ9Ik0tMSAxbDItMk0wIDEwTDEwIDBNOSAxMWwyLTIiIHN0cm9rZT0iI2RjZGNkYyIvPjwvc3ZnPg==');
@@ -19,10 +19,10 @@ $calendar-cell-width--desktop: 100px;
     }
 
     thead {
-      border-bottom: 2px solid repairs-hub-colour('calendar-divider');
+      border-bottom: 2px solid repairs-hub-colour('grey');
 
       tr {
-        border-top: 1px solid repairs-hub-colour('calendar-border');
+        border-top: 1px solid repairs-hub-colour('lighter-grey');
 
         th {
           background-color: repairs-hub-colour('white');
@@ -49,7 +49,7 @@ $calendar-cell-width--desktop: 100px;
     }
 
     td {
-      border: 1px solid repairs-hub-colour('calendar-border');
+      border: 1px solid repairs-hub-colour('lighter-grey');
     }
 
     td {
@@ -69,7 +69,7 @@ $calendar-cell-width--desktop: 100px;
         }
 
         &.selected {
-          background-color: repairs-hub-colour('calendar-selected');
+          background-color: repairs-hub-colour('light-green');
         }
 
         span.date {
@@ -97,7 +97,7 @@ $calendar-cell-width--desktop: 100px;
         }
 
         span.today {
-          background-color: repairs-hub-colour('calendar-current');
+          background-color: repairs-hub-colour('dark-green');
         }
 
         @include govuk-media-query($from: tablet) {
@@ -140,7 +140,7 @@ $calendar-cell-width--desktop: 100px;
         top: 0;
         width: 16px;
         height: 16px;
-        border: 1px solid repairs-hub-colour('calendar-border');
+        border: 1px solid repairs-hub-colour('lighter-grey');
       }
 
       &.available {

--- a/src/styles/components/property-details.scss
+++ b/src/styles/components/property-details.scss
@@ -9,7 +9,7 @@
 
     &.bg {
       &-orange {
-        background: repairs-hub-colour('warning');
+        background: repairs-hub-colour('orange');
       }
 
       &-dark-green {

--- a/src/styles/components/sor-status.scss
+++ b/src/styles/components/sor-status.scss
@@ -10,7 +10,7 @@
         color: repairs-hub-colour('black');
       }
       &--status-increased {
-        background-color: repairs-hub-colour('danger');
+        background-color: repairs-hub-colour('dark-red');
         color: repairs-hub-colour('white');
       }
       &--status-new {

--- a/src/styles/components/work-orders.scss
+++ b/src/styles/components/work-orders.scss
@@ -60,7 +60,7 @@
         color: repairs-hub-colour('white');
       }
       &--status-variation-rejected {
-        background-color: repairs-hub-colour('danger');
+        background-color: repairs-hub-colour('dark-red');
         color: repairs-hub-colour('white');
       }
       &--status-no-access {

--- a/src/styles/show-env-names.scss
+++ b/src/styles/show-env-names.scss
@@ -6,7 +6,7 @@
   }
 
   &-development {
-    border-color: repairs-hub-colour('housing-1');
+    border-color: repairs-hub-colour('dark-green');
   }
 
   &-staging {

--- a/src/styles/show-env-names.scss
+++ b/src/styles/show-env-names.scss
@@ -10,11 +10,11 @@
   }
 
   &-staging {
-    border-color: repairs-hub-colour('warning');
+    border-color: repairs-hub-colour('orange');
   }
 
   &-localdev {
-    border-color: repairs-hub-colour('warning');
+    border-color: repairs-hub-colour('orange');
   }
 }
 


### PR DESCRIPTION
### Description of change

#### Colours, use orange colour from Hackney Design system
![Screenshot 2021-06-17 at 18 20 47](https://user-images.githubusercontent.com/7561969/122567928-1c3acf80-d041-11eb-958e-39a2adc199ec.jpg)

#### Delete focus-colour class (This class was adding a light washed cyan colour on the search box-area. Hackney Design system default colour is yellow)
![Screenshot 2021-06-17 at 18 19 51](https://user-images.githubusercontent.com/7561969/122568103-5310e580-d041-11eb-81bd-55e7385f7309.jpg)

#### Use Hackney Design system dark-green colour
![Screenshot 2021-06-17 at 18 32 03](https://user-images.githubusercontent.com/7561969/122568156-615f0180-d041-11eb-89ca-603ac796a447.jpg)

#### Rename colour danger to dark red

#### Page Announcement, being consistent in Success page & Extract PageAnnouncement to its own component
![Screenshot 2021-06-17 at 18 58 03](https://user-images.githubusercontent.com/7561969/122568275-7fc4fd00-d041-11eb-8df0-62185e473e2e.jpg)
![Screenshot 2021-06-17 at 18 59 39](https://user-images.githubusercontent.com/7561969/122568281-805d9380-d041-11eb-856b-b346b5691cae.jpg)

#### Table caption, use it for search result
![Screenshot 2021-06-18 at 11 06 20](https://user-images.githubusercontent.com/7561969/122568460-aa16ba80-d041-11eb-819a-912f8065758c.jpg)

#### Use Link react hook

#### Update calendar component to use colours by Hackney Design system
![Screenshot 2021-06-18 at 13 56 28](https://user-images.githubusercontent.com/7561969/122568498-b3078c00-d041-11eb-8bac-e58c4402eb39.jpg)

#### Refactor VariationAuthorisationSummary component to fix collapsible errors on tests

### Story Link

https://www.pivotaltracker.com/story/show/178395035