### PR TITLE
Allow agents to close WO at the same Date of WO raised

### DIFF
--- a/cypress/integration/work-order/attend/close-by-proxy.spec.js
+++ b/cypress/integration/work-order/attend/close-by-proxy.spec.js
@@ -105,6 +105,30 @@ describe('Closing a work order on behalf of an operative', () => {
       })
     })
 
+    it('does not show errors when the raised date is on the completed date', () => {
+      cy.visit('/work-orders/10000040/close')
+
+      cy.get('form').within(() => {
+        cy.get('[type="radio"]').first().check()
+        cy.get('#date').type('2021-01-18') //Raised on 2021-01-18, 15:28
+        cy.get('#time').within(() => {
+          cy.get('#time-time').type('12')
+          cy.get('#time-minutes').type('45')
+        })
+        cy.get('#notes').type('test')
+        cy.get('[type="submit"]').contains('Submit').click()
+      })
+
+      cy.contains('Summary of updates to work order')
+      cy.get('.govuk-table__row').contains('Completion time')
+      cy.get('.govuk-table__row').contains('2021/01/18')
+      cy.get('.govuk-table__row').contains('12:45')
+      cy.get('.govuk-table__row').contains('Reason')
+      cy.get('.govuk-table__row').contains('Work Order Completed')
+      cy.get('.govuk-table__row').contains('Notes')
+      cy.get('.govuk-table__row').contains('test')
+    })
+
     it('submits the form with inputs that are invalid', () => {
       cy.visit('/work-orders/10000040/close')
 

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -91,8 +91,8 @@ const CloseWorkOrderForm = ({
                     isInThePast: (value) =>
                       isPast(new Date(value)) ||
                       'Please select a date that is in the past',
-                    isLaterThanRaisedDate: (value) =>
-                      new Date(value) >
+                    isEqualOrLaterThanRaisedDate: (value) =>
+                      new Date(value) >=
                         new Date(new Date(dateRaised).toDateString()) ||
                       `Completion date must be on or after ${new Date(
                         dateRaised


### PR DESCRIPTION
### Description of change

Allow agents to close WO at the same Date of WO raised

### Story Link

https://www.pivotaltracker.com/story/show/180164060