### PR TITLE
Low priority target times include additional non-working days for 2021

### DIFF
--- a/src/utils/helpers/completionDateTimes.js
+++ b/src/utils/helpers/completionDateTimes.js
@@ -9,6 +9,8 @@ import {
   isWithinInterval,
 } from 'date-fns'
 import { bankHolidays } from './bankHolidays'
+import { lowPriorityHolidays } from './lowPriorityHolidays'
+import { LOW_PRIORITY_CODES } from './priorities'
 
 const WORKDAY_START_HOUR = 8
 const WORKDAY_END_HOUR = 18
@@ -39,11 +41,25 @@ export const isCurrentTimeOutOfHours = () => {
   return false
 }
 
-export const isNonWorkingDay = (date) => isWeekend(date) || isBankHoliday(date)
+export const isNonWorkingDay = (date, lowPriority = false) =>
+  isWeekend(date) ||
+  isBankHoliday(date) ||
+  (lowPriority && isLowPriorityHoliday(date))
+
+// Sometimes Hackney have holidays which only apply to low priority orders.
+const isLowPriorityHoliday = (date) => {
+  const formattedDate = format(date, 'yyyy-MM-dd')
+
+  return lowPriorityHolidays.some((holiday) => holiday === formattedDate)
+}
 
 // Returns supplied start date plus however many calendar days we loop over to satisfy
 // the required number of working days.
-const dateAfterCountWorkingDays = (startDate, targetWorkingDaysCount) => {
+const dateAfterCountWorkingDays = ({
+  startDate,
+  targetWorkingDaysCount,
+  lowPriority,
+}) => {
   let workingDaysCount = 0
   let calendarDaysCount = 0
 
@@ -52,7 +68,7 @@ const dateAfterCountWorkingDays = (startDate, targetWorkingDaysCount) => {
 
     const date = addDays(startDate, calendarDaysCount)
 
-    if (!isNonWorkingDay(date)) {
+    if (!isNonWorkingDay(date, lowPriority)) {
       workingDaysCount += 1
     }
   }
@@ -80,7 +96,11 @@ export const calculateCompletionDateTime = (priorityCode) => {
       now = subDays(now, 1)
     }
 
-    return dateAfterCountWorkingDays(now, completionTargetWorkingDays)
+    return dateAfterCountWorkingDays({
+      startDate: now,
+      targetWorkingDaysCount: completionTargetWorkingDays,
+      lowPriority: LOW_PRIORITY_CODES.includes(priorityCode),
+    })
   }
 }
 

--- a/src/utils/helpers/lowPriorityHolidays.js
+++ b/src/utils/helpers/lowPriorityHolidays.js
@@ -1,0 +1,1 @@
+export const lowPriorityHolidays = ['2021-12-29', '2021-12-30', '2021-12-31']

--- a/src/utils/helpers/priorities.js
+++ b/src/utils/helpers/priorities.js
@@ -3,7 +3,6 @@ export const EMERGENCY_PRIORITY_CODE = 2
 export const URGENT_PRIORITY_CODE = 3
 export const NORMAL_PRIORITY_CODE = 4
 
-export const priorityCodesRequiringAppointments = [
-  URGENT_PRIORITY_CODE,
-  NORMAL_PRIORITY_CODE,
-]
+export const LOW_PRIORITY_CODES = [URGENT_PRIORITY_CODE, NORMAL_PRIORITY_CODE]
+
+export const priorityCodesRequiringAppointments = LOW_PRIORITY_CODES


### PR DESCRIPTION
### Description of change

There are 3 upcoming days where Hackney does not do low priority orders.

This adds those days by hard coding them and excludes such days in the target time / number of working days calculation for low priority orders.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/180616594