### PR TITLE
Refactor operative selection & align with react hook form approach

### DIFF
--- a/src/components/Form/DataList/DataList.js
+++ b/src/components/Form/DataList/DataList.js
@@ -17,6 +17,7 @@ const DataList = ({
   required,
   labelMessage,
   value,
+  defaultValue,
   additionalDivClasses,
 }) => {
   useEffect(() => {
@@ -60,6 +61,7 @@ const DataList = ({
         list={`autocomplete-list-${name}`}
         autoComplete="off"
         onChange={(e) => onChange && onChange(e)}
+        defaultValue={defaultValue}
         {...(value && { value })}
       />
 

--- a/src/components/Operatives/OperativeDataList.js
+++ b/src/components/Operatives/OperativeDataList.js
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types'
-import { useState } from 'react'
 import { DataList } from '../Form'
 
 const OperativeDataList = ({
+  selectedOperative,
   name,
-  value,
   options,
   label,
   index,
-  operativeId,
   register,
   errors,
   showAddOperative,
@@ -16,34 +14,16 @@ const OperativeDataList = ({
   showRemoveOperative,
   removeOperativeHandler,
 }) => {
-  const [selectedOperativeName, setSelectedOperativeName] = useState(value)
-  const [selectedOperativeId, setSelectedOperativeId] = useState(operativeId)
-
-  const OPERATIVE_ID_REGEX = /\[(\d+)\]$/
-
-  const onChange = (e) => {
-    setSelectedOperativeName(e.target.value)
-
-    const idMatch = e.target.value.match(OPERATIVE_ID_REGEX)
-    const newOperativeId = Array.isArray(idMatch)
-      ? idMatch[idMatch.length - 1]
-      : ''
-
-    setSelectedOperativeId(newOperativeId)
-  }
-
   return (
     <>
       <div>
         <DataList
+          defaultValue={selectedOperative}
           name={name}
-          onChange={onChange}
-          value={selectedOperativeName}
           options={options}
           label={label}
           register={register({
             validate: (value) => {
-              setSelectedOperativeName(value)
               return options.includes(value) || 'Please select an operative'
             },
           })}
@@ -60,13 +40,6 @@ const OperativeDataList = ({
             -
           </button>
         )}
-        <input
-          id={`operativeId-${index}`}
-          name={`operativeId-${index}`}
-          type="hidden"
-          ref={register}
-          value={selectedOperativeId}
-        />
       </div>
 
       <div>
@@ -82,9 +55,8 @@ const OperativeDataList = ({
 
 OperativeDataList.propTypes = {
   name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  selectedOperative: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  operativeId: PropTypes.number.isRequired,
   index: PropTypes.number.isRequired,
   options: PropTypes.array.isRequired,
   register: PropTypes.func.isRequired,

--- a/src/components/Operatives/SelectOperatives.js
+++ b/src/components/Operatives/SelectOperatives.js
@@ -22,21 +22,23 @@ const SelectOperatives = ({
           Search by operative name and select from the list
         </p>
 
-        {selectedOperatives.map((operative, index) => {
+        {selectedOperatives.map((selectedOperative, index) => {
           return (
             <OperativeDataList
               key={index}
               label={`Operative name ${index + 1} *`}
               name={`operative-${index}`}
-              value={
-                operative
-                  ? formatOperativeOptionText(operative.id, operative.name)
+              selectedOperative={
+                selectedOperative
+                  ? formatOperativeOptionText(
+                      selectedOperative.id,
+                      selectedOperative.name
+                    )
                   : ''
               }
               options={availableOperatives.map((operative) =>
                 formatOperativeOptionText(operative.id, operative.name)
               )}
-              operativeId={operative ? operative.id : -1}
               index={index}
               register={register}
               errors={errors}

--- a/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
+++ b/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
@@ -44,12 +44,6 @@ exports[`SelectOperatives component should render properly 1`] = `
           />
         </datalist>
       </div>
-      <input
-        id="operativeId-0"
-        name="operativeId-0"
-        type="hidden"
-        value="1"
-      />
     </div>
     <div>
       <a

--- a/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
+++ b/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
@@ -86,6 +86,7 @@ exports[`RaiseWorkOrderForm component should render properly 1`] = `
             id="trade"
             list="autocomplete-list-trade"
             name="trade"
+            value=""
           />
           <datalist
             id="autocomplete-list-trade"

--- a/src/components/WorkOrders/CloseWorkOrder.js
+++ b/src/components/WorkOrders/CloseWorkOrder.js
@@ -27,6 +27,8 @@ const CloseWorkOrder = ({ reference }) => {
   const [CloseWorkOrderFormPage, setCloseWorkOrderFormPage] = useState(true)
   const router = useRouter()
 
+  const OPERATIVE_ID_REGEX = /\[(\d+)\]$/
+
   const makePostRequest = async (
     workOrderCompleteFormData,
     operativeAssignmentFormData
@@ -145,9 +147,15 @@ const CloseWorkOrder = ({ reference }) => {
     const properDate = convertToDateFormat(e)
     setCompletionDate(properDate)
 
-    const operativeIds = Object.entries(e)
-      .filter(([key]) => key.match(/^operativeId-\d+$/))
-      .map(([, value]) => Number.parseInt(value))
+    const operativeIds = Object.keys(e)
+      .filter((k) => k.match(/operative-\d+/))
+      .map((operativeKey) => {
+        const matches = e[operativeKey].match(OPERATIVE_ID_REGEX)
+
+        if (Array.isArray(matches)) {
+          return Number.parseInt(matches[matches.length - 1])
+        }
+      })
 
     setSelectedOperatives(
       operativeIds.map((operativeId) =>

--- a/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
@@ -201,12 +201,6 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
               />
             </datalist>
           </div>
-          <input
-            id="operativeId-0"
-            name="operativeId-0"
-            type="hidden"
-            value="1"
-          />
         </div>
         <div />
         <div>
@@ -247,12 +241,6 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
           >
             -
           </button>
-          <input
-            id="operativeId-1"
-            name="operativeId-1"
-            type="hidden"
-            value="2"
-          />
         </div>
         <div>
           <a


### PR DESCRIPTION
React Hook Form encourages the use of uncontrolled components. The
previous implementation was an odd mix of partially controlled and
uncontrolled with state both in components and in the DOM.

- Remove state management within OperativeDataList and rely on the
  form parent to extract operative ids instead of using hidden fields.
- Use a defaultValue prop instead of value [1]

This should hopefully help us to rationalise this form and help us
when implementing percentages.

1 - see https://reactjs.org/docs/uncontrolled-components.html#default-values)

We now avoid the React warning about a component changing from controlled to uncontrolled

![image](https://user-images.githubusercontent.com/1370570/130227984-9e0f786d-e4d4-47ef-a882-fc72873f860b.png)
