### PR TITLE
Add isRaisable param to sorCodes request

### DIFF
--- a/cypress/fixtures/scheduleOfRates/codesWithIsRaisableTrue.json
+++ b/cypress/fixtures/scheduleOfRates/codesWithIsRaisableTrue.json
@@ -1,0 +1,47 @@
+[
+  {
+    "code": "PLP5R082",
+    "shortDescription": "RE ENAMEL ANY SIZE BATH",
+    "longDescription": "Prepare and reenamel surface of bath including removing and replacing plumbing fittings as required  Any size bath",
+    "priority": {
+      "priorityCode": 4,
+      "description": "5 [N] NORMAL"
+    },
+    "cost": 148.09
+  },
+  {
+    "code": "20000030",
+    "shortDescription": "DAYWORK PLUMBER BAND 3",
+    "priority": {
+      "priorityCode": 4,
+      "description": "5 [N] NORMAL"
+    }
+  },
+  {
+    "code": "20060020",
+    "shortDescription": "BATHROOM PLUMBING REPAIRS",
+    "priority": {
+      "priorityCode": 4,
+      "description": "5 [N] NORMAL"
+    },
+    "cost": 50.17
+  },
+  {
+    "code": "20060030",
+    "shortDescription": "KITCHEN PLUMBING REPAIRS",
+    "priority": {
+      "priorityCode": 4,
+      "description": "5 [N] NORMAL"
+    },
+    "cost": 5.8
+  },
+  {
+    "code": "DES5R003",
+    "shortDescription": "Immediate call outs",
+    "priority": {
+      "priorityCode": 1,
+      "description": "1 [I] IMMEDIATE"
+    },
+    "cost": 0
+  }
+]

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -26,14 +26,33 @@ describe('Raise repair form', () => {
       },
       { fixture: 'contractors/contractors.json' }
     )
+
+    //this checks if url has params "isRaisableTrue"
     cy.intercept(
       {
         method: 'GET',
-        path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01',
+        pathname: '/api/schedule-of-rates/codes',
+        query: {
+          tradeCode: 'PL',
+          propertyReference: '00012345',
+          contractorReference: 'H01',
+        },
       },
-      { fixture: 'scheduleOfRates/codes.json' }
+      (req) => {
+        if (req.url.includes('isRaisable=true')) {
+          req.reply({
+            statusCode: 200, // default
+            fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json',
+          })
+        } else {
+          req.reply({
+            statusCode: 200, // default
+            fixture: 'scheduleOfRates/codes.json',
+          })
+        }
+      }
     )
+
     cy.intercept(
       { method: 'GET', path: '/api/schedule-of-rates/priorities' },
       { fixture: 'scheduleOfRates/priorities.json' }

--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -53,13 +53,30 @@ describe('Updating a work order', () => {
         ).as('taskListRequest')
       })
 
+      //this checks if url has params "isRaisableTrue"
       cy.intercept(
         {
           method: 'GET',
-          path:
-            '/api/schedule-of-rates/codes?tradeCode=DE&propertyReference=00012345&contractorReference=SCC',
+          pathname: '/api/schedule-of-rates/codes',
+          query: {
+            tradeCode: 'DE',
+            propertyReference: '00012345',
+            contractorReference: 'SCC',
+          },
         },
-        { fixture: 'scheduleOfRates/codes.json' }
+        (req) => {
+          if (req.url.includes('isRaisable=true')) {
+            req.reply({
+              statusCode: 200,
+              fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json',
+            })
+          } else {
+            req.reply({
+              statusCode: 200,
+              fixture: 'scheduleOfRates/codes.json',
+            })
+          }
+        }
       ).as('sorCodesRequest')
 
       cy.intercept(
@@ -526,13 +543,30 @@ describe('Updating a work order', () => {
         })
         .as('hubUserRequest')
 
+      //this checks if url has params "isRaisableTrue"
       cy.intercept(
         {
           method: 'GET',
-          path:
-            '/api/schedule-of-rates/codes?tradeCode=DE&propertyReference=00012345&contractorReference=SCC',
+          pathname: '/api/schedule-of-rates/codes',
+          query: {
+            tradeCode: 'DE',
+            propertyReference: '00012345',
+            contractorReference: 'SCC',
+          },
         },
-        { fixture: 'scheduleOfRates/codes.json' }
+        (req) => {
+          if (req.url.includes('isRaisable=true')) {
+            req.reply({
+              statusCode: 200,
+              fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json',
+            })
+          } else {
+            req.reply({
+              statusCode: 200,
+              fixture: 'scheduleOfRates/codes.json',
+            })
+          }
+        }
       ).as('sorCodesRequest')
 
       cy.fixture('workOrders/workOrder.json').then((workOrder) => {

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -85,7 +85,12 @@ const TradeContractorRateScheduleItemView = ({
     setGetSorCodesError(null)
 
     try {
-      const sorCodes = await getSorCodes(tradeCode, propertyRef, contractorRef)
+      const sorCodes = await getSorCodes(
+        tradeCode,
+        propertyRef,
+        contractorRef,
+        true
+      )
 
       setSorCodes(sorCodes)
       setRateScheduleItemDisabled(false)

--- a/src/utils/frontEndApiClient/scheduleOfRates/codes.js
+++ b/src/utils/frontEndApiClient/scheduleOfRates/codes.js
@@ -3,16 +3,17 @@ import axios from 'axios'
 export const getSorCodes = async (
   tradeCode,
   propertyReference,
-  contractorReference
+  contractorReference,
+  isRaisable = false
 ) => {
   const { data } = await axios.get('/api/schedule-of-rates/codes', {
     params: {
       tradeCode: tradeCode,
       propertyReference: propertyReference,
       contractorReference: contractorReference,
+      isRaisable: isRaisable,
     },
   })
-
   return data
 }
 

--- a/src/utils/frontEndApiClient/scheduleOfRates/codes.test.js
+++ b/src/utils/frontEndApiClient/scheduleOfRates/codes.test.js
@@ -22,6 +22,30 @@ describe('getSorCodes`', () => {
         contractorReference: 'H01',
         propertyReference: '00001234',
         tradeCode: 'PL',
+        isRaisable: false,
+      },
+    })
+  })
+
+  it('calls the Next JS API with isRaisable: true params', async () => {
+    const responseData = { data: 'test' }
+
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: responseData,
+      })
+    )
+
+    const response = await getSorCodes('PL', '00001234', 'H01', true)
+
+    expect(response).toEqual(responseData)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith('/api/schedule-of-rates/codes', {
+      params: {
+        contractorReference: 'H01',
+        propertyReference: '00001234',
+        tradeCode: 'PL',
+        isRaisable: true,
       },
     })
   })


### PR DESCRIPTION
### Description of change
- Added "isRaisable" to API request for SOR codes 
- Updated test for API request (added check is isRaised is true/false)
- Updated integration test for create and update 
- Added new file with "codesWithIsRaisableTrue" as fixture for create and deleted some codes from there 
- For update the fixture is "codes" when all codes can be found

### Further work
- maybe in "cypress/integration/work-order/create/create.spec.js" add test that will check the length of sorCodes that we receive from back end? ("scheduleOfRates/codesWithIsRaisableTrue" length is 5 and "scheduleOfRates/codes" length is 10)
-check why in 'work-order/update.spec.js"  "as('sorCodesRequest')" is not working  (line 80) it fails on lines: 105, 236, 341, 570, 729

