### PR TITLE
Disable selection of logged in operative

### DIFF
--- a/cypress/fixtures/operatives/workOrder.json
+++ b/cypress/fixtures/operatives/workOrder.json
@@ -19,9 +19,9 @@
     "reason": null,
     "note": "School run"
   },
-  "canAssignOperative" : true,
-  "totalSMVs" : 76,
-  "operatives" : [
+  "canAssignOperative": true,
+  "totalSMVs": 76,
+  "operatives": [
     {
       "id": 1,
       "payrollNumber": "hu0001",

--- a/cypress/fixtures/operatives/workOrders.json
+++ b/cypress/fixtures/operatives/workOrders.json
@@ -20,9 +20,9 @@
       "reason": null,
       "note": null
     },
-    "canAssignOperative" : true,
-    "totalSMVs" : 76,
-    "operatives" : [
+    "canAssignOperative": true,
+    "totalSMVs": 76,
+    "operatives": [
       {
         "id": 1,
         "payrollNumber": "hu0001",
@@ -53,9 +53,9 @@
       "reason": null,
       "note": null
     },
-    "canAssignOperative" : true,
-    "totalSMVs" : 76,
-    "operatives" : [
+    "canAssignOperative": true,
+    "totalSMVs": 76,
+    "operatives": [
       {
         "id": 1,
         "payrollNumber": "hu0001",
@@ -85,9 +85,9 @@
       "reason": null,
       "note": null
     },
-    "canAssignOperative" : true,
-    "totalSMVs" : 76,
-    "operatives" : [
+    "canAssignOperative": true,
+    "totalSMVs": 76,
+    "operatives": [
       {
         "id": 1,
         "payrollNumber": "hu0001",
@@ -117,9 +117,9 @@
       "reason": null,
       "note": null
     },
-    "canAssignOperative" : true,
-    "totalSMVs" : 76,
-    "operatives" : [
+    "canAssignOperative": true,
+    "totalSMVs": 76,
+    "operatives": [
       {
         "id": 1,
         "payrollNumber": "hu0001",

--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -519,6 +519,13 @@ describe('Updating a work order', () => {
         { body: '' }
       ).as('jobStatusUpdateRequest')
 
+      cy.fixture('hubUser/user.json')
+        .then((user) => {
+          user.operativePayrollNumber = 'OP001'
+          cy.intercept({ method: 'GET', path: '/api/hub-user' }, { body: user })
+        })
+        .as('hubUserRequest')
+
       cy.intercept(
         {
           method: 'GET',
@@ -782,7 +789,14 @@ describe('Updating a work order', () => {
 
       cy.get('.operatives').within(() => {
         cy.get('input[list]').should('have.length', 1)
-        cy.get('input[list]').eq(0).should('have.value', 'Operative A [1]')
+        cy.get('input[list]')
+          .eq(0)
+          .should('have.value', 'Operative A [1]')
+          .should('be.disabled')
+        cy.get('select')
+          .eq(0)
+          .should('have.value', '100%')
+          .should('be.disabled')
 
         cy.get('a')
           .contains(/Add operative from list/)
@@ -863,16 +877,16 @@ describe('Updating a work order', () => {
         workOrder.totalSMVs = 76
         workOrder.operatives = [
           {
-            id: 1,
-            payrollNumber: 'OP001',
-            name: 'Operative A',
+            id: 2,
+            payrollNumber: 'OP002',
+            name: 'Operative B',
             trades: [],
             jobPercentage: 50,
           },
           {
-            id: 2,
-            payrollNumber: 'OP002',
-            name: 'Operative B',
+            id: 1,
+            payrollNumber: 'OP001',
+            name: 'Operative A',
             trades: [],
             jobPercentage: 50,
           },
@@ -911,6 +925,8 @@ describe('Updating a work order', () => {
       cy.get('.operatives').within(() => {
         cy.get('input[list]').should('have.length', 3)
         cy.get('input[list]').eq(0).should('have.value', 'Operative A [1]')
+        cy.get('input[list]').eq(0).should('be.disabled')
+
         cy.get('input[list]').eq(1).should('have.value', 'Operative B [2]')
         cy.get('input[list]').eq(2).should('have.value', 'Operative C [3]')
       })

--- a/src/components/Operatives/OperativeDataList.js
+++ b/src/components/Operatives/OperativeDataList.js
@@ -11,6 +11,7 @@ const OperativeDataList = ({
   errors,
   isOperativeNameSelected,
   getValues,
+  disabled,
 }) => {
   const onChange = () => {
     isOperativeNameSelected(true)
@@ -42,7 +43,17 @@ const OperativeDataList = ({
         error={errors && errors[name]}
         additionalDivClasses={['operative-datalist']}
         widthClass="govuk-!-width-full"
+        disabled={disabled}
       />
+
+      {disabled && (
+        <input
+          name={`operative-${index}`}
+          type="hidden"
+          value={selectedOperative}
+          ref={register}
+        />
+      )}
     </>
   )
 }

--- a/src/components/Operatives/OperativeForm.js
+++ b/src/components/Operatives/OperativeForm.js
@@ -10,6 +10,7 @@ const OperativeForm = ({
   availableOperatives,
   selectedPercentagesToShowOnEdit,
   totalSMV,
+  currentUserPayrollNumber,
 }) => {
   const { handleSubmit, register, errors, trigger, getValues } = useForm({})
 
@@ -30,6 +31,7 @@ const OperativeForm = ({
             trigger={trigger}
             getValues={getValues}
             totalSMV={totalSMV}
+            currentUserPayrollNumber={currentUserPayrollNumber}
           />
 
           <PrimarySubmitButton label={'Confirm'} />

--- a/src/components/Operatives/OperativeList.js
+++ b/src/components/Operatives/OperativeList.js
@@ -1,12 +1,20 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
+import { sortOperativesWithPayrollFirst } from '../../utils/helpers/operatives'
 
-const OperativeList = ({ operatives, workOrderReference }) => {
+const OperativeList = ({
+  operatives,
+  currentUserPayrollNumber,
+  workOrderReference,
+}) => {
   return (
     <>
       <h4 className="lbh-heading-h4">Operatives</h4>
       <ol className="govuk-list govuk-!-margin-top-6 govuk-!-margin-bottom-9">
-        {operatives.map((operative, index) => {
+        {sortOperativesWithPayrollFirst(
+          operatives,
+          currentUserPayrollNumber
+        ).map((operative, index) => {
           const percentageDisplay = operative.jobPercentage
             ? `${operative.jobPercentage}%`
             : 'N/A'

--- a/src/components/Operatives/OperativeWorkOrder.js
+++ b/src/components/Operatives/OperativeWorkOrder.js
@@ -22,6 +22,7 @@ const OperativeWorkOrder = ({
   personAlerts,
   locationAlerts,
   tasksAndSors,
+  currentUserPayrollNumber,
 }) => {
   const operativesCount = workOrder.operatives.length
   const { register, errors, handleSubmit } = useForm()
@@ -73,6 +74,7 @@ const OperativeWorkOrder = ({
             {linkText}
           </a>
         </Link>
+        <br />
       </>
     )
   }
@@ -95,6 +97,7 @@ const OperativeWorkOrder = ({
 
       <OperativeList
         operatives={workOrder.operatives}
+        currentUserPayrollNumber={currentUserPayrollNumber}
         workOrderReference={workOrderReference}
       />
 

--- a/src/components/Operatives/SelectOperatives.js
+++ b/src/components/Operatives/SelectOperatives.js
@@ -13,6 +13,7 @@ const SelectOperatives = ({
   trigger,
   getValues,
   totalSMV,
+  currentUserPayrollNumber,
 }) => {
   const [selectedOperatives, setSelectedOperatives] = useState(
     // Add at least one slot for an operative
@@ -135,11 +136,19 @@ const SelectOperatives = ({
           )}
 
         {selectedOperatives.map((selectedOperative, index) => {
+          const operativeIsCurrentUser =
+            currentUserPayrollNumber &&
+            currentUserPayrollNumber === selectedOperative?.payrollNumber
+
           return (
             <div key={index}>
               <OperativeDataList
                 label={`Operative name ${index + 1} *`}
-                name={`operative-${index}`}
+                name={
+                  operativeIsCurrentUser
+                    ? `operative-disabled-${index}`
+                    : `operative-${index}`
+                }
                 selectedOperative={
                   selectedOperative
                     ? formatOperativeOptionText(
@@ -159,6 +168,7 @@ const SelectOperatives = ({
                 onSelectedOperative={onSelectedOperative}
                 selectedOperatives={selectedOperatives}
                 getValues={getValues}
+                {...(operativeIsCurrentUser && { disabled: 'disabled' })}
               />
 
               {process.env.NEXT_PUBLIC_OPERATIVE_SPLITTING_ENABLED ===

--- a/src/components/Operatives/SelectOperatives.test.js
+++ b/src/components/Operatives/SelectOperatives.test.js
@@ -6,14 +6,17 @@ describe('SelectOperatives component', () => {
     {
       id: 1,
       name: 'Operative A',
+      payrollNumber: 'PN1',
     },
     {
       id: 2,
       name: 'Operative B',
+      payrollNumber: 'PN2',
     },
     {
       id: 3,
       name: 'Operative C',
+      payrollNumber: 'PN3',
     },
   ]
 
@@ -24,6 +27,19 @@ describe('SelectOperatives component', () => {
         availableOperatives={operatives}
         register={() => {}}
         selectedPercentagesToShowOnEdit={[]}
+      />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should disable the current operative when a current user payroll number is supplied', () => {
+    const { asFragment } = render(
+      <SelectOperatives
+        assignedOperativesToWorkOrder={operatives}
+        availableOperatives={operatives}
+        register={() => {}}
+        selectedPercentagesToShowOnEdit={[]}
+        currentUserPayrollNumber="PN1"
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Operatives/__snapshots__/OperativeWorkOrder.test.js.snap
+++ b/src/components/Operatives/__snapshots__/OperativeWorkOrder.test.js.snap
@@ -361,6 +361,7 @@ exports[`OperativeWorkOrder component with multiple operatives should render wor
   >
     Update operatives
   </a>
+  <br />
   <a
     class="govuk-button lbh-button"
     data-module="govuk-button"
@@ -726,6 +727,7 @@ exports[`OperativeWorkOrder component with single operative should render work o
   >
     Add operatives
   </a>
+  <br />
   <a
     class="govuk-button lbh-button"
     data-module="govuk-button"
@@ -1126,6 +1128,7 @@ exports[`OperativeWorkOrder component with single operative should render work o
   >
     Add operatives
   </a>
+  <br />
   <form>
     <div
       class="govuk-form-group lbh-form-group"
@@ -1525,6 +1528,7 @@ exports[`OperativeWorkOrder component with single operative should render work o
   >
     Add operatives
   </a>
+  <br />
   <form>
     <div
       class="govuk-form-group lbh-form-group"

--- a/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
+++ b/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
@@ -1,5 +1,444 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SelectOperatives component should disable the current operative when a current user payroll number is supplied 1`] = `
+<DocumentFragment>
+  <div
+    class="operatives"
+  >
+    <p
+      class="govuk-heading-m"
+    >
+      Search by operative name and select from the list
+    </p>
+    <div>
+      <div
+        class="govuk-form-group lbh-form-group operative-datalist"
+        id="operative-disabled-0-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="operative-disabled-0"
+        >
+          Operative name 1 *  
+        </label>
+        <input
+          aria-disabled="disabled"
+          autocomplete="off"
+          class="govuk-select lbh-select govuk-!-width-full"
+          data-testid="operative-disabled-0"
+          disabled=""
+          id="operative-disabled-0"
+          list="autocomplete-list-operative-disabled-0"
+          name="operative-disabled-0"
+          value="Operative A [1]"
+        />
+        <datalist
+          id="autocomplete-list-operative-disabled-0"
+        >
+          <option
+            value="Operative A [1]"
+          />
+          <option
+            value="Operative B [2]"
+          />
+          <option
+            value="Operative C [3]"
+          />
+        </datalist>
+      </div>
+      <input
+        name="operative-0"
+        type="hidden"
+        value="Operative A [1]"
+      />
+      <div
+        class="select-percentage"
+      >
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="percentage-0-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="percentage-0"
+          >
+            Work done 
+          </label>
+          <select
+            class="govuk-select lbh-select undefined"
+            data-testid="percentage-0"
+            id="percentage-0"
+            name="percentage-0"
+          >
+            <option
+              value=""
+            />
+            <option
+              value="100%"
+            >
+              100%
+            </option>
+            <option
+              value="90%"
+            >
+              90%
+            </option>
+            <option
+              value="80%"
+            >
+              80%
+            </option>
+            <option
+              value="70%"
+            >
+              70%
+            </option>
+            <option
+              value="60%"
+            >
+              60%
+            </option>
+            <option
+              value="50%"
+            >
+              50%
+            </option>
+            <option
+              value="40%"
+            >
+              40%
+            </option>
+            <option
+              value="33.3%"
+            >
+              33.3%
+            </option>
+            <option
+              value="30%"
+            >
+              30%
+            </option>
+            <option
+              value="20%"
+            >
+              20%
+            </option>
+            <option
+              value="10%"
+            >
+              10%
+            </option>
+            <option
+              value="-"
+            >
+              -
+            </option>
+          </select>
+        </div>
+      </div>
+      <div
+        class="smv-read-only"
+      >
+        <p
+          class="lbh-body smv-read-only--label"
+        >
+          SMV
+        </p>
+        <p
+          class="lbh-body smv-read-only--value"
+        >
+          NaN
+        </p>
+      </div>
+    </div>
+    <div>
+      <div
+        class="govuk-form-group lbh-form-group operative-datalist"
+        id="operative-1-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="operative-1"
+        >
+          Operative name 2 *  
+        </label>
+        <input
+          autocomplete="off"
+          class="govuk-select lbh-select govuk-!-width-full"
+          data-testid="operative-1"
+          id="operative-1"
+          list="autocomplete-list-operative-1"
+          name="operative-1"
+          value="Operative B [2]"
+        />
+        <datalist
+          id="autocomplete-list-operative-1"
+        >
+          <option
+            value="Operative A [1]"
+          />
+          <option
+            value="Operative B [2]"
+          />
+          <option
+            value="Operative C [3]"
+          />
+        </datalist>
+      </div>
+      <div
+        class="select-percentage"
+      >
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="percentage-1-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="percentage-1"
+          >
+            Work done 
+          </label>
+          <select
+            class="govuk-select lbh-select undefined"
+            data-testid="percentage-1"
+            id="percentage-1"
+            name="percentage-1"
+          >
+            <option
+              value=""
+            />
+            <option
+              value="100%"
+            >
+              100%
+            </option>
+            <option
+              value="90%"
+            >
+              90%
+            </option>
+            <option
+              value="80%"
+            >
+              80%
+            </option>
+            <option
+              value="70%"
+            >
+              70%
+            </option>
+            <option
+              value="60%"
+            >
+              60%
+            </option>
+            <option
+              value="50%"
+            >
+              50%
+            </option>
+            <option
+              value="40%"
+            >
+              40%
+            </option>
+            <option
+              value="33.3%"
+            >
+              33.3%
+            </option>
+            <option
+              value="30%"
+            >
+              30%
+            </option>
+            <option
+              value="20%"
+            >
+              20%
+            </option>
+            <option
+              value="10%"
+            >
+              10%
+            </option>
+            <option
+              value="-"
+            >
+              -
+            </option>
+          </select>
+        </div>
+      </div>
+      <div
+        class="smv-read-only"
+      >
+        <p
+          class="lbh-body smv-read-only--label"
+        >
+          SMV
+        </p>
+        <p
+          class="lbh-body smv-read-only--value"
+        >
+          NaN
+        </p>
+      </div>
+    </div>
+    <div>
+      <div
+        class="govuk-form-group lbh-form-group operative-datalist"
+        id="operative-2-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="operative-2"
+        >
+          Operative name 3 *  
+        </label>
+        <input
+          autocomplete="off"
+          class="govuk-select lbh-select govuk-!-width-full"
+          data-testid="operative-2"
+          id="operative-2"
+          list="autocomplete-list-operative-2"
+          name="operative-2"
+          value="Operative C [3]"
+        />
+        <datalist
+          id="autocomplete-list-operative-2"
+        >
+          <option
+            value="Operative A [1]"
+          />
+          <option
+            value="Operative B [2]"
+          />
+          <option
+            value="Operative C [3]"
+          />
+        </datalist>
+      </div>
+      <div
+        class="select-percentage"
+      >
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="percentage-2-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="percentage-2"
+          >
+            Work done 
+          </label>
+          <select
+            class="govuk-select lbh-select undefined"
+            data-testid="percentage-2"
+            id="percentage-2"
+            name="percentage-2"
+          >
+            <option
+              value=""
+            />
+            <option
+              value="100%"
+            >
+              100%
+            </option>
+            <option
+              value="90%"
+            >
+              90%
+            </option>
+            <option
+              value="80%"
+            >
+              80%
+            </option>
+            <option
+              value="70%"
+            >
+              70%
+            </option>
+            <option
+              value="60%"
+            >
+              60%
+            </option>
+            <option
+              value="50%"
+            >
+              50%
+            </option>
+            <option
+              value="40%"
+            >
+              40%
+            </option>
+            <option
+              value="33.3%"
+            >
+              33.3%
+            </option>
+            <option
+              value="30%"
+            >
+              30%
+            </option>
+            <option
+              value="20%"
+            >
+              20%
+            </option>
+            <option
+              value="10%"
+            >
+              10%
+            </option>
+            <option
+              value="-"
+            >
+              -
+            </option>
+          </select>
+        </div>
+      </div>
+      <div
+        class="smv-read-only"
+      >
+        <p
+          class="lbh-body smv-read-only--label"
+        >
+          SMV
+        </p>
+        <p
+          class="lbh-body smv-read-only--value"
+        >
+          NaN
+        </p>
+      </div>
+    </div>
+    <div>
+      <a
+        class="lbh-link"
+        href="#"
+      >
+        + Add operative from list
+      </a>
+    </div>
+    <div>
+      <a
+        class="lbh-link"
+        href="#"
+      >
+        - Remove operative from list
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SelectOperatives component should render properly 1`] = `
 <DocumentFragment>
   <div

--- a/src/components/WorkOrder/WorkOrderView.js
+++ b/src/components/WorkOrder/WorkOrderView.js
@@ -16,6 +16,7 @@ import OperativeWorkOrder from '../Operatives/OperativeWorkOrder'
 const WorkOrderView = ({ workOrderReference }) => {
   const { user } = useContext(UserContext)
   const [property, setProperty] = useState({})
+  const [currentUser, setCurrentUser] = useState({})
   const [workOrder, setWorkOrder] = useState({})
   const [locationAlerts, setLocationAlerts] = useState([])
   const [tasksAndSors, setTasksAndSors] = useState([])
@@ -69,6 +70,13 @@ const WorkOrderView = ({ workOrderReference }) => {
         path: `/api/workOrders/${workOrderReference}/tasks`,
       })
 
+      const currentUser = await frontEndApiRequest({
+        method: 'get',
+        path: '/api/hub-user',
+      })
+
+      setCurrentUser(currentUser)
+
       setTasksAndSors(
         sortObjectsByDateKey(tasksAndSors, ['dateAdded'], 'dateAdded')
       )
@@ -113,6 +121,7 @@ const WorkOrderView = ({ workOrderReference }) => {
           personAlerts={personAlerts}
           locationAlerts={locationAlerts}
           tasksAndSors={tasksAndSors}
+          currentUserPayrollNumber={currentUser?.operativePayrollNumber}
         />
       </>
     )

--- a/src/utils/helpers/operatives.js
+++ b/src/utils/helpers/operatives.js
@@ -1,0 +1,3 @@
+export const sortOperativesWithPayrollFirst = (operatives, payrollNumber) => {
+  return operatives.sort((o1) => (o1.payrollNumber === payrollNumber ? -1 : 1))
+}


### PR DESCRIPTION
Prevent the user from modifying themselves as being assigned to a work order. 

Also reorder the list of operatives on the work order and list of inputs on the edit form so that the currently logged-in operative always sees themselves as the first item.

Story: https://www.pivotaltracker.com/n/projects/2500129/stories/179671631

![image](https://user-images.githubusercontent.com/1370570/139476923-cd3cc956-67ea-47ec-903d-9137fdcb24b6.png)
