### PR TITLE
Allow users to save selected filters as default preset to localStorage

### DIFF
--- a/src/components/Tag/FilterTag.js
+++ b/src/components/Tag/FilterTag.js
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types'
+
+const FilterTag = ({ text }) => {
+  return (
+    <li>
+      <a className="lbh-body-xs filter-tag">{text}</a>
+    </li>
+  )
+}
+
+FilterTag.propTypes = {
+  text: PropTypes.string.isRequired,
+}
+
+export default FilterTag

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -5,6 +5,7 @@ import { Checkbox, Button } from '../../Form'
 import UserContext from '../../UserContext/UserContext'
 import { STATUS_AUTHORISATION_PENDING_APPROVAL } from '../../../utils/status-codes'
 import Collapsible from '../../Layout/Collapsible/Collapsible'
+import FilterTag from '../../Tag/FilterTag'
 
 const WorkOrdersFilter = ({
   loading,
@@ -12,10 +13,37 @@ const WorkOrdersFilter = ({
   register,
   appliedFilters,
   clearFilters,
+  selectedFilters,
 }) => {
   const { user } = useContext(UserContext)
 
   const CHECKBOX_NUMBER = 5
+
+  const saveAppliedFiltersToLocalStorage = (e) => {
+    e.preventDefault()
+
+    if (
+      window.confirm(
+        `Save my selected filters:\n${JSON.stringify(selectedFilters).replace(
+          /["{}:]/g,
+          ' '
+        )} as the default preset?`
+      )
+    ) {
+      localStorage.setItem(
+        'RH - default work order filters',
+        JSON.stringify(appliedFilters)
+      )
+    }
+  }
+
+  const removeAppliedFiltersFromLocalStorage = (e) => {
+    e.preventDefault()
+
+    if (window.confirm('Remove my default saved filters?')) {
+      localStorage.removeItem('RH - default work order filters')
+    }
+  }
 
   const statusFilterOptions = () => {
     if (user && user.hasContractorPermissions) {
@@ -64,16 +92,71 @@ const WorkOrdersFilter = ({
     }
   }
 
-  const filterOptionsHtml = () => {
+  const selectedFilterOptions = () => {
+    if (Object.keys(selectedFilters).length === 0) {
+      return <p className="lbh-body-m">You have no selected filters</p>
+    }
+
+    return Object.keys(selectedFilters).map((filterCategory) => {
+      return (
+        <div key={filterCategory}>
+          <h4 className="lbh-heading-h4">{filterCategory}</h4>
+          <ul className="filter-tags" id={`selected-filters-${filterCategory}`}>
+            {selectedFilters[filterCategory].map((option, i) => {
+              return <FilterTag text={option} key={i} />
+            })}
+          </ul>
+        </div>
+      )
+    })
+  }
+
+  const selectedFilterOptionsHtml = () => {
     return (
-      <div className="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5">
-        <div className="govuk-!-padding-left-2">
-          <Button label="Apply filters" type="submit" />
+      <div className="selected-filters govuk-!-padding-bottom-2">
+        <div className="govuk-!-padding-2">
           <div>
             <a className="lbh-link" href="#" onClick={(e) => clearFilters(e)}>
               Clear filters
             </a>
           </div>
+          <div>
+            <a
+              className="lbh-link"
+              href="#"
+              onClick={(e) => saveAppliedFiltersToLocalStorage(e)}
+            >
+              Save selected filters as my default preset
+            </a>
+          </div>
+          <div>
+            <a
+              className="lbh-link"
+              href="#"
+              onClick={(e) => removeAppliedFiltersFromLocalStorage(e)}
+            >
+              Remove saved default filter preset
+            </a>
+          </div>
+
+          {selectedFilterOptions()}
+        </div>
+      </div>
+    )
+  }
+
+  const filterOptionsHtml = () => {
+    return (
+      <div className="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5">
+        <Collapsible
+          heading="Selected filters"
+          collapsableDivClassName="filter-collapsible"
+          contentMargin="govuk-!-margin-0"
+          children={selectedFilterOptionsHtml()}
+        />
+
+        <div className="govuk-!-padding-left-2 govuk-!-margin-top-0">
+          <Button label="Apply filters" type="submit" />
         </div>
 
         {showContractorFilters() && (

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
@@ -6,17 +6,18 @@ import { contractManager } from 'factories/contract_manager'
 import { authorisationManager } from 'factories/authorisation_manager'
 import { multipleContractor } from 'factories/multiple_contractor'
 import { agentAndContractor } from 'factories/agent_and_contractor'
+import { SelectedFilterOptions } from '../../../utils/helpers/filter'
 
 describe('WorkOrdersFilter component', () => {
   const props = {
     filters: {
       Priority: [
         {
-          key: 'I',
+          key: '1',
           description: 'Immediate',
         },
         {
-          key: 'E',
+          key: '2',
           description: 'Emergency',
         },
       ],
@@ -83,10 +84,20 @@ describe('WorkOrdersFilter component', () => {
         },
       ],
     },
+    appliedFilters: {
+      ContractorReference: ['PCL', 'AVP'],
+      StatusCode: ['80'],
+      Priorities: ['1', '2'],
+    },
     loading: false,
     register: jest.fn(),
     clearFilters: jest.fn(),
   }
+
+  const selectedFilters = new SelectedFilterOptions(
+    props.appliedFilters,
+    props.filters
+  ).getSelectedFilterOptions()
 
   describe('when logged in as a contractor with more than one contractor role', () => {
     it('should render properly with filter by contractor (only groups they belong to) and no authorisation pending approval status', () => {
@@ -97,6 +108,8 @@ describe('WorkOrdersFilter component', () => {
             loading={props.loading}
             register={props.register}
             clearFilters={props.clearFilters}
+            appliedFilters={props.appliedFilters}
+            selectedFilters={selectedFilters}
           />
         </UserContext.Provider>
       )
@@ -113,6 +126,8 @@ describe('WorkOrdersFilter component', () => {
             loading={props.loading}
             register={props.register}
             clearFilters={props.clearFilters}
+            appliedFilters={props.appliedFilters}
+            selectedFilters={selectedFilters}
           />
         </UserContext.Provider>
       )
@@ -129,6 +144,8 @@ describe('WorkOrdersFilter component', () => {
             loading={props.loading}
             register={props.register}
             clearFilters={props.clearFilters}
+            appliedFilters={props.appliedFilters}
+            selectedFilters={selectedFilters}
           />
         </UserContext.Provider>
       )
@@ -145,6 +162,8 @@ describe('WorkOrdersFilter component', () => {
             loading={props.loading}
             register={props.register}
             clearFilters={props.clearFilters}
+            appliedFilters={props.appliedFilters}
+            selectedFilters={selectedFilters}
           />
         </UserContext.Provider>
       )
@@ -169,6 +188,8 @@ describe('WorkOrdersFilter component', () => {
             loading={props.loading}
             register={props.register}
             clearFilters={props.clearFilters}
+            appliedFilters={props.appliedFilters}
+            selectedFilters={selectedFilters}
           />
         </UserContext.Provider>
       )

--- a/src/components/WorkOrders/Filter/WorkOrdersFilterView.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilterView.js
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form'
 import { getFilters } from '../../../utils/frontend-api-client/filters'
 import ErrorMessage from '../../Errors/ErrorMessage/ErrorMessage'
 import WorkOrdersFilter from './WorkOrdersFilter'
+import { SelectedFilterOptions } from '../../../utils/helpers/filter'
 
 const WorkOrdersFilterView = ({
   onFilterSubmit,
@@ -14,6 +15,7 @@ const WorkOrdersFilterView = ({
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
   const [filters, setFilters] = useState()
+  const [selectedFilters, setSelectedFilters] = useState()
 
   const onSubmit = async (formData) => {
     formData.StatusCode = { ...formData.StatusCode }
@@ -28,7 +30,13 @@ const WorkOrdersFilterView = ({
     try {
       const workOrderFilters = await getFilters('WorkOrder')
 
+      const selectedFilters = new SelectedFilterOptions(
+        appliedFilters,
+        workOrderFilters
+      ).getSelectedFilterOptions()
+
       setFilters(workOrderFilters)
+      setSelectedFilters(selectedFilters)
     } catch (e) {
       setFilters(null)
       console.error('An error has occured:', e.response)
@@ -60,6 +68,7 @@ const WorkOrdersFilterView = ({
             register={register}
             appliedFilters={appliedFilters}
             clearFilters={clearFilters}
+            selectedFilters={selectedFilters}
           />
         </form>
       </div>

--- a/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
+++ b/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
@@ -31,8 +31,139 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
       <div
         class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
       >
+        <section
+          class="lbh-collapsible"
+        >
+          <div
+            aria-expanded="true"
+            class="lbh-collapsible__button filter-collapsible"
+          >
+            <h2
+              class="lbh-heading-h2 lbh-collapsible__heading"
+            >
+              Selected filters
+            </h2>
+            <svg
+              height="10"
+              viewBox="0 0 17 10"
+              width="17"
+            >
+              <path
+                d="M2 1.5L8.5 7.5L15 1.5"
+                stroke-width="3"
+              />
+            </svg>
+          </div>
+          <div
+            class="lbh-collapsible__content govuk-!-margin-0"
+          >
+            <div
+              class="selected-filters govuk-!-padding-bottom-2"
+            >
+              <div
+                class="govuk-!-padding-2"
+              >
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Clear filters
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Save selected filters as my default preset
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Remove saved default filter preset
+                  </a>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Contractor
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Contractor"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Purdy Contracts (P) Ltd
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Avonline Network (A) Ltd
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Status
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Status"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        In Progress
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Priority
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Priority"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Immediate
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Emergency
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
         <div
-          class="govuk-!-padding-left-2"
+          class="govuk-!-padding-left-2 govuk-!-margin-top-0"
         >
           <button
             class="govuk-button lbh-button"
@@ -41,14 +172,6 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
           >
             Apply filters
           </button>
-          <div>
-            <a
-              class="lbh-link"
-              href="#"
-            >
-              Clear filters
-            </a>
-          </div>
         </div>
         <div
           class="border-bottom-grey"
@@ -69,6 +192,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.AVP"
                   name="ContractorReference.AVP"
@@ -85,6 +209,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.PCL"
                   name="ContractorReference.PCL"
@@ -135,6 +260,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="StatusCode.80"
                   name="StatusCode.80"
@@ -259,14 +385,15 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.I"
-                  name="Priorities.I"
+                  id="Priorities.1"
+                  name="Priorities.1"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.I"
+                  for="Priorities.1"
                 >
                   Immediate
                 </label>
@@ -275,14 +402,15 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.E"
-                  name="Priorities.E"
+                  id="Priorities.2"
+                  name="Priorities.2"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.E"
+                  for="Priorities.2"
                 >
                   Emergency
                 </label>
@@ -409,8 +537,139 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
       <div
         class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
       >
+        <section
+          class="lbh-collapsible"
+        >
+          <div
+            aria-expanded="true"
+            class="lbh-collapsible__button filter-collapsible"
+          >
+            <h2
+              class="lbh-heading-h2 lbh-collapsible__heading"
+            >
+              Selected filters
+            </h2>
+            <svg
+              height="10"
+              viewBox="0 0 17 10"
+              width="17"
+            >
+              <path
+                d="M2 1.5L8.5 7.5L15 1.5"
+                stroke-width="3"
+              />
+            </svg>
+          </div>
+          <div
+            class="lbh-collapsible__content govuk-!-margin-0"
+          >
+            <div
+              class="selected-filters govuk-!-padding-bottom-2"
+            >
+              <div
+                class="govuk-!-padding-2"
+              >
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Clear filters
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Save selected filters as my default preset
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Remove saved default filter preset
+                  </a>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Contractor
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Contractor"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Purdy Contracts (P) Ltd
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Avonline Network (A) Ltd
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Status
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Status"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        In Progress
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Priority
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Priority"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Immediate
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Emergency
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
         <div
-          class="govuk-!-padding-left-2"
+          class="govuk-!-padding-left-2 govuk-!-margin-top-0"
         >
           <button
             class="govuk-button lbh-button"
@@ -419,14 +678,6 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
           >
             Apply filters
           </button>
-          <div>
-            <a
-              class="lbh-link"
-              href="#"
-            >
-              Clear filters
-            </a>
-          </div>
         </div>
         <div
           class="border-bottom-grey"
@@ -447,6 +698,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.AVP"
                   name="ContractorReference.AVP"
@@ -463,6 +715,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.PCL"
                   name="ContractorReference.PCL"
@@ -513,6 +766,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="StatusCode.80"
                   name="StatusCode.80"
@@ -653,14 +907,15 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.I"
-                  name="Priorities.I"
+                  id="Priorities.1"
+                  name="Priorities.1"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.I"
+                  for="Priorities.1"
                 >
                   Immediate
                 </label>
@@ -669,14 +924,15 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.E"
-                  name="Priorities.E"
+                  id="Priorities.2"
+                  name="Priorities.2"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.E"
+                  for="Priorities.2"
                 >
                   Emergency
                 </label>
@@ -803,8 +1059,139 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
       <div
         class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
       >
+        <section
+          class="lbh-collapsible"
+        >
+          <div
+            aria-expanded="true"
+            class="lbh-collapsible__button filter-collapsible"
+          >
+            <h2
+              class="lbh-heading-h2 lbh-collapsible__heading"
+            >
+              Selected filters
+            </h2>
+            <svg
+              height="10"
+              viewBox="0 0 17 10"
+              width="17"
+            >
+              <path
+                d="M2 1.5L8.5 7.5L15 1.5"
+                stroke-width="3"
+              />
+            </svg>
+          </div>
+          <div
+            class="lbh-collapsible__content govuk-!-margin-0"
+          >
+            <div
+              class="selected-filters govuk-!-padding-bottom-2"
+            >
+              <div
+                class="govuk-!-padding-2"
+              >
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Clear filters
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Save selected filters as my default preset
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Remove saved default filter preset
+                  </a>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Contractor
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Contractor"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Purdy Contracts (P) Ltd
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Avonline Network (A) Ltd
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Status
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Status"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        In Progress
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Priority
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Priority"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Immediate
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Emergency
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
         <div
-          class="govuk-!-padding-left-2"
+          class="govuk-!-padding-left-2 govuk-!-margin-top-0"
         >
           <button
             class="govuk-button lbh-button"
@@ -813,14 +1200,6 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
           >
             Apply filters
           </button>
-          <div>
-            <a
-              class="lbh-link"
-              href="#"
-            >
-              Clear filters
-            </a>
-          </div>
         </div>
         <div
           class="border-bottom-grey"
@@ -841,6 +1220,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.AVP"
                   name="ContractorReference.AVP"
@@ -857,6 +1237,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.PCL"
                   name="ContractorReference.PCL"
@@ -907,6 +1288,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="StatusCode.80"
                   name="StatusCode.80"
@@ -1031,14 +1413,15 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.I"
-                  name="Priorities.I"
+                  id="Priorities.1"
+                  name="Priorities.1"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.I"
+                  for="Priorities.1"
                 >
                   Immediate
                 </label>
@@ -1047,14 +1430,15 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.E"
-                  name="Priorities.E"
+                  id="Priorities.2"
+                  name="Priorities.2"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.E"
+                  for="Priorities.2"
                 >
                   Emergency
                 </label>
@@ -1181,8 +1565,139 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
       <div
         class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
       >
+        <section
+          class="lbh-collapsible"
+        >
+          <div
+            aria-expanded="true"
+            class="lbh-collapsible__button filter-collapsible"
+          >
+            <h2
+              class="lbh-heading-h2 lbh-collapsible__heading"
+            >
+              Selected filters
+            </h2>
+            <svg
+              height="10"
+              viewBox="0 0 17 10"
+              width="17"
+            >
+              <path
+                d="M2 1.5L8.5 7.5L15 1.5"
+                stroke-width="3"
+              />
+            </svg>
+          </div>
+          <div
+            class="lbh-collapsible__content govuk-!-margin-0"
+          >
+            <div
+              class="selected-filters govuk-!-padding-bottom-2"
+            >
+              <div
+                class="govuk-!-padding-2"
+              >
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Clear filters
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Save selected filters as my default preset
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Remove saved default filter preset
+                  </a>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Contractor
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Contractor"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Purdy Contracts (P) Ltd
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Avonline Network (A) Ltd
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Status
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Status"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        In Progress
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Priority
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Priority"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Immediate
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Emergency
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
         <div
-          class="govuk-!-padding-left-2"
+          class="govuk-!-padding-left-2 govuk-!-margin-top-0"
         >
           <button
             class="govuk-button lbh-button"
@@ -1191,14 +1706,6 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
           >
             Apply filters
           </button>
-          <div>
-            <a
-              class="lbh-link"
-              href="#"
-            >
-              Clear filters
-            </a>
-          </div>
         </div>
         <div
           class="border-bottom-grey"
@@ -1219,6 +1726,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="StatusCode.80"
                   name="StatusCode.80"
@@ -1343,14 +1851,15 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.I"
-                  name="Priorities.I"
+                  id="Priorities.1"
+                  name="Priorities.1"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.I"
+                  for="Priorities.1"
                 >
                   Immediate
                 </label>
@@ -1359,14 +1868,15 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.E"
-                  name="Priorities.E"
+                  id="Priorities.2"
+                  name="Priorities.2"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.E"
+                  for="Priorities.2"
                 >
                   Emergency
                 </label>
@@ -1493,8 +2003,139 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
       <div
         class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
       >
+        <section
+          class="lbh-collapsible"
+        >
+          <div
+            aria-expanded="true"
+            class="lbh-collapsible__button filter-collapsible"
+          >
+            <h2
+              class="lbh-heading-h2 lbh-collapsible__heading"
+            >
+              Selected filters
+            </h2>
+            <svg
+              height="10"
+              viewBox="0 0 17 10"
+              width="17"
+            >
+              <path
+                d="M2 1.5L8.5 7.5L15 1.5"
+                stroke-width="3"
+              />
+            </svg>
+          </div>
+          <div
+            class="lbh-collapsible__content govuk-!-margin-0"
+          >
+            <div
+              class="selected-filters govuk-!-padding-bottom-2"
+            >
+              <div
+                class="govuk-!-padding-2"
+              >
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Clear filters
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Save selected filters as my default preset
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Remove saved default filter preset
+                  </a>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Contractor
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Contractor"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Purdy Contracts (P) Ltd
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Avonline Network (A) Ltd
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Status
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Status"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        In Progress
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Priority
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Priority"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Immediate
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Emergency
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
         <div
-          class="govuk-!-padding-left-2"
+          class="govuk-!-padding-left-2 govuk-!-margin-top-0"
         >
           <button
             class="govuk-button lbh-button"
@@ -1503,14 +2144,6 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
           >
             Apply filters
           </button>
-          <div>
-            <a
-              class="lbh-link"
-              href="#"
-            >
-              Clear filters
-            </a>
-          </div>
         </div>
         <div
           class="border-bottom-grey"
@@ -1531,6 +2164,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.AVP"
                   name="ContractorReference.AVP"
@@ -1547,6 +2181,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="ContractorReference.PCL"
                   name="ContractorReference.PCL"
@@ -1597,6 +2232,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
                   id="StatusCode.80"
                   name="StatusCode.80"
@@ -1737,14 +2373,15 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.I"
-                  name="Priorities.I"
+                  id="Priorities.1"
+                  name="Priorities.1"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.I"
+                  for="Priorities.1"
                 >
                   Immediate
                 </label>
@@ -1753,14 +2390,15 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                 class="govuk-checkboxes__item govuk-!-margin-0"
               >
                 <input
+                  checked=""
                   class="govuk-checkboxes__input"
-                  id="Priorities.E"
-                  name="Priorities.E"
+                  id="Priorities.2"
+                  name="Priorities.2"
                   type="checkbox"
                 />
                 <label
                   class="govuk-label govuk-checkboxes__label"
-                  for="Priorities.E"
+                  for="Priorities.2"
                 >
                   Emergency
                 </label>

--- a/src/components/WorkOrders/WorkOrdersView.js
+++ b/src/components/WorkOrders/WorkOrdersView.js
@@ -15,7 +15,7 @@ const WorkOrdersView = ({ query }) => {
   const [loading, setLoading] = useState(false)
   const [appliedFilters, setAppliedFilters] = useState()
   const pageNumber = parseInt(query?.pageNumber || 1)
-  const queryParams = appliedFilters || query
+  const queryParams = appliedFilters || query || {}
 
   const onFilterSubmit = async (formData) => {
     const setFilters = setFilterOptions(formData)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,13 +35,18 @@ const Home = ({ query }) => {
   }
 
   const HomeView = ({ contractors }) => {
+    // Use saved filter preset in local storage as the default applied filters (if present)
+    const defaultFilters = JSON.parse(
+      localStorage.getItem('RH - default work order filters')
+    )
+
     if (user.hasAgentPermissions) {
       if (user.hasContractorPermissions) {
         if (Object.entries(query).length === 0) {
           return (
             <WorkOrdersView
               pageNumber={1}
-              query={{ ContractorReference: contractors }}
+              query={defaultFilters || { ContractorReference: contractors }}
             />
           )
         } else {
@@ -59,13 +64,26 @@ const Home = ({ query }) => {
         if (user.hasAuthorisationManagerPermissions) {
           // Default filter selected for Authorisation Pending Approval work orders
           return (
-            <WorkOrdersView pageNumber={1} query={{ StatusCode: '1010' }} />
+            <WorkOrdersView
+              pageNumber={1}
+              query={defaultFilters || { StatusCode: '1010' }}
+            />
           )
         } else if (user.hasContractManagerPermissions) {
           // Default filter selected for Variation Pending Approval work orders
-          return <WorkOrdersView pageNumber={1} query={{ StatusCode: '90' }} />
+          return (
+            <WorkOrdersView
+              pageNumber={1}
+              query={defaultFilters || { StatusCode: '90' }}
+            />
+          )
         } else {
-          return <WorkOrdersView pageNumber={1} />
+          return (
+            <WorkOrdersView
+              pageNumber={1}
+              {...(defaultFilters && { query: defaultFilters })}
+            />
+          )
         }
       } else {
         return <WorkOrdersView query={query} />

--- a/src/styles/components/filter.scss
+++ b/src/styles/components/filter.scss
@@ -8,6 +8,26 @@
   box-shadow: inset 0 0 0 1px #b1b4b6;
   margin-top: 0;
 }
+.selected-filters {
+  background-color: repairs-hub-colour('lighter-grey');
+  box-shadow: inset 0 0 0 1px #b1b4b6;
+}
+.filter-tag {
+  background-color: repairs-hub-colour('white');
+  border: 1px solid repairs-hub-colour('black');
+  display: inline-block;
+  margin-top: 5px;
+  padding: 5px;
+  text-decoration: none;
+}
+.filter-tags {
+  margin-top: 0px;
+  li {
+    display: inline-block;
+    margin-right: 10px;
+    margin-top: 0px;
+  }
+}
 
 @media screen and (max-width: 1024px) {
   .filter-container {

--- a/src/utils/helpers/filter.js
+++ b/src/utils/helpers/filter.js
@@ -18,3 +18,74 @@ export const setFilterOptions = (formData) => {
 
   return filterOptions
 }
+
+const keyToDescriptionMap = (filters) => {
+  let filterMap = {}
+
+  Object.keys(filters).forEach((filterCategory) => {
+    let filterCategoryObject = filters[filterCategory]
+
+    const keyToDescriptionMapping = filterCategoryObject.map((object) => {
+      return {
+        [object.key]: object.description,
+      }
+    })
+
+    Object.assign(filterMap, {
+      [filterCategory]: Object.assign(...keyToDescriptionMapping),
+    })
+  })
+
+  return filterMap
+}
+
+export class SelectedFilterOptions {
+  constructor(appliedFilters, filters) {
+    this.keyToDescriptionMap = keyToDescriptionMap(filters)
+    this.selectedContractors = appliedFilters.ContractorReference
+    this.selectedStatuses = appliedFilters.StatusCode
+    this.selectedPriorities = appliedFilters.Priorities
+    this.selectedTrades = appliedFilters.TradeCodes
+  }
+
+  getSelectedFilterOptions() {
+    return {
+      ...(this.selectedContractors && { Contractor: this.getContractors() }),
+      ...(this.selectedStatuses && { Status: this.getStatuses() }),
+      ...(this.selectedPriorities && { Priority: this.getPriorities() }),
+      ...(this.selectedTrades && { Trade: this.getTrades() }),
+    }
+  }
+
+  getContractors() {
+    return (this.selectedContractors && [this.selectedContractors].flat()).map(
+      (contractor) => {
+        return this.keyToDescriptionMap.Contractors[contractor]
+      }
+    )
+  }
+
+  getStatuses() {
+    return (this.selectedStatuses && [this.selectedStatuses].flat()).map(
+      (status) => {
+        return this.keyToDescriptionMap.Status[status]
+      }
+    )
+  }
+
+  getPriorities() {
+    return (this.selectedPriorities && [this.selectedPriorities].flat()).map(
+      (priority) => {
+        return this.keyToDescriptionMap.Priority[priority]
+      }
+    )
+  }
+
+  getTrades() {
+    return (this.selectedTrades && [this.selectedTrades].flat()).map(
+      (trade) => {
+        return this.keyToDescriptionMap.Trades[trade]
+      }
+    )
+  }
+}

--- a/src/utils/helpers/filter.test.js
+++ b/src/utils/helpers/filter.test.js
@@ -1,0 +1,172 @@
+import { SelectedFilterOptions, setFilterOptions } from './filter'
+
+describe('#setFilterOptions', () => {
+  const formData = {
+    ContractorReference: {
+      AVP: false,
+      PCL: true,
+      SCC: true,
+    },
+    StatusCode: { 30: false, 50: false, 80: true },
+    Priorities: { 1: true, 2: false, 3: false },
+    TradeCodes: { PL: true, BK: false, EL: true },
+  }
+
+  it('it takes the formData sets what the applied filters are', () => {
+    expect(setFilterOptions(formData)).toEqual({
+      ContractorReference: ['PCL', 'SCC'],
+      Priorities: ['1'],
+      StatusCode: ['80'],
+      TradeCodes: ['PL', 'EL'],
+    })
+  })
+})
+
+describe('SelectedFilterOptions', () => {
+  const filters = {
+    Priority: [
+      {
+        key: '1',
+        description: 'Immediate',
+      },
+      {
+        key: '2',
+        description: 'Emergency',
+      },
+    ],
+    Status: [
+      {
+        key: '80',
+        description: 'In Progress',
+      },
+      {
+        key: '50',
+        description: 'Complete',
+      },
+      {
+        key: '30',
+        description: 'Work Cancelled',
+      },
+      {
+        key: '1010',
+        description: 'Authorisation Pending Approval',
+      },
+      {
+        key: '90',
+        description: 'Variation Pending Approval',
+      },
+      {
+        key: '1080',
+        description: 'Variation Approved',
+      },
+      {
+        key: '1090',
+        description: 'Variation Rejected',
+      },
+    ],
+    Trades: [
+      {
+        key: 'DE',
+        description: 'DOOR ENTRY ENGINEER',
+      },
+      {
+        key: 'EL',
+        description: 'Electrical',
+      },
+      {
+        key: 'GL',
+        description: 'Glazing',
+      },
+      {
+        key: 'PL',
+        description: 'Plumbing',
+      },
+    ],
+    Contractors: [
+      {
+        key: 'AVP',
+        description: 'Avonline Network (A) Ltd',
+      },
+      {
+        key: 'PCL',
+        description: 'Purdy Contracts (P) Ltd',
+      },
+      {
+        key: 'SCC',
+        description: 'Alphatrack (S) Systems Lt',
+      },
+    ],
+  }
+
+  describe('#getSelectedFilterOptions', () => {
+    it('when one option of each filter category is selected', () => {
+      const appliedFilters = {
+        ContractorReference: 'PCL',
+        StatusCode: '80',
+        Priorities: '1',
+        TradeCodes: 'EL',
+      }
+
+      expect(
+        new SelectedFilterOptions(
+          appliedFilters,
+          filters
+        ).getSelectedFilterOptions()
+      ).toEqual({
+        Contractor: ['Purdy Contracts (P) Ltd'],
+        Priority: ['Immediate'],
+        Status: ['In Progress'],
+        Trade: ['Electrical'],
+      })
+    })
+
+    it('when more than one option of all filter categories are selected', () => {
+      const appliedFilters = {
+        ContractorReference: ['PCL', 'AVP'],
+        StatusCode: ['80', '50'],
+        Priorities: ['1', '2'],
+        TradeCodes: ['EL', 'PL'],
+      }
+
+      expect(
+        new SelectedFilterOptions(
+          appliedFilters,
+          filters
+        ).getSelectedFilterOptions()
+      ).toEqual({
+        Contractor: ['Purdy Contracts (P) Ltd', 'Avonline Network (A) Ltd'],
+        Priority: ['Immediate', 'Emergency'],
+        Status: ['In Progress', 'Complete'],
+        Trade: ['Electrical', 'Plumbing'],
+      })
+    })
+
+    it('when not all filter categories are selected', () => {
+      const appliedFilters = {
+        ContractorReference: ['PCL', 'AVP'],
+        Priorities: '1',
+      }
+
+      expect(
+        new SelectedFilterOptions(
+          appliedFilters,
+          filters
+        ).getSelectedFilterOptions()
+      ).toEqual({
+        Contractor: ['Purdy Contracts (P) Ltd', 'Avonline Network (A) Ltd'],
+        Priority: ['Immediate'],
+      })
+    })
+
+    it('when there is nothing selected', () => {
+      const appliedFilters = {}
+
+      expect(
+        new SelectedFilterOptions(
+          appliedFilters,
+          filters
+        ).getSelectedFilterOptions()
+      ).toEqual({})
+    })
+  })
+})


### PR DESCRIPTION
### Description of change

- Allow users to save selected filters as default to localStorage
- Add UI to display selected filters
- Add link to save selected filters to local storage which will be used as the default whenever the user navigates to the work orders dashboard
- Add link to remove the saved default filters from localStorage

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/178333763

### **Collapsed**
![Screenshot 2021-06-23 at 14 09 10](https://user-images.githubusercontent.com/34001723/123132240-6dceca00-d446-11eb-9fb3-551fef5060ed.png)

### **Hidden**
![Screenshot 2021-06-23 at 14 09 38](https://user-images.githubusercontent.com/34001723/123132335-8c34c580-d446-11eb-93d2-c4f310792151.png)

### **Smaller screen**
![Screenshot 2021-06-23 at 14 11 32](https://user-images.githubusercontent.com/34001723/123132304-82ab5d80-d446-11eb-8df2-6e120f2e1aa3.png)

### **Window confirm message for saving selected filters to local storage**
![Screenshot 2021-06-23 at 14 09 23](https://user-images.githubusercontent.com/34001723/123132282-7c1ce600-d446-11eb-9f9a-f9636b5cf899.png)

