### PR TITLE
Show operatives on work orders on date that appointment has started

### DIFF
--- a/cypress/integration/work-order/show/show.spec.js
+++ b/cypress/integration/work-order/show/show.spec.js
@@ -109,39 +109,64 @@ describe('Show work order page', () => {
         })
       })
 
-      context('And the appointment start time is in the future', () => {
-        beforeEach(() => {
-          cy.clock(new Date('March 19 2021 11:59:00Z'))
-        })
+      context(
+        'When the appointment is on the same date as current date',
+        () => {
+          context('And start time is in the future of currentTime', () => {
+            beforeEach(() => {
+              cy.clock(new Date('March 19 2021 11:59:00Z'))
+            })
 
-        it('Does not show the assigned operatives', () => {
-          cy.visit('/work-orders/10000012')
+            it('Shows the assigned operatives', () => {
+              cy.visit('/work-orders/10000012')
 
-          cy.get('.appointment-details').within(() => {
-            cy.contains('Appointment details')
-            cy.contains('19 Mar 2021, 12:00-18:00')
+              cy.get('.appointment-details').within(() => {
+                cy.contains('Appointment details')
+                cy.contains('19 Mar 2021, 12:00-18:00')
+              })
+
+              cy.contains('Operative: Operative 1')
+            })
           })
 
-          cy.contains('Operative 1').should('not.exist')
-        })
-      })
+          context('And start time is in the past of currentTime', () => {
+            beforeEach(() => {
+              cy.clock(new Date('March 19 2021 12:01:00Z'))
+            })
 
-      context('And the appointment start time is in the past', () => {
-        beforeEach(() => {
-          cy.clock(new Date('March 19 2021 12:01:00Z'))
-        })
+            it('Shows the assigned operatives', () => {
+              cy.visit('/work-orders/10000012')
 
-        it('Shows the assigned operatives', () => {
-          cy.visit('/work-orders/10000012')
+              cy.get('.appointment-details').within(() => {
+                cy.contains('Appointment details')
+                cy.contains('19 Mar 2021, 12:00-18:00')
+              })
 
-          cy.get('.appointment-details').within(() => {
-            cy.contains('Appointment details')
-            cy.contains('19 Mar 2021, 12:00-18:00')
+              cy.contains('Operative: Operative 1')
+            })
+          })
+        }
+      )
+
+      context(
+        'And the appointment start dateTime is in the past of currentTime',
+        () => {
+          beforeEach(() => {
+            cy.clock(new Date('March 18 2021 11:59:00Z'))
           })
 
-          cy.contains('Operative: Operative 1')
-        })
-      })
+          it('Does not show the assigned operatives', () => {
+            cy.visit('/work-orders/10000012')
+
+            cy.get('.appointment-details').within(() => {
+              cy.contains('Appointment details')
+              cy.contains('19 Mar 2021, 12:00-18:00')
+            })
+
+            cy.contains('Operative 1').should('not.exist')
+          })
+        }
+      )
     })
 
     context(

--- a/src/components/WorkOrder/PrintJobTicketDetails.js
+++ b/src/components/WorkOrder/PrintJobTicketDetails.js
@@ -100,7 +100,7 @@ const PrintJobTicketDetails = ({
                   </strong>
                   {workOrder.operatives.length > 0 &&
                     workOrder.appointment &&
-                    workOrder.appointmentStartTimePassed() && (
+                    workOrder.appointmentISODatePassed() && (
                       <>
                         {`${workOrder.operatives
                           .map((operative) => operative.name)

--- a/src/components/WorkOrder/WorkOrderHeader.js
+++ b/src/components/WorkOrder/WorkOrderHeader.js
@@ -58,7 +58,7 @@ const WorkOrderHeader = ({
         )}
         {workOrder.operatives.length > 0 &&
           workOrder.appointment &&
-          workOrder.appointmentStartTimePassed() && (
+          workOrder.appointmentISODatePassed() && (
             <Operatives operatives={workOrder.operatives} />
           )}
       </div>

--- a/src/models/workOrder.js
+++ b/src/models/workOrder.js
@@ -1,4 +1,4 @@
-import { isSameDay } from 'date-fns'
+import { formatISO, isSameDay } from 'date-fns'
 import {
   EMERGENCY_PRIORITY_CODE,
   IMMEDIATE_PRIORITY_CODE,
@@ -31,7 +31,7 @@ export class WorkOrder {
       : this.status
   }
 
-  appointmentStartTimePassed = () => {
+  appointmentISODatePassed = () => {
     if (
       !this.appointment ||
       !this.appointment.date ||
@@ -40,13 +40,14 @@ export class WorkOrder {
       return false
     }
 
-    const currentTime = new Date().getTime()
+    const currentISODate = formatISO(new Date(), { representation: 'date' })
 
-    const appointmentStartTime = new Date(
-      `${this.appointment.date}T${this.appointment.start}`
-    ).getTime()
+    const appointmentISODate = formatISO(
+      new Date(`${this.appointment.date}T${this.appointment.start}`),
+      { representation: 'date' }
+    )
 
-    return currentTime > appointmentStartTime
+    return currentISODate >= appointmentISODate
   }
 
   appointmentIsToday = () => {

--- a/src/models/workOrder.test.js
+++ b/src/models/workOrder.test.js
@@ -66,14 +66,14 @@ describe('WorkOrder', () => {
     })
   })
 
-  describe('appointmentStartTimePassed()', () => {
+  describe('appointmentISODatePassed()', () => {
     it('returns false when there is no appointment', () => {
       const workOrder = new WorkOrder()
 
-      expect(workOrder.appointmentStartTimePassed()).toBe(false)
+      expect(workOrder.appointmentISODatePassed()).toBe(false)
     })
 
-    it('returns true when the current time is past the appointment start time', () => {
+    it('returns true when the current date is the same as the appointment start date with past time', () => {
       const now = new Date()
 
       const date = format(now, 'yyyy-MM-dd')
@@ -83,10 +83,10 @@ describe('WorkOrder', () => {
 
       MockDate.set(addMinutes(now, 1))
 
-      expect(workOrder.appointmentStartTimePassed()).toBe(true)
+      expect(workOrder.appointmentISODatePassed()).toBe(true)
     })
 
-    it('returns false when the current time is before the appointment start time', () => {
+    it('returns true when the current date is the same as the appointment start date with before time', () => {
       const now = new Date()
 
       const date = format(now, 'yyyy-MM-dd')
@@ -96,7 +96,20 @@ describe('WorkOrder', () => {
 
       MockDate.set(subMinutes(now, 1))
 
-      expect(workOrder.appointmentStartTimePassed()).toBe(false)
+      expect(workOrder.appointmentISODatePassed()).toBe(true)
+    })
+
+    it('returns false when the current date is before the appointment date', () => {
+      const now = new Date()
+
+      const date = format(now, 'yyyy-MM-dd')
+      const start = format(now, 'HH:mm')
+
+      const workOrder = new WorkOrder({ appointment: { date, start } })
+
+      MockDate.set(subDays(now, 1))
+
+      expect(workOrder.appointmentISODatePassed()).toBe(false)
     })
   })
 


### PR DESCRIPTION
### Description of change

Show operatives on work orders on date that appointment has started, before we were debating on the current dateTime, where now only on the date