### PR TITLE
Always show the operative WO view if accessed via mobile working

### DIFF
--- a/cypress/integration/work-order/attend/close.spec.js
+++ b/cypress/integration/work-order/attend/close.spec.js
@@ -141,7 +141,7 @@ describe('Closing my own work order', () => {
     })
 
     it('requires a variation reason and includes a jobStatusUpdate call', () => {
-      cy.visit('/work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
 
       cy.wait(['@workOrderRequest', '@propertyRequest', '@tasksRequest'])
 

--- a/cypress/integration/work-order/show/show.spec.js
+++ b/cypress/integration/work-order/show/show.spec.js
@@ -430,7 +430,7 @@ describe('Show work order page', () => {
     })
 
     it('shows links to expand description text, if text is more than 3 lines', () => {
-      cy.visit('work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
 
       cy.wait(['@operativesWorkOrder', '@property', '@task'])
       cy.contains('WO 10000621')

--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -556,7 +556,7 @@ describe('Updating a work order', () => {
     })
 
     it('does not show link list of operatives, when there is only one', () => {
-      cy.visit('work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
 
       cy.contains('WO 10000621')
 
@@ -566,7 +566,7 @@ describe('Updating a work order', () => {
     })
 
     it('allows editing of an existing task quantity', () => {
-      cy.visit('/work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
 
       cy.get('.latest-tasks-and-sors-table').within(() => {
         cy.get('a').contains('DES5R006').click()
@@ -637,7 +637,7 @@ describe('Updating a work order', () => {
     })
 
     it('allows editing of an existing task quantity with a "Remove SOR" shortcut', () => {
-      cy.visit('/work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
 
       cy.get('.latest-tasks-and-sors-table').within(() => {
         cy.get('a').contains('DES5R006').click()
@@ -700,7 +700,7 @@ describe('Updating a work order', () => {
     })
 
     it('allows adding new SOR', () => {
-      cy.visit('/work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
       cy.contains('Add new SOR').click()
 
       cy.wait('@sorCodesRequest')
@@ -791,7 +791,7 @@ describe('Updating a work order', () => {
         { fixture: 'operatives/operatives.json' }
       ).as('operatives')
 
-      cy.visit('/work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
       cy.wait(['@workOrderRequest', '@tasksRequest', '@propertyRequest'])
 
       cy.contains('a', 'Add operatives').click()
@@ -916,7 +916,7 @@ describe('Updating a work order', () => {
         { fixture: 'operatives/operatives.json' }
       ).as('operatives')
 
-      cy.visit('/work-orders/10000621')
+      cy.visit('/operatives/1/work-orders/10000621')
       cy.wait([
         '@workOrderRequestMultipleOperatives',
         '@tasksRequest',

--- a/src/components/Operatives/OperativeWorkOrderListItem.js
+++ b/src/components/Operatives/OperativeWorkOrderListItem.js
@@ -4,60 +4,66 @@ import Status from '../WorkOrder/Status'
 import cx from 'classnames'
 import { WorkOrder } from '../../models/workOrder'
 
-const OperativeWorkOrderListItem = ({ workOrder, index, statusText }) => {
+const OperativeWorkOrderListItem = ({
+  workOrder,
+  index,
+  statusText,
+  currentUser,
+}) => {
   return (
-    <>
-      <Link href={`/work-orders/${workOrder.reference}`}>
-        <li
-          data-id={index}
-          className={cx(
-            'govuk-!-margin-top-3',
-            'operative-work-order-list-item',
-            workOrder.hasBeenVisited()
-              ? 'operative-work-order-list-item--inactive'
-              : 'operative-work-order-list-item--active'
-          )}
-        >
-          <div className="appointment-details">
-            <div>
-              <h3 className="lbh-heading-h3 lbh-!-font-weight-bold govuk-!-margin-0 govuk-!-display-inline">
-                {`${workOrder.appointment.start} – ${workOrder.appointment.end}`}
-              </h3>
+    <Link
+      href={`/operatives/${currentUser?.operativePayrollNumber}/work-orders/${workOrder.reference}`}
+    >
+      <li
+        data-id={index}
+        className={cx(
+          'govuk-!-margin-top-3',
+          'operative-work-order-list-item',
+          workOrder.hasBeenVisited()
+            ? 'operative-work-order-list-item--inactive'
+            : 'operative-work-order-list-item--active'
+        )}
+      >
+        <div className="appointment-details">
+          <div>
+            <h3 className="lbh-heading-h3 lbh-!-font-weight-bold govuk-!-margin-0 govuk-!-display-inline">
+              {`${workOrder.appointment.start} – ${workOrder.appointment.end}`}
+            </h3>
 
-              {statusText && (
-                <Status
-                  text={statusText}
-                  className="govuk-!-margin-top-0 govuk-!-margin-left-2 uppercase"
-                />
-              )}
-            </div>
-            <p
-              className={cx(
-                'lbh-body lbh-!-font-weight-bold govuk-!-margin-0 govuk-!-margin-bottom-2 capitalize'
-              )}
-            >
-              {workOrder.priority.toLowerCase().split(' ').slice(-1)}
-            </p>
-            <p className="lbh-body govuk-!-margin-0">{workOrder.property}</p>
-            <p className="lbh-body govuk-!-margin-0 govuk-!-margin-bottom-8">
-              {workOrder.propertyPostCode}
-            </p>
-            <p className="lbh-body govuk-!-margin-0 truncate-description truncate-line-3">
-              {workOrder.description}
-            </p>
+            {statusText && (
+              <Status
+                text={statusText}
+                className="govuk-!-margin-top-0 govuk-!-margin-left-2 uppercase"
+              />
+            )}
           </div>
-          <div className="govuk-!-margin-0">
-            <span className="arrow right"></span>
-          </div>
-        </li>
-      </Link>
-    </>
+          <p
+            className={cx(
+              'lbh-body lbh-!-font-weight-bold govuk-!-margin-0 govuk-!-margin-bottom-2 capitalize'
+            )}
+          >
+            {workOrder.priority.toLowerCase().split(' ').slice(-1)}
+          </p>
+          <p className="lbh-body govuk-!-margin-0">{workOrder.property}</p>
+          <p className="lbh-body govuk-!-margin-0 govuk-!-margin-bottom-8">
+            {workOrder.propertyPostCode}
+          </p>
+          <p className="lbh-body govuk-!-margin-0 truncate-description truncate-line-3">
+            {workOrder.description}
+          </p>
+        </div>
+        <div className="govuk-!-margin-0">
+          <span className="arrow right"></span>
+        </div>
+      </li>
+    </Link>
   )
 }
 
 OperativeWorkOrderListItem.propTypes = {
   workOrder: PropTypes.instanceOf(WorkOrder).isRequired,
   index: PropTypes.number.isRequired,
+  currentUser: PropTypes.object.isRequired,
   statusText: PropTypes.string,
 }
 

--- a/src/components/Operatives/OperativeWorkOrderListItem.test.js
+++ b/src/components/Operatives/OperativeWorkOrderListItem.test.js
@@ -32,6 +32,7 @@ describe('OperativeWorkOrderListItem component', () => {
     const { asFragment } = render(
       <OperativeWorkOrderListItem
         workOrder={new WorkOrder(props.workOrder)}
+        currentUser={{ operativePayrollNumber: 1 }}
         index={0}
       />
     )

--- a/src/components/Operatives/OperativeWorkOrdersView.js
+++ b/src/components/Operatives/OperativeWorkOrdersView.js
@@ -11,6 +11,7 @@ import { WorkOrder } from '../../models/workOrder'
 
 const OperativeWorkOrdersView = () => {
   const currentDate = beginningOfDay(new Date())
+  const [currentUser, setCurrentUser] = useState({})
   const [inProgressWorkOrders, setInProgressWorkOrders] = useState([])
   const [visitedWorkOrders, setVisitedWorkOrders] = useState([])
   const [error, setError] = useState()
@@ -25,6 +26,8 @@ const OperativeWorkOrdersView = () => {
         method: 'get',
         path: '/api/hub-user',
       })
+
+      setCurrentUser(currentUser)
 
       const data = await frontEndApiRequest({
         method: 'get',
@@ -68,6 +71,7 @@ const OperativeWorkOrdersView = () => {
             return ''
           }
         })()}
+        currentUser={currentUser}
       />
     ))
   }
@@ -88,7 +92,7 @@ const OperativeWorkOrdersView = () => {
         <>
           {inProgressWorkOrders?.length || visitedWorkOrders?.length ? (
             <>
-              <ol className="lbh-list">
+              <ol className="lbh-list mobile-working-work-order-list">
                 {renderWorkOrderListItems(inProgressWorkOrders)}
                 {renderWorkOrderListItems(visitedWorkOrders)}
               </ol>

--- a/src/components/WorkOrder/OperativeWorkOrderView.js
+++ b/src/components/WorkOrder/OperativeWorkOrderView.js
@@ -71,22 +71,6 @@ const OperativeWorkOrderView = ({ workOrderReference }) => {
     setLoading(false)
   }
 
-  const renderOperativeWorkOrder = () => {
-    return (
-      <>
-        <OperativeWorkOrder
-          workOrderReference={workOrderReference}
-          property={property}
-          workOrder={workOrder}
-          personAlerts={personAlerts}
-          locationAlerts={locationAlerts}
-          tasksAndSors={tasksAndSors}
-          currentUserPayrollNumber={currentUser?.operativePayrollNumber}
-        />
-      </>
-    )
-  }
-
   useEffect(() => {
     setLoading(true)
 
@@ -105,8 +89,19 @@ const OperativeWorkOrderView = ({ workOrderReference }) => {
             tenure &&
             locationAlerts &&
             personAlerts &&
-            workOrder &&
-            renderOperativeWorkOrder()}
+            workOrder && (
+              <>
+                <OperativeWorkOrder
+                  workOrderReference={workOrderReference}
+                  property={property}
+                  workOrder={workOrder}
+                  personAlerts={personAlerts}
+                  locationAlerts={locationAlerts}
+                  tasksAndSors={tasksAndSors}
+                  currentUserPayrollNumber={currentUser?.operativePayrollNumber}
+                />
+              </>
+            )}
           {error && <ErrorMessage label={error} />}
         </>
       )}

--- a/src/components/WorkOrder/OperativeWorkOrderView.js
+++ b/src/components/WorkOrder/OperativeWorkOrderView.js
@@ -1,0 +1,121 @@
+import PropTypes from 'prop-types'
+import { useState, useEffect } from 'react'
+import Spinner from '../Spinner'
+import ErrorMessage from '../Errors/ErrorMessage'
+import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
+import { WorkOrder } from '@/models/workOrder'
+import { sortObjectsByDateKey } from '@/utils/date'
+import OperativeWorkOrder from '../Operatives/OperativeWorkOrder'
+
+const OperativeWorkOrderView = ({ workOrderReference }) => {
+  const [property, setProperty] = useState({})
+  const [currentUser, setCurrentUser] = useState({})
+  const [workOrder, setWorkOrder] = useState({})
+  const [locationAlerts, setLocationAlerts] = useState([])
+  const [tasksAndSors, setTasksAndSors] = useState([])
+  const [personAlerts, setPersonAlerts] = useState([])
+  const [tenure, setTenure] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState()
+
+  const getWorkOrderView = async (workOrderReference) => {
+    setError(null)
+
+    try {
+      const workOrder = await frontEndApiRequest({
+        method: 'get',
+        path: `/api/workOrders/${workOrderReference}`,
+      })
+      const propertyObject = await frontEndApiRequest({
+        method: 'get',
+        path: `/api/properties/${workOrder.propertyReference}`,
+      })
+
+      const tasksAndSors = await frontEndApiRequest({
+        method: 'get',
+        path: `/api/workOrders/${workOrderReference}/tasks`,
+      })
+
+      const currentUser = await frontEndApiRequest({
+        method: 'get',
+        path: '/api/hub-user',
+      })
+
+      setCurrentUser(currentUser)
+
+      setTasksAndSors(
+        sortObjectsByDateKey(tasksAndSors, ['dateAdded'], 'dateAdded')
+      )
+
+      setWorkOrder(new WorkOrder(workOrder))
+      setProperty(propertyObject.property)
+      setLocationAlerts(propertyObject.alerts.locationAlert)
+      setPersonAlerts(propertyObject.alerts.personAlert)
+      if (propertyObject.tenure) setTenure(propertyObject.tenure)
+    } catch (e) {
+      setWorkOrder(null)
+      setProperty(null)
+      console.error('An error has occured:', e.response)
+
+      if (e.response?.status === 404) {
+        setError(
+          `Could not find a work order with reference ${workOrderReference}`
+        )
+      } else {
+        setError(
+          `Oops an error occurred with error status: ${e.response?.status} with message: ${e.response?.data?.message}`
+        )
+      }
+    }
+
+    setLoading(false)
+  }
+
+  const renderOperativeWorkOrder = () => {
+    return (
+      <>
+        <OperativeWorkOrder
+          workOrderReference={workOrderReference}
+          property={property}
+          workOrder={workOrder}
+          personAlerts={personAlerts}
+          locationAlerts={locationAlerts}
+          tasksAndSors={tasksAndSors}
+          currentUserPayrollNumber={currentUser?.operativePayrollNumber}
+        />
+      </>
+    )
+  }
+
+  useEffect(() => {
+    setLoading(true)
+
+    getWorkOrderView(workOrderReference)
+  }, [])
+
+  return (
+    <>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <>
+          {property &&
+            property.address &&
+            property.hierarchyType &&
+            tenure &&
+            locationAlerts &&
+            personAlerts &&
+            workOrder &&
+            renderOperativeWorkOrder()}
+          {error && <ErrorMessage label={error} />}
+        </>
+      )}
+    </>
+  )
+}
+
+OperativeWorkOrderView.propTypes = {
+  workOrderReference: PropTypes.string.isRequired,
+}
+
+export default OperativeWorkOrderView

--- a/src/components/WorkOrder/WorkOrderView.js
+++ b/src/components/WorkOrder/WorkOrderView.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useState, useEffect, useContext } from 'react'
+import { useState, useEffect } from 'react'
 import WorkOrderDetails from './WorkOrderDetails'
 import Spinner from '../Spinner'
 import ErrorMessage from '../Errors/ErrorMessage'
@@ -9,14 +9,9 @@ import Tabs from '../Tabs'
 import { WorkOrder } from '@/models/workOrder'
 import { sortObjectsByDateKey } from '@/utils/date'
 import PrintJobTicketDetails from './PrintJobTicketDetails'
-import UserContext from '../UserContext'
-import { canSeeWorkOrder } from '@/utils/userPermissions'
-import OperativeWorkOrder from '../Operatives/OperativeWorkOrder'
 
 const WorkOrderView = ({ workOrderReference }) => {
-  const { user } = useContext(UserContext)
   const [property, setProperty] = useState({})
-  const [currentUser, setCurrentUser] = useState({})
   const [workOrder, setWorkOrder] = useState({})
   const [locationAlerts, setLocationAlerts] = useState([])
   const [tasksAndSors, setTasksAndSors] = useState([])
@@ -70,13 +65,6 @@ const WorkOrderView = ({ workOrderReference }) => {
         path: `/api/workOrders/${workOrderReference}/tasks`,
       })
 
-      const currentUser = await frontEndApiRequest({
-        method: 'get',
-        path: '/api/hub-user',
-      })
-
-      setCurrentUser(currentUser)
-
       setTasksAndSors(
         sortObjectsByDateKey(tasksAndSors, ['dateAdded'], 'dateAdded')
       )
@@ -111,59 +99,6 @@ const WorkOrderView = ({ workOrderReference }) => {
     setLoading(false)
   }
 
-  const renderOperativeWorkOrder = () => {
-    return (
-      <>
-        <OperativeWorkOrder
-          workOrderReference={workOrderReference}
-          property={property}
-          workOrder={workOrder}
-          personAlerts={personAlerts}
-          locationAlerts={locationAlerts}
-          tasksAndSors={tasksAndSors}
-          currentUserPayrollNumber={currentUser?.operativePayrollNumber}
-        />
-      </>
-    )
-  }
-
-  const renderWorkOrder = () => {
-    return (
-      <>
-        <WorkOrderDetails
-          property={property}
-          workOrder={workOrder}
-          tenure={tenure}
-          locationAlerts={locationAlerts}
-          personAlerts={personAlerts}
-          schedulerSessionId={schedulerSessionId}
-          tasksAndSors={tasksAndSors}
-          printClickHandler={printClickHandler}
-        />
-        <Tabs
-          tabsList={tabsList}
-          propertyReference={property.propertyReference}
-          workOrderReference={workOrderReference}
-          tasksAndSors={tasksAndSors}
-        />
-        {/* Only displayed for print media */}
-        <PrintJobTicketDetails
-          workOrder={workOrder}
-          property={property}
-          locationAlerts={locationAlerts}
-          personAlerts={personAlerts}
-          tasksAndSors={tasksAndSors}
-        />
-      </>
-    )
-  }
-
-  const renderWorkOrderView = () => {
-    return user && canSeeWorkOrder(user)
-      ? renderWorkOrder()
-      : renderOperativeWorkOrder()
-  }
-
   useEffect(() => {
     setLoading(true)
 
@@ -182,8 +117,34 @@ const WorkOrderView = ({ workOrderReference }) => {
             tenure &&
             locationAlerts &&
             personAlerts &&
-            workOrder &&
-            renderWorkOrderView()}
+            workOrder && (
+              <>
+                <WorkOrderDetails
+                  property={property}
+                  workOrder={workOrder}
+                  tenure={tenure}
+                  locationAlerts={locationAlerts}
+                  personAlerts={personAlerts}
+                  schedulerSessionId={schedulerSessionId}
+                  tasksAndSors={tasksAndSors}
+                  printClickHandler={printClickHandler}
+                />
+                <Tabs
+                  tabsList={tabsList}
+                  propertyReference={property.propertyReference}
+                  workOrderReference={workOrderReference}
+                  tasksAndSors={tasksAndSors}
+                />
+                {/* Only displayed for print media */}
+                <PrintJobTicketDetails
+                  workOrder={workOrder}
+                  property={property}
+                  locationAlerts={locationAlerts}
+                  personAlerts={personAlerts}
+                  tasksAndSors={tasksAndSors}
+                />
+              </>
+            )}
           {error && <ErrorMessage label={error} />}
         </>
       )}

--- a/src/pages/operatives/[operativeId]/work-orders/[id].js
+++ b/src/pages/operatives/[operativeId]/work-orders/[id].js
@@ -1,0 +1,24 @@
+import Meta from '@/components/Meta'
+import { getQueryProps } from '@/utils/helpers/serverSideProps'
+import { OPERATIVE_ROLE } from '@/utils/user'
+import OperativeWorkOrderView from '../../../../components/WorkOrder/OperativeWorkOrderView'
+
+const OperativeWorkOrderPage = ({ query }) => {
+  // This page was created so users in operative and other groups
+  // can access a work order via different links to take different actions.
+
+  // We intentionally do nothing with the operativeId supplied in the query
+  // Instead the API is relied upon to check operative work order access.
+  return (
+    <>
+      <Meta title={`Work Order ${query.id}`} />
+      <OperativeWorkOrderView workOrderReference={query.id} />
+    </>
+  )
+}
+
+export const getServerSideProps = getQueryProps
+
+OperativeWorkOrderPage.permittedRoles = [OPERATIVE_ROLE]
+
+export default OperativeWorkOrderPage


### PR DESCRIPTION
### Description of change

Separate page and route for an operative visiting a work order.

Prior to this, when a user happens to have both the operative and a non-operative role, we display the non-operative role's view of the page but this is not defined behaviour. This PR ensures that operatives accessing a work order from mobile working will always see the mobile working "view" of a work order.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/180434973

### Not included

Workflows / permissions to allow a user who has act both as an operative and a non-operative to access and navigate through the application taking different actions.