### PR TITLE
Add planner comments to printed tickets

### DIFF
--- a/src/components/WorkOrder/PrintJobTicketDetails.js
+++ b/src/components/WorkOrder/PrintJobTicketDetails.js
@@ -184,6 +184,17 @@ const PrintJobTicketDetails = ({
             </span>
           </div>
 
+          {workOrder.plannerComments && (
+            <div className="govuk-!-margin-top-4">
+              <h5 className="lbh-heading-h5 display-inline">
+                Planner comments
+              </h5>
+              <span className="lbh-body-s govuk-!-margin-left-4">
+                {workOrder.plannerComments}
+              </span>
+            </div>
+          )}
+
           <table className="sors govuk-!-margin-top-6 govuk-!-margin-bottom-3">
             <thead>
               <tr className="lbh-body-s govuk-!-font-weight-bold">


### PR DESCRIPTION
### Description of change

Show a planner comments section on printed tickets.

![Screenshot 2021-09-09 at 15 00 21](https://user-images.githubusercontent.com/1370570/132712325-b4e2a7a6-5588-4616-aff6-e59e8695f922.png)


### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/179316935

### Decisions

No tests. Not currently sure how to test printed content.
