### PR TITLE
Remove whole number validation for existing rate schedule item quantities

### DIFF
--- a/cypress/integration/raise-repair/form.spec.js
+++ b/cypress/integration/raise-repair/form.spec.js
@@ -259,13 +259,13 @@ describe('Raise repair form', () => {
       cy.get(
         'div[id="rateScheduleItems[0][quantity]-form-group"] .govuk-error-message'
       ).within(() => {
-        cy.contains('Quantity must be 0 or more')
+        cy.contains('Quantity must be greater than 0')
       })
       cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('-1')
       cy.get(
         'div[id="rateScheduleItems[0][quantity]-form-group"] .govuk-error-message'
       ).within(() => {
-        cy.contains('Quantity must be 0 or more')
+        cy.contains('Quantity must be greater than 0')
       })
 
       // Enter a valid quantity

--- a/cypress/integration/work-order/update-work-order.spec.js
+++ b/cypress/integration/work-order/update-work-order.spec.js
@@ -218,7 +218,7 @@ describe('Contractor update a job', () => {
       cy.get(
         'div[id="rateScheduleItems[0][quantity]-form-group"] .govuk-error-message'
       ).within(() => {
-        cy.contains('Quantity must be 0 or more')
+        cy.contains('Quantity must be greater than 0')
       })
       cy.get('input[id="rateScheduleItems[0][quantity]"]')
         .clear()
@@ -227,7 +227,7 @@ describe('Contractor update a job', () => {
       cy.get(
         'div[id="rateScheduleItems[0][quantity]-form-group"] .govuk-error-message'
       ).within(() => {
-        cy.contains('Quantity must be 0 or more')
+        cy.contains('Quantity must be greater than 0')
       })
     })
   })
@@ -249,9 +249,55 @@ describe('Contractor update a job', () => {
 
     cy.wait('@taskListRequest')
     cy.get('#repair-request-form').within(() => {
+      // Enter a non-number quantity
+      cy.get('#quantity-0-form-group').within(() => {
+        cy.get('input[id="quantity-0"]').clear().type('x')
+      })
+
+      cy.get('[type="submit"]').contains('Next').click()
+      cy.get('div[id="quantity-0-form-group"] .govuk-error-message').within(
+        () => {
+          cy.contains('Quantity must be a number')
+        }
+      )
+
+      // Enter a quantity with 1 decimal point
+      cy.get('input[id="quantity-0"]').clear().type('1.5').blur()
+      cy.get('div[id="quantity-0-form-group"] .govuk-error-message').should(
+        'not.exist'
+      )
+      // Enter a quantity with 2 decimal points
+      cy.get('input[id="quantity-0"]').clear().type('1.55').blur()
+      cy.get('div[id="quantity-0-form-group"] .govuk-error-message').should(
+        'not.exist'
+      )
+      // Enter a quantity less than 1 with 2 decimal points
+      cy.get('input[id="quantity-0"]').clear().type('0.55').blur()
+      cy.get('div[id="quantity-0-form-group"] .govuk-error-message').should(
+        'not.exist'
+      )
+      // Enter a quantity with more than 2 decimal points
+      cy.get('input[id="quantity-0"]').clear().type('1.555').blur()
+      cy.get('div[id="quantity-0-form-group"] .govuk-error-message').within(
+        () => {
+          cy.contains(
+            'Quantity including a decimal point is permitted a maximum of 2 decimal places'
+          )
+        }
+      )
+      // Enter a negative quantity
+      cy.get('input[id="quantity-0"]').clear().type('-1').blur()
+      cy.get('div[id="quantity-0-form-group"] .govuk-error-message').within(
+        () => {
+          cy.contains('Quantity must be 0 or more')
+        }
+      )
+
+      // Enter valid number
       cy.get('#quantity-0-form-group').within(() => {
         cy.get('input[id="quantity-0"]').clear().type('0')
       })
+
       cy.get('#variationReason').get('.govuk-textarea').type('Needs more work')
       cy.get('[type="submit"]').contains('Next').click()
     })

--- a/src/components/WorkElement/RateScheduleItem.js
+++ b/src/components/WorkElement/RateScheduleItem.js
@@ -89,7 +89,7 @@ const RateScheduleItem = ({
                 if (isNaN(value)) {
                   return 'Quantity must be a number'
                 } else if (value <= 0) {
-                  return 'Quantity must be 0 or more'
+                  return 'Quantity must be greater than 0'
                 } else if (!maxTwoDecimalPoints.test(value)) {
                   return 'Quantity including a decimal point is permitted a maximum of 2 decimal places'
                 } else {

--- a/src/components/WorkOrders/RateScheduleItems/LatestRateScheduleItems.js
+++ b/src/components/WorkOrders/RateScheduleItems/LatestRateScheduleItems.js
@@ -42,9 +42,15 @@ const LatestRateScheduleItems = ({ latestTasks, errors, register }) => {
                   register={register({
                     required: 'Please enter a quantity',
                     validate: (value) => {
-                      const valueAsNumber = parseFloat(value)
-                      if (!Number.isInteger(valueAsNumber)) {
-                        return 'Quantity must be a whole number'
+                      const maxTwoDecimalPoints = /^(?=.*\d)\d*(?:\.\d{1,2})?$/
+                      if (isNaN(value)) {
+                        return 'Quantity must be a number'
+                      } else if (value < 0) {
+                        return 'Quantity must be 0 or more'
+                      } else if (!maxTwoDecimalPoints.test(value)) {
+                        return 'Quantity including a decimal point is permitted a maximum of 2 decimal places'
+                      } else {
+                        return true
                       }
                     },
                   })}


### PR DESCRIPTION
### Description of change

Remove whole number validation for existing rate schedule item quantities
- When updating a work order that already has a decimal quantity for it's SOR code, there is a validation in place that only permits whole numbers. This PR removes this to match the two decimal quantity validation like in the main RateScheduleItem component
- Change validation message to reflect 'Quantity must be greater than 0' for new rate schedule items added
- Allow quantity of 0 for existing rate schedule items and update validation message accordingly

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/178604152