### PR TITLE
Work order test

### DIFF
--- a/cypress/integration/search/search-for-property-or-work-order.spec.js
+++ b/cypress/integration/search/search-for-property-or-work-order.spec.js
@@ -65,7 +65,7 @@ describe('Search by work order reference, postcode or address', () => {
           cy.get('[type="submit"]').contains('Search').click()
         })
 
-        it.only('checks the heading', () => {
+        it('checks the heading', () => {
           cy.get('.govuk-table').within(() => {
             cy.contains('caption', 'We found 2 matching results for: pitcairn')
           })

--- a/cypress/integration/work-order/show-work-order.spec.js
+++ b/cypress/integration/work-order/show-work-order.spec.js
@@ -265,4 +265,45 @@ describe('Show work order page', () => {
       })
     })
   })
+
+  context('When the work order has work orders on repairs history tab', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          path:
+            '/api/workOrders?propertyReference=00012345&PageSize=50&PageNumber=1',
+        },
+        { fixture: 'work-orders/work-orders.json' }
+      ).as('repairsHistory')
+      cy.intercept(
+        { method: 'GET', path: '/api/workOrders/10000040' },
+        { fixture: 'work-orders/priority-immediate.json' }
+      )
+      cy.intercept(
+        { method: 'GET', path: '/api/properties/00089473' },
+        { fixture: 'properties/property.json' }
+      )
+      cy.intercept(
+        {
+          method: 'GET',
+          path:
+            '/api/workOrders?propertyReference=00089473&PageSize=50&PageNumber=1',
+        },
+        { body: [] }
+      )
+
+      cy.visit('/work-orders/10000012')
+      cy.wait('@repairsHistory')
+    })
+
+    it('Clicks the first repair of repairs history', () => {
+      cy.contains('10000040').click()
+      cy.url().should('contains', 'work-orders/10000040')
+
+      cy.get('.lbh-heading-h1').within(() => {
+        cy.contains('Works order: 10000040')
+      })
+    })
+  })
 })


### PR DESCRIPTION
### Description of change

- Add test to click on work order from repairs history
- Remove missing only action on tests https://github.com/LBHackney-IT/repairs-hub-frontend/commit/22fb3d2ad078ab974821a78b11d540b2b767c4bc