### PR TITLE
Attempt to fix intermittent test failure

### DIFF
--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -540,6 +540,8 @@ describe('Updating a work order', () => {
         cy.get('a').contains('DES5R006').click()
       })
 
+      cy.wait(['@workOrderRequest', '@tasksRequest'])
+
       cy.url().should(
         'contain',
         '/work-orders/10000621/tasks/ade7c53b-8947-414c-b88f-9c5e3d875cbf/edit'


### PR DESCRIPTION
Add `cy.wait` on a stubbed response in an attempt to fix [this failed test](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5fc0fa140d27c17563dd0136/617695a793a98a788bd6a21f-0-build/artifacts/cypress/screenshots/work-order/update.spec.js/Updating%20a%20work%20order%20--%20As%20an%20operative%20--%20allows%20editing%20of%20an%20existing%20task%20quantity%20%28failed%29.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20211025T113835Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20211025%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=23915fad9680a9e49d60c8358fb62442919fbede581c5de393ab66421190bde0).