### PR TITLE
Show trade filter checkbox as selected when filter applied

### DIFF
--- a/cypress/integration/work-orders/filter.spec.js
+++ b/cypress/integration/work-orders/filter.spec.js
@@ -405,6 +405,13 @@ describe('Filter work orders', () => {
       cy.get('.govuk-checkboxes').find('[name="TradeCodes.PL"]').check()
       cy.get('[type="submit"]').contains('Apply filters').click()
 
+      cy.get('.govuk-checkboxes')
+        .find('[name="ContractorReference.PCL"]')
+        .should('be.checked')
+      cy.get('.govuk-checkboxes')
+        .find('[name="TradeCodes.PL"]')
+        .should('be.checked')
+
       // Plumbing trade and Purdy contractor work orders
       cy.get('[data-ref=10000040]').should('not.exist')
       cy.get('[data-ref=10000035]').should('not.exist')

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -184,7 +184,7 @@ const WorkOrdersFilter = ({
                   name={`TradeCodes.${trade.key}`}
                   label={trade.description}
                   register={register}
-                  checked={appliedFilters?.Trades?.includes(trade.key)}
+                  checked={appliedFilters?.TradeCodes?.includes(trade.key)}
                   hidden={index >= CHECKBOX_NUMBER}
                 />
               ))}


### PR DESCRIPTION
### Description of change

Show trade filter checkbox as selected when filter applied
- Fixes bug where a trade filter may have been applied but the UI failed to indicate this in the relevant checkbox
- Add spec to ensure that checkbox has been selected if filters have been applied

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/178603488