### PR TITLE
Fix overtime query param detection

### DIFF
--- a/cypress/integration/work-order/attend/close.spec.js
+++ b/cypress/integration/work-order/attend/close.spec.js
@@ -29,6 +29,7 @@ describe('Closing my own work order', () => {
 
       cy.loginWithOperativeRole()
     })
+
     it('the operative cannot set the work as overtime', () => {
       cy.visit('/operatives/1/work-orders/10000621')
 
@@ -132,6 +133,115 @@ describe('Closing my own work order', () => {
                 comments: 'Work order closed - I attended - Overtime',
                 eventTime: new Date(now.setHours(16, 0, 1)).toISOString(),
                 isOvertime: true,
+              },
+            ],
+          })
+
+        cy.get('.modal-container').within(() => {
+          cy.contains('Work order 10000621 successfully completed')
+
+          cy.get('[data-testid="modal-close"]').click()
+        })
+
+        cy.get('.modal-container').should('not.exist')
+
+        cy.get('.lbh-heading-h2').contains('Friday 11 June')
+      })
+    }
+  )
+
+  context(
+    'when the job is completed without variation and operative does not choose Overtime',
+    () => {
+      beforeEach(() => {
+        cy.clock(new Date(now).setHours(16, 0, 1))
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/operatives/hu0001/workorders',
+          },
+          {
+            fixture: 'operatives/workOrders.json',
+          }
+        ).as('workOrderIndexRequest')
+
+        cy.intercept('/api/workOrders/10000621', {
+          fixture: 'workOrders/workOrder.json',
+        }).as('workOrderRequest')
+
+        cy.intercept(
+          { method: 'GET', path: '/api/properties/00012345' },
+          { fixture: 'properties/property.json' }
+        ).as('propertyRequest')
+
+        cy.intercept(
+          { method: 'GET', path: '/api/workOrders/10000621/tasks' },
+          { fixture: 'workOrders/tasksAndSorsUnvaried.json' }
+        ).as('tasksRequest')
+
+        cy.intercept(
+          { method: 'POST', path: '/api/jobStatusUpdate' },
+          { body: '' }
+        ).as('jobStatusUpdateRequest')
+
+        cy.intercept(
+          { method: 'POST', path: '/api/workOrderComplete' },
+          { body: '' }
+        ).as('workOrderCompleteRequest')
+
+        cy.loginWithOperativeRole()
+      })
+
+      it('confirms success and returns me to the index', () => {
+        cy.visit('/')
+
+        cy.wait('@workOrderIndexRequest')
+
+        cy.get('.arrow.right').eq(1).click()
+
+        cy.wait(['@workOrderRequest', '@propertyRequest', '@tasksRequest'])
+
+        cy.get('[data-testid=isOvertime]').should('not.be.checked')
+
+        cy.contains('button', 'Confirm').click()
+
+        cy.wait('@workOrderRequest')
+
+        cy.get('.govuk-button').contains('Close work order').click()
+
+        cy.get('#notes').type('I attended')
+
+        cy.url().should(
+          'match',
+          /work-orders\/10000621\/close\?isOvertime=false$/
+        )
+
+        cy.get('.govuk-form-group--error').contains(
+          'Please select a reason for closing the work order'
+        )
+
+        cy.get('.lbh-radios input[type="radio"]').check('Work Order Completed') // Checking by value, not text
+
+        cy.get('.govuk-button').contains('Close work order').click()
+
+        cy.wait('@workOrderCompleteRequest')
+
+        cy.get('@workOrderCompleteRequest')
+          .its('request.body')
+          .should('deep.equal', {
+            workOrderReference: {
+              id: '10000621',
+              description: '',
+              allocatedBy: '',
+            },
+            jobStatusUpdates: [
+              {
+                typeCode: '0',
+                otherType: 'complete',
+                comments: 'Work order closed - I attended',
+                eventTime: new Date(now.setHours(16, 0, 1)).toISOString(),
+                isOvertime: false,
               },
             ],
           })

--- a/src/components/WorkOrders/CloseWorkOrder.js
+++ b/src/components/WorkOrders/CloseWorkOrder.js
@@ -11,8 +11,9 @@ import FlashMessageContext from '../FlashMessageContext'
 
 const CloseWorkOrder = ({ reference }) => {
   const router = useRouter()
+  const query = router.query
 
-  const isOvertime = !!router.query?.isOvertime || false
+  const isOvertime = query?.isOvertime === 'true' || false
 
   const { setModalFlashMessage } = useContext(FlashMessageContext)
 


### PR DESCRIPTION
This was causing all mobile orders to be submitted as overtime because
by examining the truthiness of isOvertime query param strings the
flag was always being set to true.
