### PR TITLE
Split operative work proportions (part I)

### DIFF
--- a/src/components/Operatives/OperativeDataList.js
+++ b/src/components/Operatives/OperativeDataList.js
@@ -9,46 +9,39 @@ const OperativeDataList = ({
   index,
   register,
   errors,
-  showAddOperative,
-  addOperativeHandler,
-  showRemoveOperative,
-  removeOperativeHandler,
+  isOperativeNameSelected,
+  getValues,
 }) => {
+  const onChange = () => {
+    isOperativeNameSelected(true)
+  }
+
   return (
     <>
-      <div>
-        <DataList
-          defaultValue={selectedOperative}
-          name={name}
-          options={options}
-          label={label}
-          register={register({
-            validate: (value) => {
-              return options.includes(value) || 'Please select an operative'
-            },
-          })}
-          error={errors && errors[name]}
-          additionalDivClasses={['govuk-!-display-inline-block']}
-        />
-        {showRemoveOperative && (
-          <button
-            className="cursor-pointer govuk-!-margin-left-2"
-            aria-label="Remove operative"
-            type="button"
-            onClick={() => removeOperativeHandler(index)}
-          >
-            -
-          </button>
-        )}
-      </div>
-
-      <div>
-        {showAddOperative && (
-          <a className="lbh-link" href="#" onClick={addOperativeHandler}>
-            + Add operative from list
-          </a>
-        )}
-      </div>
+      <DataList
+        name={name}
+        onChange={onChange}
+        defaultValue={selectedOperative}
+        options={options}
+        label={label}
+        register={register({
+          validate: (value) => {
+            if (!options.includes(value)) {
+              return 'Please select an operative'
+            } else if (
+              Object.entries(getValues())
+                .filter(
+                  ([k]) => k !== `operative-${index}` && k.match(/operative-/)
+                )
+                .some(([, name], i) => name === value && i < index)
+            ) {
+              return 'This operative has already been added'
+            }
+          },
+        })}
+        error={errors && errors[name]}
+        additionalDivClasses={['govuk-!-display-inline-block']}
+      />
     </>
   )
 }

--- a/src/components/Operatives/SelectOperatives.js
+++ b/src/components/Operatives/SelectOperatives.js
@@ -1,71 +1,234 @@
 import PropTypes from 'prop-types'
 import { useState } from 'react'
+import cx from 'classnames'
 import OperativeDataList from './OperativeDataList'
+import SelectPercentage from '../WorkOrders/SelectPercentage'
 
 const SelectOperatives = ({
-  currentOperatives,
+  assignedOperativesToWorkOrder,
   availableOperatives,
   register,
   errors,
+  selectedPercentagesToShowOnEdit,
+  trigger,
+  getValues,
 }) => {
   const [selectedOperatives, setSelectedOperatives] = useState(
     // Add at least one slot for an operative
-    currentOperatives.length > 0 ? currentOperatives : [null]
+    assignedOperativesToWorkOrder.length > 0
+      ? assignedOperativesToWorkOrder
+      : [null]
   )
+  const [operativeNameIsSelected, setOperativeNameIsSelected] = useState(false)
+
+  const onSelectedOperative = (operativeId, index) => {
+    selectedOperatives[index] = availableOperatives.find(
+      (operative) => operative.id === parseInt(operativeId)
+    )
+
+    setSelectedOperatives(selectedOperatives)
+  }
+
+  const isOperativeNameSelected = (nameWasSelected) => {
+    setOperativeNameIsSelected(nameWasSelected)
+  }
 
   const formatOperativeOptionText = (id, name) => `${name} [${id}]`
 
+  const caculateInitialPercentage = (currentOperativesNumber) => {
+    if (selectedPercentagesToShowOnEdit.length > 0) {
+      return selectedPercentagesToShowOnEdit
+    } else if (currentOperativesNumber === 1) {
+      return ['100%']
+    } else if (currentOperativesNumber === 2) {
+      return ['50%', '50%']
+    } else if (currentOperativesNumber === 3) {
+      return ['33.3%', '33.3%', '33.3%']
+    } else if (currentOperativesNumber === 0) {
+      //for the cases when there are no assigned operatives
+      return ['-']
+    }
+    let operativeIndexPercentages = []
+    for (let i = 0; i < currentOperativesNumber; i++) {
+      operativeIndexPercentages.push('-')
+    }
+    return operativeIndexPercentages
+  }
+
+  const [updatedPercentages, setUpdatedPercentages] = useState(
+    caculateInitialPercentage(assignedOperativesToWorkOrder.length)
+  )
+
+  const calculateTotalPercentage = (
+    selOperatives,
+    operativesIndexPercentages
+  ) => {
+    //not using rounding logic in case options are (33.3, 33.3 and 30, then it will round it to 100, and it is not correct)
+    if (
+      selOperatives.length === 3 &&
+      operativesIndexPercentages[0] === '33.3%' &&
+      operativesIndexPercentages[1] === '33.3%' &&
+      operativesIndexPercentages[2] === '33.3%'
+    ) {
+      return 100
+    }
+    return [...Array(selOperatives.length).keys()]
+      .map((activeOperativeIndex) => {
+        if (
+          operativesIndexPercentages[activeOperativeIndex] == '-' ||
+          Object.keys(operativesIndexPercentages).length === 0
+        ) {
+          return 0
+        } else {
+          return parseInt(
+            operativesIndexPercentages[activeOperativeIndex].slice(0, -1)
+          )
+        }
+      })
+      .reduce((a, b) => {
+        return a + b
+      })
+  }
+
+  const updatePercentages = (operativeIndex, selectedPercentage) => {
+    updatedPercentages[operativeIndex] = selectedPercentage
+    setUpdatedPercentages(updatedPercentages)
+
+    calculateTotalPercentage(selectedOperatives, updatedPercentages)
+
+    if (errors && errors[`percentage-0`]) {
+      trigger()
+    }
+  }
+
+  const duplicateOperativeErrors = (errors) => {
+    return Object.entries(errors).some(
+      ([a, b]) =>
+        a.match(/operative/) && b['message'].match(/already been added/)
+    )
+  }
+
   return (
     <>
-      <div className="operatives">
+      <div
+        className={cx('operatives', {
+          'govuk-form-group--error':
+            errors &&
+            (errors['percentage-0'] || duplicateOperativeErrors(errors)),
+        })}
+      >
         <p className="govuk-heading-m">
           Search by operative name and select from the list
         </p>
 
+        {errors &&
+          (errors['percentage-0'] || duplicateOperativeErrors(errors)) && (
+            <span class="govuk-error-message lbh-error-message">
+              <span class="govuk-visually-hidden">Error:</span>{' '}
+              {errors['percentage-0']?.message}
+              {
+                Object.entries(errors).find(([a]) => a.match(/operative/))
+                  ?.message
+              }
+            </span>
+          )}
+
         {selectedOperatives.map((selectedOperative, index) => {
           return (
-            <OperativeDataList
-              key={index}
-              label={`Operative name ${index + 1} *`}
-              name={`operative-${index}`}
-              selectedOperative={
-                selectedOperative
-                  ? formatOperativeOptionText(
-                      selectedOperative.id,
-                      selectedOperative.name
+            <div key={index}>
+              <OperativeDataList
+                label={`Operative name ${index + 1} *`}
+                name={`operative-${index}`}
+                selectedOperative={
+                  selectedOperative
+                    ? formatOperativeOptionText(
+                        selectedOperative.id,
+                        selectedOperative.name
+                      )
+                    : ''
+                }
+                options={availableOperatives.map((operative) =>
+                  formatOperativeOptionText(operative.id, operative.name)
+                )}
+                operativeId={selectedOperative ? selectedOperative.id : -1}
+                index={index}
+                register={register}
+                errors={errors}
+                isOperativeNameSelected={isOperativeNameSelected}
+                onSelectedOperative={onSelectedOperative}
+                selectedOperatives={selectedOperatives}
+                getValues={getValues}
+              />
+
+              <SelectPercentage
+                updatePercentages={updatePercentages}
+                index={index}
+                operativeIndex={index}
+                assignedOperativesToWorkOrder={
+                  assignedOperativesToWorkOrder.length
+                }
+                selectedOperatives={selectedOperatives}
+                operativeNameIsSelected={operativeNameIsSelected}
+                errors={errors}
+                register={register({
+                  validate: () => {
+                    return (
+                      calculateTotalPercentage(
+                        selectedOperatives,
+                        updatedPercentages
+                      ) === 100 ||
+                      'Work done total across operatives must be equal to 100%'
                     )
-                  : ''
-              }
-              options={availableOperatives.map((operative) =>
-                formatOperativeOptionText(operative.id, operative.name)
-              )}
-              index={index}
-              register={register}
-              errors={errors}
-              showAddOperative={index === selectedOperatives.length - 1}
-              addOperativeHandler={(e) => {
-                e.preventDefault()
-                setSelectedOperatives([...selectedOperatives, null])
-              }}
-              showRemoveOperative={
-                index > 0 && index === selectedOperatives.length - 1
-              }
-              removeOperativeHandler={(operativeIndex) => {
-                setSelectedOperatives([
-                  ...selectedOperatives.slice(0, operativeIndex),
-                  ...selectedOperatives.slice(operativeIndex + 1),
-                ])
-              }}
-            />
+                  },
+                })}
+                preSelectedPercentages={selectedPercentagesToShowOnEdit[index]}
+              />
+            </div>
           )
         })}
+        <div>
+          <a
+            className="lbh-link"
+            href="#"
+            onClick={(e) => {
+              e.preventDefault()
+              setSelectedOperatives([...selectedOperatives, null])
+              let newSelectedPercentages = updatedPercentages
+              newSelectedPercentages.push('-')
+              setUpdatedPercentages(newSelectedPercentages)
+            }}
+          >
+            + Add operative from list
+          </a>
+        </div>
+        <div>
+          {selectedOperatives.length > 1 && (
+            <a
+              className="lbh-link"
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                let newSelectedOperatives = [
+                  ...selectedOperatives.slice(0, selectedOperatives.length - 1),
+                ]
+                let newSelectedPercentages = [
+                  ...updatedPercentages.slice(0, selectedOperatives.length - 1),
+                ]
+                setUpdatedPercentages(newSelectedPercentages)
+                setSelectedOperatives(newSelectedOperatives)
+              }}
+            >
+              - Remove operative from list
+            </a>
+          )}
+        </div>
       </div>
     </>
   )
 }
 
 SelectOperatives.propTypes = {
-  currentOperatives: PropTypes.array.isRequired,
+  assignedOperativesToWorkOrder: PropTypes.array.isRequired,
   availableOperatives: PropTypes.array.isRequired,
   register: PropTypes.func.isRequired,
 }

--- a/src/components/Operatives/SelectOperatives.test.js
+++ b/src/components/Operatives/SelectOperatives.test.js
@@ -20,9 +20,10 @@ describe('SelectOperatives component', () => {
   it('should render properly', () => {
     const { asFragment } = render(
       <SelectOperatives
-        currentOperatives={[operatives[0]]}
+        assignedOperativesToWorkOrder={[operatives[0]]}
         availableOperatives={operatives}
         register={() => {}}
+        selectedPercentagesToShowOnEdit={[]}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
+++ b/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
@@ -44,6 +44,77 @@ exports[`SelectOperatives component should render properly 1`] = `
           />
         </datalist>
       </div>
+      <div
+        class="select_percentage govuk-!-display-inline-block govuk-!-margin-left-4"
+      >
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="percentage-0-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="percentage-0"
+          >
+            Work done 
+          </label>
+          <select
+            class="govuk-select lbh-select undefined"
+            data-testid="percentage-0"
+            disabled=""
+            id="percentage-0"
+            name="percentage-0"
+          >
+            <option
+              value=""
+            />
+            <option
+              value="100%"
+            >
+              100%
+            </option>
+            <option
+              value="-"
+            >
+              -
+            </option>
+          </select>
+        </div>
+        <div
+          style="display: none;"
+        >
+          <div
+            class="govuk-form-group lbh-form-group"
+            id="percentage-0-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="percentage-0"
+            >
+              Work done 
+            </label>
+            <select
+              class="govuk-select lbh-select undefined"
+              data-testid="percentage-0"
+              id="percentage-0"
+              name="percentage-0"
+            >
+              <option
+                value=""
+              />
+              <option
+                value="100%"
+              >
+                100%
+              </option>
+              <option
+                value="-"
+              >
+                -
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
     </div>
     <div>
       <a
@@ -53,6 +124,7 @@ exports[`SelectOperatives component should render properly 1`] = `
         + Add operative from list
       </a>
     </div>
+    <div />
   </div>
 </DocumentFragment>
 `;

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -13,15 +13,23 @@ const CloseWorkOrderForm = ({
   reference,
   onGetToSummary,
   availableOperatives,
-  currentOperatives,
+  assignedOperativesToWorkOrder,
   operativeAssignmentMandatory,
   notes,
   time,
   date,
   reason,
   dateRaised,
+  selectedPercentagesToShowOnEdit,
 }) => {
-  const { handleSubmit, register, control, errors } = useForm({})
+  const {
+    handleSubmit,
+    register,
+    control,
+    errors,
+    trigger,
+    getValues,
+  } = useForm({})
 
   return (
     <>
@@ -77,10 +85,13 @@ const CloseWorkOrderForm = ({
 
           {operativeAssignmentMandatory && (
             <SelectOperatives
-              currentOperatives={currentOperatives}
+              assignedOperativesToWorkOrder={assignedOperativesToWorkOrder}
               availableOperatives={availableOperatives}
               register={register}
               errors={errors}
+              selectedPercentagesToShowOnEdit={selectedPercentagesToShowOnEdit}
+              trigger={trigger}
+              getValues={getValues}
             />
           )}
 

--- a/src/components/WorkOrders/CloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.test.js
@@ -22,6 +22,7 @@ describe('CloseWorkOrderForm component', () => {
     operatives: operatives,
     availableOperatives: operatives,
     reason: 'No Access',
+    selectedPercentagesToShowOnEdit: [],
   }
 
   it('should render properly', () => {
@@ -34,8 +35,9 @@ describe('CloseWorkOrderForm component', () => {
         date={props.date}
         reason={props.reason}
         operativeAssignmentMandatory={true}
-        currentOperatives={props.operatives}
+        assignedOperativesToWorkOrder={props.operatives}
         availableOperatives={props.availableOperatives}
+        selectedPercentagesToShowOnEdit={props.selectedPercentagesToShowOnEdit}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/WorkOrders/SelectPercentage.js
+++ b/src/components/WorkOrders/SelectPercentage.js
@@ -1,0 +1,154 @@
+import ProperTypes from 'prop-types'
+import { useEffect, useState } from 'react'
+import Select from '../Form/Select/Select'
+
+const SelectPercentage = ({
+  updatePercentages,
+  operativeIndex,
+  index,
+  assignedOperativesToWorkOrder,
+  selectedOperatives,
+  operativeNameIsSelected,
+  register,
+  preSelectedPercentages,
+}) => {
+  const isOnlyOneOperative = (selectedOperatives) => {
+    return selectedOperatives.length === 1
+  }
+
+  const getDefaultPercentage = (selectedOperatives) => {
+    if (preSelectedPercentages && selectedOperatives.length !== 1) {
+      return preSelectedPercentages
+    } else if (
+      (operativeIndex === 0 &&
+        selectedOperatives.length === 1 &&
+        operativeNameIsSelected) ||
+      (operativeIndex === 0 &&
+        selectedOperatives.length === 1 &&
+        assignedOperativesToWorkOrder === 1)
+    ) {
+      return '100%'
+    } else if (
+      assignedOperativesToWorkOrder === 2 &&
+      selectedOperatives.length === 2
+    ) {
+      return '50%'
+    } else if (
+      assignedOperativesToWorkOrder === 3 &&
+      selectedOperatives.length === 3
+    ) {
+      return '33.3%'
+    }
+    return '-'
+  }
+  const [selectedPercentage, setSelectedPercentage] = useState(
+    getDefaultPercentage(selectedOperatives)
+  )
+
+  const getPossiblePercentages = (selectedOperatives) => {
+    if (isOnlyOneOperative(selectedOperatives)) {
+      return ['100%', '-']
+    } else if (selectedOperatives.length == 3) {
+      return [
+        '100%',
+        '90%',
+        '80%',
+        '70%',
+        '60%',
+        '50%',
+        '40%',
+        '30%',
+        '33.3%',
+        '20%',
+        '10%',
+        '-',
+      ]
+    } else {
+      return [
+        '100%',
+        '90%',
+        '80%',
+        '70%',
+        '60%',
+        '50%',
+        '40%',
+        '30%',
+        '20%',
+        '10%',
+        '-',
+      ]
+    }
+  }
+
+  const onChange = (e) => {
+    // if percentage errors, then update state and percentages
+    // then trigger validation
+    setSelectedPercentage(e.target.value)
+    updatePercentages(operativeIndex, e.target.value)
+  }
+
+  useEffect(() => {
+    let onlyOneOperativeAndSelectedOperative =
+      operativeIndex === 0 &&
+      selectedOperatives.length === 1 &&
+      operativeNameIsSelected
+    let onlyOneAssignedOperative =
+      operativeIndex === 0 &&
+      selectedOperatives.length === 1 &&
+      assignedOperativesToWorkOrder === 1
+    let some = preSelectedPercentages && selectedOperatives.length === 1
+    if (
+      onlyOneOperativeAndSelectedOperative ||
+      onlyOneAssignedOperative ||
+      some
+    ) {
+      setSelectedPercentage('100%')
+      updatePercentages(operativeIndex, '100%')
+    } else if (
+      selectedOperatives.length !== 3 &&
+      selectedPercentage === '33.3%'
+    ) {
+      setSelectedPercentage('-')
+      updatePercentages(operativeIndex, '-')
+    }
+  }, [selectedOperatives, operativeNameIsSelected, selectedPercentage])
+
+  let isDisabled = isOnlyOneOperative(selectedOperatives)
+
+  return (
+    <>
+      <div className="select_percentage govuk-!-display-inline-block govuk-!-margin-left-4">
+        <Select
+          label="Work done"
+          name={`percentage-${index}`}
+          options={getPossiblePercentages(selectedOperatives)}
+          value={selectedPercentage}
+          disabled={isDisabled}
+          onChange={onChange}
+          register={register}
+        />
+        {/* Disabled elements are not sent on onSubmit, so if the element is disabled
+            we create another hidden input with the same name and the same value.
+            This one will be sent */}
+        {isDisabled && (
+          <div style={{ display: 'none' }}>
+            <Select
+              label="Work done"
+              name={`percentage-${index}`}
+              options={getPossiblePercentages(selectedOperatives)}
+              value={selectedPercentage}
+              register={register}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+SelectPercentage.prototype = {
+  operativesNumber: ProperTypes.number,
+  operativeIndex: ProperTypes.number,
+}
+
+export default SelectPercentage

--- a/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
@@ -201,8 +201,87 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
               />
             </datalist>
           </div>
+          <div
+            class="select_percentage govuk-!-display-inline-block govuk-!-margin-left-4"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-0-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-0"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-0"
+                id="percentage-0"
+                name="percentage-0"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
         </div>
-        <div />
         <div>
           <div
             class="govuk-form-group lbh-form-group govuk-!-display-inline-block"
@@ -234,13 +313,86 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
               />
             </datalist>
           </div>
-          <button
-            aria-label="Remove operative"
-            class="cursor-pointer govuk-!-margin-left-2"
-            type="button"
+          <div
+            class="select_percentage govuk-!-display-inline-block govuk-!-margin-left-4"
           >
-            -
-          </button>
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-1-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-1"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-1"
+                id="percentage-1"
+                name="percentage-1"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
         </div>
         <div>
           <a
@@ -248,6 +400,14 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
             href="#"
           >
             + Add operative from list
+          </a>
+        </div>
+        <div>
+          <a
+            class="lbh-link"
+            href="#"
+          >
+            - Remove operative from list
           </a>
         </div>
       </div>

--- a/src/utils/hact/workOrderStatusUpdate/assignOperatives.js
+++ b/src/utils/hact/workOrderStatusUpdate/assignOperatives.js
@@ -6,10 +6,12 @@ export const buildOperativeAssignmentFormData = (
     relatedWorkOrderReference: {
       id: workOrderReference,
     },
-    operativesAssigned: operatives.map((operative) => ({
+    operativesAssigned: operatives.map((op) => ({
       identification: {
-        number: operative.id,
+        number: op.operative.id,
       },
+      calculatedBonus:
+        op.percentage == '-' ? 0 : parseFloat(op.percentage.slice(0, -1)),
     })),
     typeCode: '10',
   }

--- a/src/utils/hact/workOrderStatusUpdate/assignOperatives.test.js
+++ b/src/utils/hact/workOrderStatusUpdate/assignOperatives.test.js
@@ -4,16 +4,25 @@ describe('buildOperativeAssignmentFormData', () => {
   it('builds the notes to post to the JobStatusUpdate endpoint in Repairs API', async () => {
     const operatives = [
       {
-        id: 1,
-        name: 'Operative A',
+        operative: {
+          id: 1,
+          name: 'Operative A',
+        },
+        percentage: '80%',
       },
       {
-        id: 2,
-        name: 'Operative B',
+        operative: {
+          id: 2,
+          name: 'Operative B',
+        },
+        percentage: '20%',
       },
       {
-        id: 3,
-        name: 'Operative C',
+        operative: {
+          id: 3,
+          name: 'Operative C',
+        },
+        percentage: '-',
       },
     ]
 
@@ -27,16 +36,19 @@ describe('buildOperativeAssignmentFormData', () => {
           identification: {
             number: 1,
           },
+          calculatedBonus: 80,
         },
         {
           identification: {
             number: 2,
           },
+          calculatedBonus: 20,
         },
         {
           identification: {
             number: 3,
           },
+          calculatedBonus: 0,
         },
       ],
       typeCode: '10',


### PR DESCRIPTION
Implemented by @siapankina.

https://www.pivotaltracker.com/n/projects/2500129/stories/178847301

Split operatives work proportions using a percentage select.

Pre-assigned operatives (i.e. those from DRS) are each assigned a "default", equal proportion.

This PR does not cover the option to select 'operative payment done'. (This may be implemented as part II.)

#### UI

![split_three](https://user-images.githubusercontent.com/1370570/131565513-00fecf3b-da20-431d-af83-a3421da8ffe8.png)
![error](https://user-images.githubusercontent.com/1370570/131565509-eb49cef9-9ea8-4279-ba53-ef5060113851.png)


