### PR TITLE
Attach notes when operatives are splitting their work orders

### DIFF
--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -878,6 +878,8 @@ describe('Updating a work order', () => {
               calculatedBonus: 0,
             },
           ],
+          comments:
+            'Work order updated - Assigned operatives Operative A : 50%, Operative B : 50%, Operative C : -',
           typeCode: '10',
         })
     })
@@ -1010,6 +1012,8 @@ describe('Updating a work order', () => {
               calculatedBonus: 50,
             },
           ],
+          comments:
+            'Work order updated - Assigned operatives Operative A : 30%, Operative B : 20%, Operative C : 50%',
           typeCode: '10',
         })
     })

--- a/src/components/Operatives/OperativeFormView.js
+++ b/src/components/Operatives/OperativeFormView.js
@@ -96,6 +96,15 @@ const OperativeFormView = ({ workOrderReference }) => {
     setLoading(false)
   }
 
+  const operativesAndPercentagesForNotes = (opsAndPercentages) => {
+    return opsAndPercentages
+      .map(
+        (op) =>
+          `${op.operative.name}${op.percentage ? ` : ${op.percentage}` : ''}`
+      )
+      .join(', ')
+  }
+
   const onSubmit = (e) => {
     const operativeIds = Object.keys(e)
       .filter((k) => k.match(/operative-\d+/))
@@ -127,9 +136,16 @@ const OperativeFormView = ({ workOrderReference }) => {
       }
     })
 
+    const operativesAssignedNote =
+      operativesWithPercentages.length > 0 &&
+      `Assigned operatives ${operativesAndPercentagesForNotes(
+        operativesWithPercentages
+      )}`
+
     const operativeAssignmentFormData = buildOperativeAssignmentFormData(
       workOrderReference,
-      operativesWithPercentages
+      operativesWithPercentages,
+      operativesAssignedNote
     )
 
     makePostRequest(operativeAssignmentFormData)

--- a/src/utils/hact/workOrderStatusUpdate/assignOperatives.js
+++ b/src/utils/hact/workOrderStatusUpdate/assignOperatives.js
@@ -1,6 +1,7 @@
 export const buildOperativeAssignmentFormData = (
   workOrderReference,
-  operatives
+  operatives,
+  operativesNotes
 ) => {
   return {
     relatedWorkOrderReference: {
@@ -15,6 +16,9 @@ export const buildOperativeAssignmentFormData = (
           op.percentage == '-' ? 0 : parseFloat(op.percentage.slice(0, -1)),
       }),
     })),
+    ...(operativesNotes && {
+      comments: `Work order updated - ${operativesNotes}`,
+    }),
     typeCode: '10',
   }
 }

--- a/src/utils/hact/workOrderStatusUpdate/assignOperatives.test.js
+++ b/src/utils/hact/workOrderStatusUpdate/assignOperatives.test.js
@@ -1,31 +1,24 @@
 import { buildOperativeAssignmentFormData } from './assignOperatives'
 
 describe('buildOperativeAssignmentFormData', () => {
-  it('builds the notes to post to the JobStatusUpdate endpoint in Repairs API', async () => {
-    const operatives = [
-      {
-        operative: {
-          id: 1,
-          name: 'Operative A',
-        },
-        percentage: '80%',
+  const operatives = [
+    {
+      operative: {
+        id: 1,
+        name: 'Operative A',
       },
-      {
-        operative: {
-          id: 2,
-          name: 'Operative B',
-        },
-        percentage: '20%',
+      percentage: '80%',
+    },
+    {
+      operative: {
+        id: 2,
+        name: 'Operative B',
       },
-      {
-        operative: {
-          id: 3,
-          name: 'Operative C',
-        },
-        percentage: '-',
-      },
-    ]
+      percentage: '20%',
+    },
+  ]
 
+  it('builds operatives to post to the JobStatusUpdate endpoint in Repairs API', async () => {
     const response = buildOperativeAssignmentFormData('1', operatives)
     expect(response).toEqual({
       relatedWorkOrderReference: {
@@ -44,13 +37,34 @@ describe('buildOperativeAssignmentFormData', () => {
           },
           calculatedBonus: 20,
         },
+      ],
+      typeCode: '10',
+    })
+  })
+
+  it('builds operatives with notes to post to the JobStatusUpdate endpoint in Repairs API', async () => {
+    const note = 'Assigned operatives: Operative A 80%, Operative B 20%'
+    const response = buildOperativeAssignmentFormData('1', operatives, note)
+    expect(response).toEqual({
+      relatedWorkOrderReference: {
+        id: '1',
+      },
+      operativesAssigned: [
         {
           identification: {
-            number: 3,
+            number: 1,
           },
-          calculatedBonus: 0,
+          calculatedBonus: 80,
+        },
+        {
+          identification: {
+            number: 2,
+          },
+          calculatedBonus: 20,
         },
       ],
+      comments:
+        'Work order updated - Assigned operatives: Operative A 80%, Operative B 20%',
       typeCode: '10',
     })
   })


### PR DESCRIPTION
### Description of change

Attach notes when operatives are splitting their work orders

### Story Link

https://www.pivotaltracker.com/story/show/180206733