### PR TITLE
Correct response cache time

### DIFF
--- a/src/utils/helpers/cache.js
+++ b/src/utils/helpers/cache.js
@@ -1,3 +1,5 @@
 export const CACHE_MAX_SIZE = 500
 
 export const CACHE_MAX_AGE_IN_MS = 300000 // 5 minutes
+
+export const CACHE_MAX_AGE_IN_SECONDS = CACHE_MAX_AGE_IN_MS / 1000

--- a/src/utils/serviceApiClient.js
+++ b/src/utils/serviceApiClient.js
@@ -4,7 +4,7 @@ import * as HttpStatus from 'http-status-codes'
 import { isAuthorised } from './googleAuth'
 import { paramsSerializer } from './urls'
 import { cache } from './middleware/cache'
-import { CACHE_MAX_AGE_IN_MS } from './helpers/cache'
+import { CACHE_MAX_AGE_IN_SECONDS } from './helpers/cache'
 
 const {
   REPAIRS_SERVICE_API_URL,
@@ -21,7 +21,7 @@ export const serviceAPIRequest = cache(
 
       response.setHeader(
         'Cache-Control',
-        `public,max-age=${CACHE_MAX_AGE_IN_MS}`
+        `public,max-age=${CACHE_MAX_AGE_IN_SECONDS}`
       )
       response.setHeader('X-Cache', 'HIT')
 


### PR DESCRIPTION
The max-age directive requires seconds instead of milliseconds.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#expiration