### PR TITLE
Style rate schedule item

### DIFF
--- a/src/components/Form/TextInput/index.js
+++ b/src/components/Form/TextInput/index.js
@@ -13,13 +13,18 @@ const TextInput = ({
   required,
   onBlur,
   defaultValue,
+  additionalDivClasses,
   ...otherProps
 }) => (
   <div
     id={`${name}-form-group`}
-    className={cx('govuk-form-group lbh-form-group', {
-      'govuk-form-group--error': error,
-    })}
+    className={cx(
+      'govuk-form-group lbh-form-group',
+      {
+        'govuk-form-group--error': error,
+      },
+      additionalDivClasses
+    )}
   >
     <label className="govuk-label lbh-label" htmlFor={name}>
       {label} {required && <span className="govuk-required">*</span>}

--- a/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
+++ b/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
@@ -154,84 +154,75 @@ exports[`RaiseWorkOrderForm component should render properly 1`] = `
         >
           <div>
             <div
-              class="govuk-grid-row rate-schedule-item display-flex align-items-center position-relative"
-              id="rate-schedule-item-0"
+              class="rate-schedule-item govuk-!-margin-top-0"
             >
               <div
-                class="govuk-grid-column-two-thirds"
+                class="govuk-form-group lbh-form-group rate-schedule-item--sor-code"
+                id="rateScheduleItems[0][code]-form-group"
               >
-                <div
-                  class="govuk-form-group lbh-form-group"
-                  id="rateScheduleItems[0][code]-form-group"
+                <label
+                  class="govuk-label lbh-label"
+                  for="rateScheduleItems[0][code]"
                 >
-                  <label
-                    class="govuk-label lbh-label"
-                    for="rateScheduleItems[0][code]"
+                  SOR Code 
+                  <span
+                    class="govuk-required"
                   >
-                    SOR Code 
-                    <span
-                      class="govuk-required"
-                    >
-                      *
-                    </span>
-                     
-                    <span>
-                       - Search by code or description
-                    </span>
-                  </label>
-                  <input
-                    aria-disabled="true"
-                    autocomplete="off"
-                    class="govuk-select lbh-select govuk-!-margin-top-0 govuk-!-width-full"
-                    data-testid="rateScheduleItems[0][code]"
-                    disabled=""
-                    id="rateScheduleItems[0][code]"
-                    list="autocomplete-list-rateScheduleItems[0][code]"
-                    name="rateScheduleItems[0][code]"
-                    value=""
-                  />
-                  <datalist
-                    id="autocomplete-list-rateScheduleItems[0][code]"
-                  />
-                </div>
+                    *
+                  </span>
+                   
+                  <span>
+                     - Search by code or description
+                  </span>
+                </label>
                 <input
-                  id="rateScheduleItems[0][description]"
-                  name="rateScheduleItems[0][description]"
-                  type="hidden"
+                  aria-disabled="true"
+                  autocomplete="off"
+                  class="govuk-select lbh-select govuk-!-margin-top-0 govuk-!-width-full"
+                  data-testid="rateScheduleItems[0][code]"
+                  disabled=""
+                  id="rateScheduleItems[0][code]"
+                  list="autocomplete-list-rateScheduleItems[0][code]"
+                  name="rateScheduleItems[0][code]"
+                  value=""
                 />
-                <input
-                  id="rateScheduleItems[0][cost]"
-                  name="rateScheduleItems[0][cost]"
-                  type="hidden"
+                <datalist
+                  id="autocomplete-list-rateScheduleItems[0][code]"
                 />
               </div>
+              <input
+                id="rateScheduleItems[0][description]"
+                name="rateScheduleItems[0][description]"
+                type="hidden"
+              />
+              <input
+                id="rateScheduleItems[0][cost]"
+                name="rateScheduleItems[0][cost]"
+                type="hidden"
+              />
               <div
-                class="govuk-grid-column-one-third"
+                class="govuk-form-group lbh-form-group rate-schedule-item--quantity"
+                id="rateScheduleItems[0][quantity]-form-group"
               >
-                <div
-                  class="govuk-form-group lbh-form-group"
-                  id="rateScheduleItems[0][quantity]-form-group"
+                <label
+                  class="govuk-label lbh-label"
+                  for="rateScheduleItems[0][quantity]"
                 >
-                  <label
-                    class="govuk-label lbh-label"
-                    for="rateScheduleItems[0][quantity]"
+                  Quantity 
+                  <span
+                    class="govuk-required"
                   >
-                    Quantity 
-                    <span
-                      class="govuk-required"
-                    >
-                      *
-                    </span>
-                  </label>
-                  <input
-                    class="govuk-input lbh-input govuk-!-width-full"
-                    disabled=""
-                    id="rateScheduleItems[0][quantity]"
-                    name="rateScheduleItems[0][quantity]"
-                    type="text"
-                    value=""
-                  />
-                </div>
+                    *
+                  </span>
+                </label>
+                <input
+                  class="govuk-input lbh-input govuk-!-width-full"
+                  disabled=""
+                  id="rateScheduleItems[0][quantity]"
+                  name="rateScheduleItems[0][quantity]"
+                  type="text"
+                  value=""
+                />
               </div>
             </div>
             <a

--- a/src/components/WorkElement/RateScheduleItem.js
+++ b/src/components/WorkElement/RateScheduleItem.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import { GridRow, GridColumn } from '../Layout/Grid'
 import { DataList, TextInput } from '../Form'
 
 const RateScheduleItem = ({
@@ -20,75 +19,69 @@ const RateScheduleItem = ({
 }) => {
   return (
     <>
-      <GridRow
-        className="rate-schedule-item display-flex align-items-center position-relative"
-        id={`rate-schedule-item-${index}`}
-      >
-        <GridColumn width="two-thirds">
-          <DataList
-            name={`rateScheduleItems[${index}][code]`}
-            label="SOR Code"
-            labelMessage="- Search by code or description"
-            options={sorCodesList}
-            defaultValue={code ?? ''}
-            disabled={disabled}
-            onChange={(event) => onChange && onChange(index, event)}
-            required={true}
-            selected={code ?? ''}
-            register={register({
-              required: 'Please select an SOR code',
-              validate: (value) =>
-                sorCodesList.includes(value) || 'SOR code is not valid',
-            })}
-            error={errors && errors.rateScheduleItems?.[`${index}`]?.code}
-            widthClass="govuk-!-margin-top-0 govuk-!-width-full"
-          />
+      <div className="rate-schedule-item govuk-!-margin-top-0">
+        <DataList
+          name={`rateScheduleItems[${index}][code]`}
+          label="SOR Code"
+          labelMessage="- Search by code or description"
+          options={sorCodesList}
+          defaultValue={code ?? ''}
+          disabled={disabled}
+          onChange={(event) => onChange && onChange(index, event)}
+          required={true}
+          selected={code ?? ''}
+          register={register({
+            required: 'Please select an SOR code',
+            validate: (value) =>
+              sorCodesList.includes(value) || 'SOR code is not valid',
+          })}
+          error={errors && errors.rateScheduleItems?.[`${index}`]?.code}
+          widthClass="govuk-!-margin-top-0 govuk-!-width-full"
+          additionalDivClasses="rate-schedule-item--sor-code"
+        />
 
-          <input
-            id={`rateScheduleItems[${index}][description]`}
-            name={`rateScheduleItems[${index}][description]`}
-            {...(hiddenDescriptionValue && { value: description ?? '' })}
-            type="hidden"
-            ref={register}
-          />
-          <input
-            id={`rateScheduleItems[${index}][cost]`}
-            name={`rateScheduleItems[${index}][cost]`}
-            {...(cost && { value: cost ?? '' })}
-            type="hidden"
-            ref={register}
-          />
-        </GridColumn>
-        <GridColumn width="one-third">
-          <TextInput
-            name={`rateScheduleItems[${index}][quantity]`}
-            label="Quantity"
-            error={errors && errors.rateScheduleItems?.[`${index}`]?.quantity}
-            widthClass="govuk-!-width-full"
-            required={true}
-            defaultValue={quantity ?? ''}
-            onChange={(event) => onInputChange && onInputChange(index, event)}
-            disabled={disabled}
-            register={register({
-              required: 'Please enter a quantity',
-              validate: (value) => {
-                const maxTwoDecimalPoints = /^(?=.*\d)\d*(?:\.\d{1,2})?$/
-                if (isNaN(value)) {
-                  return 'Quantity must be a number'
-                } else if (value <= 0) {
-                  return 'Quantity must be greater than 0'
-                } else if (!maxTwoDecimalPoints.test(value)) {
-                  return 'Quantity including a decimal point is permitted a maximum of 2 decimal places'
-                } else {
-                  return true
-                }
-              },
-            })}
-          />
-        </GridColumn>
-
+        <input
+          id={`rateScheduleItems[${index}][description]`}
+          name={`rateScheduleItems[${index}][description]`}
+          {...(hiddenDescriptionValue && { value: description ?? '' })}
+          type="hidden"
+          ref={register}
+        />
+        <input
+          id={`rateScheduleItems[${index}][cost]`}
+          name={`rateScheduleItems[${index}][cost]`}
+          {...(cost && { value: cost ?? '' })}
+          type="hidden"
+          ref={register}
+        />
+        <TextInput
+          name={`rateScheduleItems[${index}][quantity]`}
+          label="Quantity"
+          error={errors && errors.rateScheduleItems?.[`${index}`]?.quantity}
+          widthClass="govuk-!-width-full"
+          required={true}
+          defaultValue={quantity ?? ''}
+          additionalDivClasses="rate-schedule-item--quantity"
+          onChange={(event) => onInputChange && onInputChange(index, event)}
+          disabled={disabled}
+          register={register({
+            required: 'Please enter a quantity',
+            validate: (value) => {
+              const maxTwoDecimalPoints = /^(?=.*\d)\d*(?:\.\d{1,2})?$/
+              if (isNaN(value)) {
+                return 'Quantity must be a number'
+              } else if (value <= 0) {
+                return 'Quantity must be greater than 0'
+              } else if (!maxTwoDecimalPoints.test(value)) {
+                return 'Quantity including a decimal point is permitted a maximum of 2 decimal places'
+              } else {
+                return true
+              }
+            },
+          })}
+        />
         {showRemoveRateScheduleItem && (
-          <div className="remove-rate-schedule-item position-absolute right-negative-3">
+          <div className="remove-rate-schedule-item govuk-!-margin-0">
             <button
               id={`remove-rate-schedule-item-${index}`}
               className="cursor-pointer"
@@ -99,7 +92,7 @@ const RateScheduleItem = ({
             </button>
           </div>
         )}
-      </GridRow>
+      </div>
     </>
   )
 }

--- a/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
+++ b/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
@@ -202,92 +202,83 @@ exports[`WorkOrderUpdateForm component should render properly 1`] = `
       class="govuk-!-padding-bottom-5"
     >
       <div
-        class="govuk-grid-row rate-schedule-item display-flex align-items-center position-relative"
-        id="rate-schedule-item-undefined"
+        class="rate-schedule-item govuk-!-margin-top-0"
       >
         <div
-          class="govuk-grid-column-two-thirds"
+          class="govuk-form-group lbh-form-group rate-schedule-item--sor-code"
+          id="rateScheduleItems[undefined][code]-form-group"
         >
-          <div
-            class="govuk-form-group lbh-form-group"
-            id="rateScheduleItems[undefined][code]-form-group"
+          <label
+            class="govuk-label lbh-label"
+            for="rateScheduleItems[undefined][code]"
           >
-            <label
-              class="govuk-label lbh-label"
-              for="rateScheduleItems[undefined][code]"
+            SOR Code 
+            <span
+              class="govuk-required"
             >
-              SOR Code 
-              <span
-                class="govuk-required"
-              >
-                *
-              </span>
-               
-              <span>
-                 - Search by code or description
-              </span>
-            </label>
-            <input
-              autocomplete="off"
-              class="govuk-select lbh-select govuk-!-margin-top-0 govuk-!-width-full"
-              data-testid="rateScheduleItems[undefined][code]"
-              id="rateScheduleItems[undefined][code]"
-              list="autocomplete-list-rateScheduleItems[undefined][code]"
-              name="rateScheduleItems[undefined][code]"
-              value="DES5R004"
-            />
-            <datalist
-              id="autocomplete-list-rateScheduleItems[undefined][code]"
-            >
-              <option
-                value="DES5R003 - Immediate call outs"
-              />
-              <option
-                value="DES5R004 - Emergency call out"
-              />
-            </datalist>
-          </div>
+              *
+            </span>
+             
+            <span>
+               - Search by code or description
+            </span>
+          </label>
           <input
-            id="rateScheduleItems[undefined][description]"
-            name="rateScheduleItems[undefined][description]"
-            type="hidden"
-            value=""
+            autocomplete="off"
+            class="govuk-select lbh-select govuk-!-margin-top-0 govuk-!-width-full"
+            data-testid="rateScheduleItems[undefined][code]"
+            id="rateScheduleItems[undefined][code]"
+            list="autocomplete-list-rateScheduleItems[undefined][code]"
+            name="rateScheduleItems[undefined][code]"
+            value="DES5R004"
           />
+          <datalist
+            id="autocomplete-list-rateScheduleItems[undefined][code]"
+          >
+            <option
+              value="DES5R003 - Immediate call outs"
+            />
+            <option
+              value="DES5R004 - Emergency call out"
+            />
+          </datalist>
+        </div>
+        <input
+          id="rateScheduleItems[undefined][description]"
+          name="rateScheduleItems[undefined][description]"
+          type="hidden"
+          value=""
+        />
+        <input
+          id="rateScheduleItems[undefined][cost]"
+          name="rateScheduleItems[undefined][cost]"
+          type="hidden"
+        />
+        <div
+          class="govuk-form-group lbh-form-group rate-schedule-item--quantity"
+          id="rateScheduleItems[undefined][quantity]-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="rateScheduleItems[undefined][quantity]"
+          >
+            Quantity 
+            <span
+              class="govuk-required"
+            >
+              *
+            </span>
+          </label>
           <input
-            id="rateScheduleItems[undefined][cost]"
-            name="rateScheduleItems[undefined][cost]"
-            type="hidden"
+            class="govuk-input lbh-input govuk-!-width-full"
+            id="rateScheduleItems[undefined][quantity]"
+            name="rateScheduleItems[undefined][quantity]"
+            type="text"
+            value="2"
           />
         </div>
         <div
-          class="govuk-grid-column-one-third"
-        >
-          <div
-            class="govuk-form-group lbh-form-group"
-            id="rateScheduleItems[undefined][quantity]-form-group"
-          >
-            <label
-              class="govuk-label lbh-label"
-              for="rateScheduleItems[undefined][quantity]"
-            >
-              Quantity 
-              <span
-                class="govuk-required"
-              >
-                *
-              </span>
-            </label>
-            <input
-              class="govuk-input lbh-input govuk-!-width-full"
-              id="rateScheduleItems[undefined][quantity]"
-              name="rateScheduleItems[undefined][quantity]"
-              type="text"
-              value="2"
-            />
-          </div>
-        </div>
-        <div
-          class="remove-rate-schedule-item position-absolute right-negative-3"
+          class="remove-rate-schedule-item govuk-!-margin-0"
         >
           <button
             class="cursor-pointer"

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -15,6 +15,7 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
 @import 'components/phase-banner';
 @import 'components/property-details';
 @import 'components/work-orders/work-orders';
+@import 'components/work-orders/rate-schedule-item';
 @import 'components/work-orders/print';
 @import 'components/tabs';
 @import 'components/notes';

--- a/src/styles/components/work-orders/rate-schedule-item.scss
+++ b/src/styles/components/work-orders/rate-schedule-item.scss
@@ -1,0 +1,30 @@
+.rate-schedule-item--sor-code {
+  @include govuk-media-query($from: tablet) {
+    width: 66.66666%;
+    display: inline-block;
+  }
+}
+
+.rate-schedule-item--quantity {
+  display: inline-block;
+
+  @include govuk-media-query($from: tablet) {
+    padding-left: 30px;
+    width: 33.33333%;
+  }
+}
+
+.rate-schedule-item > div {
+  box-sizing: border-box;
+}
+
+.rate-schedule-item {
+  position: relative;
+}
+
+.remove-rate-schedule-item {
+  position: absolute;
+  left: 103%;
+  top: 70px;
+  display: inline-block;
+}


### PR DESCRIPTION
## Description

Restyle the rate schedule item so that its inputs stack vertically at mobile widths.

This is to support upcoming mobile variation work.

## Limitations

Does not address a preexisting issue with the small 'delete item' button. This still has poor usability at mobile widths. A design conversation may be required for how to manage this properly.

## Screenshots

Before

![image](https://user-images.githubusercontent.com/1370570/137722414-8257741e-dbae-4b58-b7e2-c5fbfb9caf89.png)

After

![image](https://user-images.githubusercontent.com/1370570/137722462-190d47cc-25db-4435-8d68-d22232493af4.png)
