### PR TITLE
Simplify header links

### DIFF
--- a/cypress/integration/home-page.spec.js
+++ b/cypress/integration/home-page.spec.js
@@ -452,14 +452,10 @@ describe('Home page', () => {
       cy.get('.lbh-header__title-link').should('have.attr', 'href', '/')
 
       // Manage work orders link
-      cy.get('#manage')
-        .contains('Manage work orders')
-        .should('have.attr', 'href', '/')
+      cy.contains('Manage work orders').should('not.exist')
 
       // Search link
-      cy.get('#search')
-        .contains('Search')
-        .should('have.attr', 'href', '/search')
+      cy.contains('Search').should('not.exist')
 
       // Logout component
       cy.get('#signout')

--- a/src/components/Layout/Header/Header.js
+++ b/src/components/Layout/Header/Header.js
@@ -3,10 +3,27 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import UserContext from '../../UserContext/UserContext'
 import cx from 'classnames'
-import { canManageJobs } from '../../../utils/userPermissions'
+
+import { HEADER_LINKS } from 'src/utils/headerLinks'
 
 const HeaderComponent = ({ serviceName }) => {
   const { user } = useContext(UserContext)
+
+  const headerLinks = () => {
+    return HEADER_LINKS.map((link) => {
+      if (link.permittedRoles.some((role) => user.roles.includes(role))) {
+        return (
+          <a id={link.id} href={`/${link.href}`}>
+            {link.description}
+          </a>
+        )
+      }
+    })
+  }
+
+  const showHeaderLinks = () => {
+    return user && <div className="lbh-header__links">{headerLinks()}</div>
+  }
 
   const envNamefiltering = () => {
     if (
@@ -97,21 +114,7 @@ const HeaderComponent = ({ serviceName }) => {
                 </a>
               </Link>
             </div>
-            {user && (
-              <div className="lbh-header__links">
-                {user && canManageJobs(user) && (
-                  <a id="manage" href="/">
-                    Manage work orders
-                  </a>
-                )}
-                <a id="search" href="/search">
-                  Search
-                </a>
-                <a id="signout" href="/logout">
-                  Sign out
-                </a>
-              </div>
-            )}
+            {showHeaderLinks()}
           </div>
         </div>
       </header>

--- a/src/components/Layout/Header/Header.test.js
+++ b/src/components/Layout/Header/Header.test.js
@@ -5,7 +5,7 @@ import { agent } from 'factories/agent'
 import { contractor } from 'factories/contractor'
 import { contractManager } from 'factories/contract_manager'
 import { authorisationManager } from 'factories/authorisation_manager'
-import { agentAndContractorUserFactory } from 'factories/agent_and_contractor'
+import { agentAndContractor } from 'factories/agent_and_contractor'
 
 describe('Header', () => {
   const serviceName = 'Hackney Header'
@@ -49,7 +49,7 @@ describe('Header', () => {
       const { getByText, queryByText } = render(
         <UserContext.Provider
           value={{
-            user: agentAndContractorUserFactory,
+            user: agentAndContractor,
           }}
         >
           <Header serviceName={serviceName} />

--- a/src/utils/headerLinks.js
+++ b/src/utils/headerLinks.js
@@ -1,0 +1,43 @@
+import {
+  AGENT_ROLE,
+  CONTRACTOR_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+  OPERATIVE_ROLE,
+} from './user'
+
+export const HEADER_LINKS = [
+  {
+    href: '',
+    id: 'manage',
+    description: 'Manage work orders',
+    permittedRoles: [
+      CONTRACTOR_ROLE,
+      CONTRACT_MANAGER_ROLE,
+      AUTHORISATION_MANAGER_ROLE,
+    ],
+  },
+  {
+    href: 'search',
+    id: 'search',
+    description: 'Search',
+    permittedRoles: [
+      AGENT_ROLE,
+      CONTRACTOR_ROLE,
+      CONTRACT_MANAGER_ROLE,
+      AUTHORISATION_MANAGER_ROLE,
+    ],
+  },
+  {
+    href: 'logout',
+    id: 'signout',
+    description: 'Sign out',
+    permittedRoles: [
+      AGENT_ROLE,
+      CONTRACTOR_ROLE,
+      CONTRACT_MANAGER_ROLE,
+      AUTHORISATION_MANAGER_ROLE,
+      OPERATIVE_ROLE,
+    ],
+  },
+]

--- a/src/utils/userPermissions.js
+++ b/src/utils/userPermissions.js
@@ -1,7 +1,3 @@
-export const canManageJobs = (user) => {
-  return user.hasContractorPermissions || !user.hasAgentPermissions
-}
-
 export const canSeeAllFilters = (user) => {
   return (
     !user.hasContractorPermissions ||

--- a/src/utils/userPermissions.test.js
+++ b/src/utils/userPermissions.test.js
@@ -1,5 +1,4 @@
 import {
-  canManageJobs,
   canSeeAllFilters,
   canSeeAppointmentDetailsInfo,
   canScheduleAppointment,
@@ -7,32 +6,6 @@ import {
   canSeeWorkOrders,
   canSeeOperativeWorkOrders,
 } from './userPermissions'
-
-describe('canManageJobs', () => {
-  describe('when user is allowed to manage jobs', () => {
-    const user = {
-      name: 'Test Testerston',
-      email: 'test@test.com',
-      hasContractorPermissions: true,
-      hasAgentPermissions: false,
-    }
-    it('returns true', () => {
-      expect(canManageJobs(user)).toBe(true)
-    })
-  })
-
-  describe('when user are NOT allowed to manage jobs', () => {
-    const user = {
-      name: 'Test Testerston',
-      email: 'test@test.com',
-      hasContractorPermissions: false,
-      hasAgentPermissions: true,
-    }
-    it('returns false', () => {
-      expect(canManageJobs(user)).toBe(false)
-    })
-  })
-})
 
 describe('canSeeAllFilters', () => {
   describe('when user can see all filters', () => {


### PR DESCRIPTION
### Description of change

- Export header links into helper function
- Apply the correct header links for `OPERATIVE`
- Use the correct name of the exported build user factory