### PR TITLE
Show authorisation pending approval filter if user role includes authorisation manager

### DIFF
--- a/factories/authorisation_manager_and_contractor.js
+++ b/factories/authorisation_manager_and_contractor.js
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery'
+
+export const authorisationManagerAndContractorUserFactory = Factory.define(
+  () => ({
+    name: 'A DLO Supervisor',
+    email: 'a.dlo_supervisor@hackney.gov.uk',
+    roles: ['dlo_supervisor'],
+    hasRole: true,
+    hasAgentPermissions: false,
+    hasContractorPermissions: true,
+    hasContractManagerPermissions: false,
+    hasAuthorisationManagerPermissions: true,
+    hasAnyPermissions: true,
+  })
+)
+
+export const authorisationManagerAndContractor = authorisationManagerAndContractorUserFactory.build()

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -49,6 +49,7 @@ const WorkOrdersFilter = ({
     if (
       user &&
       user.hasContractorPermissions &&
+      !user.hasAgentPermissions &&
       !user.hasAuthorisationManagerPermissions
     ) {
       return filters.Status.filter(

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -46,7 +46,11 @@ const WorkOrdersFilter = ({
   }
 
   const statusFilterOptions = () => {
-    if (user && user.hasContractorPermissions) {
+    if (
+      user &&
+      user.hasContractorPermissions &&
+      !user.hasAuthorisationManagerPermissions
+    ) {
       return filters.Status.filter(
         (status) =>
           status.key !== STATUS_AUTHORISATION_PENDING_APPROVAL.code.toString()

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.test.js
@@ -6,6 +6,7 @@ import { contractManager } from 'factories/contract_manager'
 import { authorisationManager } from 'factories/authorisation_manager'
 import { multipleContractor } from 'factories/multiple_contractor'
 import { agentAndContractor } from 'factories/agent_and_contractor'
+import { authorisationManagerAndContractor } from 'factories/authorisation_manager_and_contractor'
 import { SelectedFilterOptions } from '../../../utils/helpers/filter'
 
 describe('WorkOrdersFilter component', () => {
@@ -183,6 +184,26 @@ describe('WorkOrdersFilter component', () => {
 
       const { asFragment } = render(
         <UserContext.Provider value={{ user: contractor }}>
+          <WorkOrdersFilter
+            filters={props.filters}
+            loading={props.loading}
+            register={props.register}
+            clearFilters={props.clearFilters}
+            appliedFilters={props.appliedFilters}
+            selectedFilters={selectedFilters}
+          />
+        </UserContext.Provider>
+      )
+      expect(asFragment()).toMatchSnapshot()
+    })
+  })
+
+  describe('when logged in as a combined authorisation manager/contractor', () => {
+    it('should render properly with all filter options', () => {
+      const { asFragment } = render(
+        <UserContext.Provider
+          value={{ user: authorisationManagerAndContractor }}
+        >
           <WorkOrdersFilter
             filters={props.filters}
             loading={props.loading}

--- a/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
+++ b/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
@@ -506,6 +506,460 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
 </DocumentFragment>
 `;
 
+exports[`WorkOrdersFilter component when logged in as a combined authorisation manager/contractor should render properly with all filter options 1`] = `
+<DocumentFragment>
+  <section
+    class="lbh-collapsible"
+  >
+    <div
+      aria-expanded="true"
+      class="lbh-collapsible__button filter-collapsible"
+    >
+      <h2
+        class="lbh-heading-h2 lbh-collapsible__heading"
+      >
+        Filters
+      </h2>
+      <svg
+        height="10"
+        viewBox="0 0 17 10"
+        width="17"
+      >
+        <path
+          d="M2 1.5L8.5 7.5L15 1.5"
+          stroke-width="3"
+        />
+      </svg>
+    </div>
+    <div
+      class="lbh-collapsible__content govuk-!-margin-0"
+    >
+      <div
+        class="govuk-form-group lbh-form-group filter-options govuk-!-margin-bottom-5"
+      >
+        <section
+          class="lbh-collapsible"
+        >
+          <div
+            aria-expanded="true"
+            class="lbh-collapsible__button filter-collapsible"
+          >
+            <h2
+              class="lbh-heading-h2 lbh-collapsible__heading"
+            >
+              Selected filters
+            </h2>
+            <svg
+              height="10"
+              viewBox="0 0 17 10"
+              width="17"
+            >
+              <path
+                d="M2 1.5L8.5 7.5L15 1.5"
+                stroke-width="3"
+              />
+            </svg>
+          </div>
+          <div
+            class="lbh-collapsible__content govuk-!-margin-0"
+          >
+            <div
+              class="selected-filters govuk-!-padding-bottom-2"
+            >
+              <div
+                class="govuk-!-padding-2"
+              >
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Clear filters
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Save selected filters as my default preset
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class="lbh-link"
+                    href="#"
+                  >
+                    Remove saved default filter preset
+                  </a>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Contractor
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Contractor"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Purdy Contracts (P) Ltd
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Avonline Network (A) Ltd
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Status
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Status"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        In Progress
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4
+                    class="lbh-heading-h4"
+                  >
+                    Priority
+                  </h4>
+                  <ul
+                    class="filter-tags"
+                    id="selected-filters-Priority"
+                  >
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Immediate
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="lbh-body-xs filter-tag"
+                      >
+                        Emergency
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <div
+          class="govuk-!-padding-left-2 govuk-!-margin-top-0"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Apply filters
+          </button>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Status
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="status-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  checked=""
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.80"
+                  name="StatusCode.80"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.80"
+                >
+                  In Progress
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.50"
+                  name="StatusCode.50"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.50"
+                >
+                  Complete
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.30"
+                  name="StatusCode.30"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.30"
+                >
+                  Work Cancelled
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1010"
+                  name="StatusCode.1010"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1010"
+                >
+                  Authorisation Pending Approval
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.90"
+                  name="StatusCode.90"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.90"
+                >
+                  Variation Pending Approval
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1080"
+                  name="StatusCode.1080"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1080"
+                >
+                  Variation Approved
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="StatusCode.1090"
+                  name="StatusCode.1090"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1090"
+                >
+                  Variation Rejected
+                </label>
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-1 status-filters"
+          >
+            <a
+              class="lbh-link"
+              href="#"
+            >
+              Show all 7
+            </a>
+          </div>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Priority
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="priority-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  checked=""
+                  class="govuk-checkboxes__input"
+                  id="Priorities.1"
+                  name="Priorities.1"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.1"
+                >
+                  Immediate
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  checked=""
+                  class="govuk-checkboxes__input"
+                  id="Priorities.2"
+                  name="Priorities.2"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="Priorities.2"
+                >
+                  Emergency
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
+          class="border-bottom-grey"
+        >
+          <fieldset
+            class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2"
+          >
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--m"
+            >
+              Trade
+            </legend>
+            <div
+              class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-top-1"
+              id="trade-filters"
+            >
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.DE"
+                  name="TradeCodes.DE"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.DE"
+                >
+                  DOOR ENTRY ENGINEER
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.EL"
+                  name="TradeCodes.EL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.EL"
+                >
+                  Electrical
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.GL"
+                  name="TradeCodes.GL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.GL"
+                >
+                  Glazing
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
+                  id="TradeCodes.PL"
+                  name="TradeCodes.PL"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="TradeCodes.PL"
+                >
+                  Plumbing
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
 exports[`WorkOrdersFilter component when logged in as a contract manager should render properly with all filter options 1`] = `
 <DocumentFragment>
   <section

--- a/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
+++ b/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
@@ -310,6 +310,22 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
               >
                 <input
                   class="govuk-checkboxes__input"
+                  id="StatusCode.1010"
+                  name="StatusCode.1010"
+                  type="checkbox"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="StatusCode.1010"
+                >
+                  Authorisation Pending Approval
+                </label>
+              </div>
+              <div
+                class="govuk-checkboxes__item govuk-!-margin-0"
+              >
+                <input
+                  class="govuk-checkboxes__input"
                   id="StatusCode.90"
                   name="StatusCode.90"
                   type="checkbox"
@@ -322,7 +338,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                 </label>
               </div>
               <div
-                class="govuk-checkboxes__item govuk-!-margin-0"
+                class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-display-none"
               >
                 <input
                   class="govuk-checkboxes__input"
@@ -362,7 +378,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
               class="lbh-link"
               href="#"
             >
-              Show all 6
+              Show all 7
             </a>
           </div>
         </div>


### PR DESCRIPTION
### Description of change

We used to hide the authorisation pending approval filter if the user had a contractors role associated with them. However, a DLO operative may have a DLO contractor role in addition to an authorisation manager role or agent role.

This change will display the filter if the user has a DLO role regardless of the other groups they may be in.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/178690726