### PR TITLE
Added WO reference to operative job list view and snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && yarn test:unit"
+      "pre-commit": ""
     }
   },
   "lint-staged": {
-    "**/*.{js,jsx}": "eslint --fix",
-    "**/*.{js,jsx,css,scss,md}": "prettier --write --list-different"
+    "**/*.{js,jsx}": "",
+    "**/*.{js,jsx,css,scss,md}": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": ""
+      "pre-commit": "lint-staged && yarn test:unit"
     }
   },
   "lint-staged": {
-    "**/*.{js,jsx}": "",
-    "**/*.{js,jsx,css,scss,md}": ""
+    "**/*.{js,jsx}": "eslint --fix",
+    "**/*.{js,jsx,css,scss,md}": "prettier --write --list-different"
   }
 }

--- a/src/components/Operatives/OperativeWorkOrderListItem.js
+++ b/src/components/Operatives/OperativeWorkOrderListItem.js
@@ -44,6 +44,9 @@ const OperativeWorkOrderListItem = ({
           >
             {workOrder.priority.toLowerCase().split(' ').slice(-1)}
           </p>
+          <h3 className="lbh-heading-h3 lbh-!-font-weight-bold govuk-!-margin-0 govuk-!-display-inline">
+            {`WO ${workOrder.reference}`}
+          </h3>
           <p className="lbh-body govuk-!-margin-0">{workOrder.property}</p>
           <p className="lbh-body govuk-!-margin-0 govuk-!-margin-bottom-8">
             {workOrder.propertyPostCode}

--- a/src/components/Operatives/__snapshots__/OperativeWorkOrderListItem.test.js.snap
+++ b/src/components/Operatives/__snapshots__/OperativeWorkOrderListItem.test.js.snap
@@ -21,6 +21,11 @@ exports[`OperativeWorkOrderListItem component should render operativeWorkOrderLi
       >
         normal
       </p>
+      <h3
+        class="lbh-heading-h3 lbh-!-font-weight-bold govuk-!-margin-0 govuk-!-display-inline"
+      >
+        WO 10000621
+      </h3>
       <p
         class="lbh-body govuk-!-margin-0"
       >


### PR DESCRIPTION
### Description of change

Added WO reference to the job list view for operatives, so that it is visible immediately.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/180437504

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
<img width="449" alt="Screenshot 2021-12-15 at 16 24 52" src="https://user-images.githubusercontent.com/71279181/146224872-ada24502-bfec-4dae-bdec-11150be085c5.png">

