### PR TITLE
Move Repairs History tab to the last position

### DIFF
--- a/cypress/integration/notes/work-order-notes.spec.js
+++ b/cypress/integration/notes/work-order-notes.spec.js
@@ -35,8 +35,8 @@ describe('Notes', () => {
 
   it('Fill out notes form and update the work order status', () => {
     cy.visit('/work-orders/10000012')
-    // Repairs history tab should be active
-    cy.get('.govuk-tabs__list-item--selected a').contains('Repairs history')
+    // Tasks and SORs tab should be active
+    cy.get('.govuk-tabs__list-item--selected a').contains('Tasks and SORs')
     // Now select Notes tab
     cy.get('a[id="tab_notes-tab"]').click()
     cy.get('#notes-tab').within(() => {

--- a/cypress/integration/tasks-and-sors/tasks-and-sors.spec.js
+++ b/cypress/integration/tasks-and-sors/tasks-and-sors.spec.js
@@ -32,10 +32,7 @@ describe('Tasks and SORs', () => {
   it('Displays tasks and sors relating to a work order', () => {
     cy.visit('/work-orders/10000012')
 
-    // Repairs history tab should be active
-    cy.get('.govuk-tabs__list-item--selected a').contains('Repairs history')
-    // Now select Tasks and SORs tab
-    cy.get('a[id="tab_tasks-and-sors-tab"]').click()
+    cy.get('.govuk-tabs__list-item--selected a').contains('Tasks and SORs')
     cy.get('#tasks-and-sors-tab').within(() => {
       cy.get('.lbh-heading-h2').contains('Tasks and SORs')
 
@@ -104,10 +101,8 @@ describe('Tasks and SORs', () => {
 
   it('Navigate directly to tasks and sors tab', () => {
     cy.visit('/work-orders/10000012#tasks-and-sors-tab')
-
     // Tasks and SORs tab should be active
     cy.get('.govuk-tabs__list-item--selected a').contains('Tasks and SORs')
-
     cy.get('#tasks-and-sors-tab').within(() => {
       cy.get('.lbh-heading-h2').contains('Tasks and SORs')
 

--- a/cypress/integration/work-order/show-work-order.spec.js
+++ b/cypress/integration/work-order/show-work-order.spec.js
@@ -293,6 +293,10 @@ describe('Show work order page', () => {
       )
 
       cy.visit('/work-orders/10000012')
+      // Tasks and SORs tab should be active
+      cy.get('.govuk-tabs__list-item--selected a').contains('Tasks and SORs')
+      // Now select Notes tab
+      cy.get('a[id="tab_repairs-history-tab"]').click()
       cy.wait('@repairsHistory')
     })
 

--- a/src/components/Tabs/__snapshots__/index.test.js.snap
+++ b/src/components/Tabs/__snapshots__/index.test.js.snap
@@ -19,9 +19,9 @@ exports[`Tabs component should render properly 1`] = `
       >
         <a
           class="govuk-tabs__tab"
-          href="#repairs-history-tab"
+          href="#tasks-and-sors-tab"
         >
-          Repairs history
+          Tasks and SORs
         </a>
       </li>
       <li
@@ -29,12 +29,16 @@ exports[`Tabs component should render properly 1`] = `
       >
         <a
           class="govuk-tabs__tab"
-          href="#tasks-and-sors-tab"
+          href="#repairs-history-tab"
         >
-          Tasks and SORs
+          Repairs history
         </a>
       </li>
     </ul>
+    <div
+      class="govuk-tabs__panel hackney-tabs-info hackney-tabs-panel"
+      id="tasks-and-sors-tab"
+    />
     <div
       class="govuk-tabs__panel hackney-tabs-info hackney-tabs-panel"
       id="repairs-history-tab"
@@ -55,10 +59,6 @@ exports[`Tabs component should render properly 1`] = `
         </h4>
       </div>
     </div>
-    <div
-      class="govuk-tabs__panel hackney-tabs-info hackney-tabs-panel"
-      id="tasks-and-sors-tab"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/src/components/Tabs/index.test.js
+++ b/src/components/Tabs/index.test.js
@@ -16,7 +16,7 @@ describe('Tabs component', () => {
   enableGOVUKFrontendJavascript.mockImplementation(() => funcSpy())
 
   const props = {
-    tabsList: ['Repairs history', 'Tasks and SORs'],
+    tabsList: ['Tasks and SORs', 'Repairs history'],
     propertyReference: '00012345',
     workOrderReference: '10203040',
   }

--- a/src/components/WorkOrder/WorkOrderView.js
+++ b/src/components/WorkOrder/WorkOrderView.js
@@ -18,10 +18,10 @@ const WorkOrderView = ({ workOrderReference }) => {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
   const tabsList = [
-    'Repairs history',
     'Tasks and SORs',
     'Notes',
     'Pending variation',
+    'Repairs history',
   ]
 
   const getWorkOrderView = async (workOrderReference) => {


### PR DESCRIPTION
### Description of change

Move the Repairs History tab to the last position

### Story Link

https://www.pivotaltracker.com/story/show/178774686

### Screenshot
![Screenshot 2021-07-09 at 11 07 24](https://user-images.githubusercontent.com/7561969/125073019-4c5f1680-e0b3-11eb-9181-472c64b4064e.jpg)
