### PR TITLE
Allow F/E to retrieve SORs using isRaisable flag

### DIFF
--- a/cypress/fixtures/scheduleOfRates/codesWithIsRaisableTrue.json
+++ b/cypress/fixtures/scheduleOfRates/codesWithIsRaisableTrue.json
@@ -1,0 +1,53 @@
+[
+  {
+    "code": "20060020",
+    "shortDescription": "BATHROOM PLUMBING REPAIRS",
+    "priority": {
+      "priorityCode": 4,
+      "description": "5 [N] NORMAL"
+    },
+    "cost": 50.17
+  },
+  {
+    "code": "20060030",
+    "shortDescription": "KITCHEN PLUMBING REPAIRS",
+    "priority": {
+      "priorityCode": 4,
+      "description": "5 [N] NORMAL"
+    },
+    "cost": 5.8
+  },
+  {
+    "code": "DES5R003",
+    "shortDescription": "Immediate call outs",
+    "priority": {
+      "priorityCode": 1,
+      "description": "1 [I] IMMEDIATE"
+    },
+    "cost": 0
+  },
+  {
+    "code": "DES5R004",
+    "shortDescription": "Emergency call out",
+    "priority": {
+      "priorityCode": 2,
+      "description": "2 [E] EMERGENCY"
+    }
+  },
+  {
+    "code": "DES5R005",
+    "shortDescription": "Normal call outs",
+    "priority": {
+      "priorityCode": 4,
+      "description": "5 [N] NORMAL"
+    }
+  },
+  {
+    "code": "DES5R006",
+    "shortDescription": "Urgent call outs",
+    "priority": {
+      "priorityCode": 3,
+      "description": "4 [U] URGENT"
+    }
+  }
+]

--- a/cypress/integration/work-order/create/appointment-form.spec.js
+++ b/cypress/integration/work-order/create/appointment-form.spec.js
@@ -28,9 +28,9 @@ describe('Schedule appointment form', () => {
       {
         method: 'GET',
         path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL',
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
       },
-      { fixture: 'scheduleOfRates/codes.json' }
+      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     )
     cy.intercept(
       { method: 'GET', path: '/api/schedule-of-rates/priorities' },

--- a/cypress/integration/work-order/create/create-with-appointment.spec.js
+++ b/cypress/integration/work-order/create/create-with-appointment.spec.js
@@ -28,17 +28,17 @@ describe('Schedule appointment form', () => {
       {
         method: 'GET',
         path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL',
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
       },
-      { fixture: 'scheduleOfRates/codes.json' }
+      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     )
     cy.intercept(
       {
         method: 'GET',
         path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01',
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01&isRaisable=true',
       },
-      { fixture: 'scheduleOfRates/codes.json' }
+      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     )
     cy.intercept(
       { method: 'GET', path: '/api/schedule-of-rates/priorities' },

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -30,9 +30,9 @@ describe('Raise repair form', () => {
       {
         method: 'GET',
         path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01',
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01&isRaisable=true',
       },
-      { fixture: 'scheduleOfRates/codes.json' }
+      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     )
     cy.intercept(
       { method: 'GET', path: '/api/schedule-of-rates/priorities' },

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -4,7 +4,7 @@ import RateScheduleItemView from './RateScheduleItemView'
 import TradeDataList from '../../WorkElement/TradeDataList'
 import ContractorDataList from './ContractorDataList'
 import { getContractors } from '../../../utils/frontEndApiClient/contractors'
-import { getSorCodes } from '../../../utils/frontEndApiClient/scheduleOfRates/codes'
+import { frontEndApiRequest } from '../../../utils/frontEndApiClient/requests'
 
 const TradeContractorRateScheduleItemView = ({
   trades,
@@ -85,7 +85,16 @@ const TradeContractorRateScheduleItemView = ({
     setGetSorCodesError(null)
 
     try {
-      const sorCodes = await getSorCodes(tradeCode, propertyRef, contractorRef)
+      const sorCodes = await frontEndApiRequest({
+        method: 'get',
+        path: '/api/schedule-of-rates/codes',
+        params: {
+          tradeCode: tradeCode,
+          propertyReference: propertyRef,
+          contractorReference: contractorRef,
+          isRaisable: true,
+        },
+      })
 
       setSorCodes(sorCodes)
       setRateScheduleItemDisabled(false)


### PR DESCRIPTION
### Description of change

Allow F/E to retrieve SORs using `isRaisable` flag

We have a lot of SORs but when agents are raising WO. we want them
to have a smaller list of SORs so we are adding this optional param

### Story Link

https://www.pivotaltracker.com/story/show/180164676