### PR TITLE
Route operative to correct WO views

### DIFF
--- a/__test__/operatives/[operativeId]/work-orders/[id]/close.test.js
+++ b/__test__/operatives/[operativeId]/work-orders/[id]/close.test.js
@@ -1,0 +1,26 @@
+import {
+  AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+  CONTRACTOR_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  OPERATIVE_ROLE,
+} from 'src/utils/user'
+import OperativeWorkOrderClosePage from '../../../../../src/pages/operatives/[operativeId]/work-orders/[id]/close'
+
+describe('OperativeWorkOrderClosePage.permittedRoles', () => {
+  ;[OPERATIVE_ROLE].forEach((role) => {
+    it(`permits the ${role} role to access the page`, () => {
+      expect(OperativeWorkOrderClosePage.permittedRoles).toContain(role)
+    })
+  })
+  ;[
+    AGENT_ROLE,
+    AUTHORISATION_MANAGER_ROLE,
+    CONTRACTOR_ROLE,
+    CONTRACT_MANAGER_ROLE,
+  ].forEach((role) => {
+    it(`does not permit the ${role} role to access the page`, () => {
+      expect(OperativeWorkOrderClosePage.permittedRoles).not.toContain(role)
+    })
+  })
+})

--- a/__test__/operatives/[operativeId]/work-orders/[id]/close.test.js
+++ b/__test__/operatives/[operativeId]/work-orders/[id]/close.test.js
@@ -5,7 +5,7 @@ import {
   CONTRACT_MANAGER_ROLE,
   OPERATIVE_ROLE,
 } from 'src/utils/user'
-import OperativeWorkOrderClosePage from '../../../../../src/pages/operatives/[operativeId]/work-orders/[id]/close'
+import OperativeWorkOrderClosePage from '@/pages/operatives/[operativeId]/work-orders/[id]/close'
 
 describe('OperativeWorkOrderClosePage.permittedRoles', () => {
   ;[OPERATIVE_ROLE].forEach((role) => {

--- a/__test__/operatives/[operativeId]/work-orders/[id]/index.test.js
+++ b/__test__/operatives/[operativeId]/work-orders/[id]/index.test.js
@@ -1,0 +1,26 @@
+import {
+  AGENT_ROLE,
+  AUTHORISATION_MANAGER_ROLE,
+  CONTRACTOR_ROLE,
+  CONTRACT_MANAGER_ROLE,
+  OPERATIVE_ROLE,
+} from 'src/utils/user'
+import OperativeWorkOrderPage from '../../../../../src/pages/operatives/[operativeId]/work-orders/[id]'
+
+describe('OperativeWorkOrderPage.permittedRoles', () => {
+  ;[OPERATIVE_ROLE].forEach((role) => {
+    it(`permits the ${role} role to access the page`, () => {
+      expect(OperativeWorkOrderPage.permittedRoles).toContain(role)
+    })
+  })
+  ;[
+    AGENT_ROLE,
+    AUTHORISATION_MANAGER_ROLE,
+    CONTRACTOR_ROLE,
+    CONTRACT_MANAGER_ROLE,
+  ].forEach((role) => {
+    it(`does not permit the ${role} role to access the page`, () => {
+      expect(OperativeWorkOrderPage.permittedRoles).not.toContain(role)
+    })
+  })
+})

--- a/__test__/operatives/[operativeId]/work-orders/[id]/index.test.js
+++ b/__test__/operatives/[operativeId]/work-orders/[id]/index.test.js
@@ -5,7 +5,7 @@ import {
   CONTRACT_MANAGER_ROLE,
   OPERATIVE_ROLE,
 } from 'src/utils/user'
-import OperativeWorkOrderPage from '../../../../../src/pages/operatives/[operativeId]/work-orders/[id]'
+import OperativeWorkOrderPage from '@/pages/operatives/[operativeId]/work-orders/[id]'
 
 describe('OperativeWorkOrderPage.permittedRoles', () => {
   ;[OPERATIVE_ROLE].forEach((role) => {

--- a/__test__/work-orders/[id]/close.test.js
+++ b/__test__/work-orders/[id]/close.test.js
@@ -8,12 +8,12 @@ import {
 } from 'src/utils/user'
 
 describe('WorkOrderClosePage.permittedRoles', () => {
-  ;[CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE, OPERATIVE_ROLE].forEach((role) => {
+  ;[CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE].forEach((role) => {
     it(`permits the ${role} role to access the page`, () => {
       expect(WorkOrderClosePage.permittedRoles).toContain(role)
     })
   })
-  ;[AGENT_ROLE, AUTHORISATION_MANAGER_ROLE].forEach((role) => {
+  ;[AGENT_ROLE, AUTHORISATION_MANAGER_ROLE, OPERATIVE_ROLE].forEach((role) => {
     it(`does not permit the ${role} role to access the page`, () => {
       expect(WorkOrderClosePage.permittedRoles).not.toContain(role)
     })

--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -593,6 +593,8 @@ describe('Updating a work order', () => {
         cy.get('button').contains('Confirm').click()
       })
 
+      cy.wait('@jobStatusUpdateRequest')
+
       cy.get('@jobStatusUpdateRequest')
         .its('request.body')
         .should('deep.equal', {
@@ -633,7 +635,9 @@ describe('Updating a work order', () => {
           },
         })
 
-      cy.url().should('contain', '/work-orders/10000621')
+      cy.wait(['@workOrderRequest', '@tasksRequest', '@propertyRequest'])
+
+      cy.contains('WO 10000621')
     })
 
     it('allows editing of an existing task quantity with a "Remove SOR" shortcut', () => {
@@ -782,7 +786,9 @@ describe('Updating a work order', () => {
           },
         })
 
-      cy.url().should('contain', '/work-orders/10000621')
+      cy.wait(['@workOrderRequest', '@tasksRequest', '@propertyRequest'])
+
+      cy.contains('WO 10000621')
     })
 
     it('allows adding operatives with percentage splits', () => {
@@ -882,6 +888,10 @@ describe('Updating a work order', () => {
             'Work order updated - Assigned operatives Operative A : 50%, Operative B : 50%, Operative C : -',
           typeCode: '10',
         })
+
+      cy.wait(['@workOrderRequest', '@tasksRequest', '@propertyRequest'])
+
+      cy.contains('WO 10000621')
     })
 
     it('allows updating operatives with percentage splits', () => {
@@ -1016,6 +1026,14 @@ describe('Updating a work order', () => {
             'Work order updated - Assigned operatives Operative A : 30%, Operative B : 20%, Operative C : 50%',
           typeCode: '10',
         })
+
+      cy.wait([
+        '@workOrderRequestMultipleOperatives',
+        '@tasksRequest',
+        '@propertyRequest',
+      ])
+
+      cy.contains('WO 10000621')
     })
   })
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
     '^@/components/(.*)$': '<rootDir>/src/components/$1',
     '^@/hooks/(.*)$': '<rootDir>/src/hooks/$1',
     '^@/models/(.*)$': '<rootDir>/src/models/$1',
+    '^@/pages/(.*)$': '<rootDir>/src/pages/$1',
     '^@/styles/(.*)$': '<rootDir>/src/styles/$1',
     '^@/utils/(.*)$': '<rootDir>/src/utils/$1',
   },

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,6 +5,7 @@
       "@/components/*": ["src/components/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/models/*": ["src/models/*"],
+      "@/pages/*": ["src/pages/*"],
       "@/styles/*": ["src/styles/*"],
       "@/utils/*": ["src/utils/*"]
     }

--- a/src/components/Operatives/NewTaskForm.js
+++ b/src/components/Operatives/NewTaskForm.js
@@ -13,6 +13,7 @@ import { buildWorkOrderUpdate } from '@/utils/hact/workOrderStatusUpdate/updateW
 const NewTaskForm = ({ workOrderReference }) => {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
+  const [currentUser, setCurrentUser] = useState({})
   const [sorCodes, setSorCodes] = useState([])
   const [existingTasks, setExistingTasks] = useState({})
   const { register, handleSubmit, errors } = useForm()
@@ -32,6 +33,13 @@ const NewTaskForm = ({ workOrderReference }) => {
         workOrder.contractorReference
       )
       setSorCodes(sorCodes)
+
+      const currentUser = await frontEndApiRequest({
+        method: 'get',
+        path: '/api/hub-user',
+      })
+
+      setCurrentUser(currentUser)
 
       const tasksAndSors = await frontEndApiRequest({
         method: 'get',
@@ -72,7 +80,9 @@ const NewTaskForm = ({ workOrderReference }) => {
         requestData: workOrderUpdateFormData,
       })
 
-      router.push(`/work-orders/${workOrderReference}`)
+      router.push(
+        `/operatives/${currentUser?.operativePayrollNumber}/work-orders/${workOrderReference}`
+      )
     } catch (e) {
       console.error(e)
 

--- a/src/components/Operatives/OperativeFormView.js
+++ b/src/components/Operatives/OperativeFormView.js
@@ -34,7 +34,9 @@ const OperativeFormView = ({ workOrderReference }) => {
         requestData: operativeAssignmentFormData,
       })
 
-      router.push(`/work-orders/${workOrderReference}`)
+      router.push(
+        `/operatives/${currentUser?.operativePayrollNumber}/work-orders/${workOrderReference}`
+      )
     } catch (e) {
       console.error(e)
       setError(

--- a/src/components/Operatives/OperativeFormView.js
+++ b/src/components/Operatives/OperativeFormView.js
@@ -178,7 +178,7 @@ const OperativeFormView = ({ workOrderReference }) => {
                   selectedPercentagesToShowOnEdit
                 }
                 totalSMV={workOrder.totalSMVs}
-                currentUserPayrollNumber={currentUser?.operativePayrollNumber}
+                currentUserPayrollNumber={currentUser.operativePayrollNumber}
               />
               {error && <ErrorMessage label={error} />}
             </>

--- a/src/components/Operatives/OperativeWorkOrder.js
+++ b/src/components/Operatives/OperativeWorkOrder.js
@@ -47,7 +47,9 @@ const OperativeWorkOrder = ({
         ),
       })
 
-      router.push(`/work-orders/${workOrderReference}/close`)
+      router.push(
+        `/operatives/${currentUserPayrollNumber}/work-orders/${workOrderReference}/close`
+      )
     } catch (e) {
       console.error(e)
 
@@ -158,7 +160,9 @@ const OperativeWorkOrder = ({
               <PrimarySubmitButton label="Confirm" />
             </form>
           ) : (
-            <Link href={`/work-orders/${workOrderReference}/close`}>
+            <Link
+              href={`/operatives/${currentUserPayrollNumber}/work-orders/${workOrderReference}/close`}
+            >
               <a
                 role="button"
                 draggable="false"

--- a/src/components/Operatives/OperativeWorkOrder.test.js
+++ b/src/components/Operatives/OperativeWorkOrder.test.js
@@ -101,6 +101,7 @@ describe('OperativeWorkOrder component with single operative', () => {
               standardMinuteValue: 15,
             },
           ]}
+          currentUserPayrollNumber={1}
         />
       )
       expect(asFragment()).toMatchSnapshot()
@@ -129,6 +130,7 @@ describe('OperativeWorkOrder component with single operative', () => {
               standardMinuteValue: 15,
             },
           ]}
+          currentUserPayrollNumber={1}
         />
       )
       expect(asFragment()).toMatchSnapshot()

--- a/src/components/Operatives/OperativeWorkOrderListItem.js
+++ b/src/components/Operatives/OperativeWorkOrderListItem.js
@@ -12,7 +12,7 @@ const OperativeWorkOrderListItem = ({
 }) => {
   return (
     <Link
-      href={`/operatives/${currentUser?.operativePayrollNumber}/work-orders/${workOrder.reference}`}
+      href={`/operatives/${currentUser.operativePayrollNumber}/work-orders/${workOrder.reference}`}
     >
       <li
         data-id={index}

--- a/src/components/Operatives/__snapshots__/OperativeWorkOrder.test.js.snap
+++ b/src/components/Operatives/__snapshots__/OperativeWorkOrder.test.js.snap
@@ -369,7 +369,7 @@ exports[`OperativeWorkOrder component with multiple operatives should render wor
     class="govuk-button lbh-button"
     data-module="govuk-button"
     draggable="false"
-    href="/work-orders/10000621/close"
+    href="/operatives/undefined/work-orders/10000621/close"
     role="button"
   >
     Confirm
@@ -721,7 +721,7 @@ exports[`OperativeWorkOrder component with single operative when has status In P
     class="govuk-button lbh-button"
     data-module="govuk-button"
     draggable="false"
-    href="/work-orders/10000621/close"
+    href="/operatives/1/work-orders/10000621/close"
     role="button"
   >
     Confirm

--- a/src/components/WorkOrder/OperativeWorkOrderView.js
+++ b/src/components/WorkOrder/OperativeWorkOrderView.js
@@ -98,7 +98,7 @@ const OperativeWorkOrderView = ({ workOrderReference }) => {
                   personAlerts={personAlerts}
                   locationAlerts={locationAlerts}
                   tasksAndSors={tasksAndSors}
-                  currentUserPayrollNumber={currentUser?.operativePayrollNumber}
+                  currentUserPayrollNumber={currentUser.operativePayrollNumber}
                 />
               </>
             )}

--- a/src/components/WorkOrder/TasksAndSors/EditTaskForm.js
+++ b/src/components/WorkOrder/TasksAndSors/EditTaskForm.js
@@ -13,6 +13,7 @@ import AppointmentHeader from '../AppointmentHeader'
 const EditTaskForm = ({ workOrderReference, taskId }) => {
   const [tasks, setTasks] = useState({})
   const [task, setTask] = useState({})
+  const [currentUser, setCurrentUser] = useState({})
   const [workOrder, setWorkOrder] = useState({})
 
   const router = useRouter()
@@ -41,7 +42,9 @@ const EditTaskForm = ({ workOrderReference, taskId }) => {
         requestData: workOrderUpdateFormData,
       })
 
-      router.push(`/work-orders/${workOrderReference}`)
+      router.push(
+        `/operatives/${currentUser?.operativePayrollNumber}/work-orders/${workOrderReference}`
+      )
     } catch (e) {
       console.error(e)
 
@@ -62,6 +65,13 @@ const EditTaskForm = ({ workOrderReference, taskId }) => {
         method: 'get',
         path: `/api/workOrders/${workOrderReference}`,
       })
+
+      const currentUser = await frontEndApiRequest({
+        method: 'get',
+        path: '/api/hub-user',
+      })
+
+      setCurrentUser(currentUser)
 
       setWorkOrder(workOrder)
 

--- a/src/pages/operatives/[operativeId]/work-orders/[id]/close.js
+++ b/src/pages/operatives/[operativeId]/work-orders/[id]/close.js
@@ -1,9 +1,9 @@
 import Meta from '@/components/Meta'
-import { getQueryProps } from '@/utils/helpers/serverSideProps'
+import CloseWorkOrder from '@/components/WorkOrders/CloseWorkOrder'
 import { OPERATIVE_ROLE } from '@/utils/user'
-import OperativeWorkOrderView from '../../../../components/WorkOrder/OperativeWorkOrderView'
+import { getQueryProps } from '@/utils/helpers/serverSideProps'
 
-const OperativeWorkOrderPage = ({ query }) => {
+const OperativeWorkOrderClosePage = ({ query }) => {
   // This page was created so users in operative and other groups
   // can access a work order via different links to take different actions.
 
@@ -11,14 +11,15 @@ const OperativeWorkOrderPage = ({ query }) => {
   // Instead the API is relied upon to check operative work order access.
   return (
     <>
-      <Meta title={`Work Order ${query.id}`} />
-      <OperativeWorkOrderView workOrderReference={query.id} />
+      <Meta title={`Close Work Order ${query.id}`} />
+
+      <CloseWorkOrder reference={query.id} />
     </>
   )
 }
 
 export const getServerSideProps = getQueryProps
 
-OperativeWorkOrderPage.permittedRoles = [OPERATIVE_ROLE]
+OperativeWorkOrderClosePage.permittedRoles = [OPERATIVE_ROLE]
 
-export default OperativeWorkOrderPage
+export default OperativeWorkOrderClosePage

--- a/src/pages/operatives/[operativeId]/work-orders/[id]/index.js
+++ b/src/pages/operatives/[operativeId]/work-orders/[id]/index.js
@@ -1,0 +1,24 @@
+import Meta from '@/components/Meta'
+import { getQueryProps } from '@/utils/helpers/serverSideProps'
+import { OPERATIVE_ROLE } from '@/utils/user'
+import OperativeWorkOrderView from '../../../../../components/WorkOrder/OperativeWorkOrderView'
+
+const OperativeWorkOrderPage = ({ query }) => {
+  // This page was created so users in operative and other groups
+  // can access a work order via different links to take different actions.
+
+  // We intentionally do nothing with the operativeId supplied in the query
+  // Instead the API is relied upon to check operative work order access.
+  return (
+    <>
+      <Meta title={`Work Order ${query.id}`} />
+      <OperativeWorkOrderView workOrderReference={query.id} />
+    </>
+  )
+}
+
+export const getServerSideProps = getQueryProps
+
+OperativeWorkOrderPage.permittedRoles = [OPERATIVE_ROLE]
+
+export default OperativeWorkOrderPage

--- a/src/pages/work-orders/[id]/close.js
+++ b/src/pages/work-orders/[id]/close.js
@@ -1,37 +1,20 @@
-import { useContext } from 'react'
 import Meta from '@/components/Meta'
-import UserContext from '@/components/UserContext'
 import CloseWorkOrderByProxy from '@/components/WorkOrders/CloseWorkOrderByProxy'
-import CloseWorkOrder from '@/components/WorkOrders/CloseWorkOrder'
-import {
-  CONTRACTOR_ROLE,
-  CONTRACT_MANAGER_ROLE,
-  OPERATIVE_ROLE,
-} from '@/utils/user'
-import { canAttendOwnWorkOrder } from '@/utils/userPermissions'
+import { CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE } from '@/utils/user'
 import { getQueryProps } from '@/utils/helpers/serverSideProps'
 
 const WorkOrderClosePage = ({ query }) => {
-  const { user } = useContext(UserContext)
-
   return (
     <>
       <Meta title={`Close Work Order ${query.id}`} />
-      {canAttendOwnWorkOrder(user) ? (
-        <CloseWorkOrder reference={query.id} />
-      ) : (
-        <CloseWorkOrderByProxy reference={query.id} />
-      )}
+
+      <CloseWorkOrderByProxy reference={query.id} />
     </>
   )
 }
 
 export const getServerSideProps = getQueryProps
 
-WorkOrderClosePage.permittedRoles = [
-  CONTRACTOR_ROLE,
-  CONTRACT_MANAGER_ROLE,
-  OPERATIVE_ROLE,
-]
+WorkOrderClosePage.permittedRoles = [CONTRACTOR_ROLE, CONTRACT_MANAGER_ROLE]
 
 export default WorkOrderClosePage


### PR DESCRIPTION
### Description of change

Don't just show operatives their work order view when they click on the work order (implemented in https://github.com/LBHackney-IT/repairs-hub-frontend/pull/456), but also following update and close actions in mobile working.

### Story Link

https://www.pivotaltracker.com/story/show/180434973/comments/228292804
