### PR TITLE
Avoid managing two priority form fields

### DIFF
--- a/cypress/integration/work-order/create/appointment-form.spec.js
+++ b/cypress/integration/work-order/create/appointment-form.spec.js
@@ -115,7 +115,7 @@ describe('Schedule appointment form', () => {
         )
 
         cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-        cy.get('#priorityDescription').select('5 [N] NORMAL')
+        cy.get('#priorityCode').select('5 [N] NORMAL')
         cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
         cy.get('#callerName').type('Bob Leek', { force: true })
         cy.get('#contactNumber')
@@ -369,7 +369,7 @@ describe('Schedule appointment form', () => {
         )
 
         cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-        cy.get('#priorityDescription').select('5 [N] NORMAL')
+        cy.get('#priorityCode').select('5 [N] NORMAL')
         cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
         cy.get('#callerName').type('Bob Leek', { force: true })
         cy.get('#contactNumber')

--- a/cypress/integration/work-order/create/create-with-appointment.spec.js
+++ b/cypress/integration/work-order/create/create-with-appointment.spec.js
@@ -119,7 +119,7 @@ describe('Schedule appointment form', () => {
         )
 
         cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-        cy.get('#priorityDescription').select('2 [E] EMERGENCY')
+        cy.get('#priorityCode').select('2 [E] EMERGENCY')
         cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
         cy.get('#callerName').type('Bob Leek', { force: true })
         cy.get('#contactNumber')
@@ -260,7 +260,7 @@ describe('Schedule appointment form', () => {
         )
 
         cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-        cy.get('#priorityDescription').select('5 [N] NORMAL')
+        cy.get('#priorityCode').select('5 [N] NORMAL')
         cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
         cy.get('#callerName').type('Bob Leek', { force: true })
         cy.get('#contactNumber')
@@ -466,7 +466,7 @@ describe('Schedule appointment form', () => {
           )
 
           cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-          cy.get('#priorityDescription').select('5 [N] NORMAL')
+          cy.get('#priorityCode').select('5 [N] NORMAL')
           cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
           cy.get('#callerName').type('NA', { force: true })
           cy.get('#contactNumber')
@@ -530,7 +530,7 @@ describe('Schedule appointment form', () => {
           )
 
           cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-          cy.get('#priorityDescription').select('4 [U] URGENT')
+          cy.get('#priorityCode').select('4 [U] URGENT')
           cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
           cy.get('#callerName').type('NA', { force: true })
           cy.get('#contactNumber')
@@ -576,7 +576,7 @@ describe('Schedule appointment form', () => {
           )
 
           cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-          cy.get('#priorityDescription').select('1 [I] IMMEDIATE')
+          cy.get('#priorityCode').select('1 [I] IMMEDIATE')
           cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
           cy.get('#callerName').type('NA', { force: true })
           cy.get('#contactNumber')
@@ -616,7 +616,7 @@ describe('Schedule appointment form', () => {
           )
 
           cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-          cy.get('#priorityDescription').select('2 [E] EMERGENCY')
+          cy.get('#priorityCode').select('2 [E] EMERGENCY')
           cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
           cy.get('#callerName').type('NA', { force: true })
           cy.get('#contactNumber')
@@ -663,7 +663,7 @@ describe('Schedule appointment form', () => {
           )
 
           cy.get('input[id="rateScheduleItems[0][quantity]"]').clear().type('2')
-          cy.get('#priorityDescription').select('5 [N] NORMAL')
+          cy.get('#priorityCode').select('5 [N] NORMAL')
           cy.get('#descriptionOfWork').get('.govuk-textarea').type('Testing')
           cy.get('#callerName').type('NA', { force: true })
           cy.get('#contactNumber')

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -89,11 +89,9 @@ describe('Raise repair form', () => {
       cy.contains('Please enter a quantity')
     })
 
-    cy.get('#priorityDescription-form-group .govuk-error-message').within(
-      () => {
-        cy.contains('Please select a priority')
-      }
-    )
+    cy.get('#priorityCode-form-group .govuk-error-message').within(() => {
+      cy.contains('Please select a priority')
+    })
 
     cy.get('#descriptionOfWork-form-group .govuk-error-message').within(() => {
       cy.contains('Please enter a repair description')
@@ -170,11 +168,11 @@ describe('Raise repair form', () => {
         'not.be.disabled'
       )
       // Priority disabled until SOR is selected
-      cy.get('#priorityDescription').should('be.disabled')
+      cy.get('#priorityCode').should('be.disabled')
       cy.get('input[id="rateScheduleItems[0][code]"]').type(
         'INP5R001 - Pre insp of wrks by Constructr'
       )
-      cy.get('#priorityDescription').should('not.be.disabled')
+      cy.get('#priorityCode').should('not.be.disabled')
 
       // Selecting no trade clears contractor and SOR code select options
       cy.get('#trade').clear()
@@ -203,16 +201,20 @@ describe('Raise repair form', () => {
         'INP5R001 - Pre insp of wrks by Constructr'
       )
       // Does not autopopulate priority description
-      cy.get('#priorityDescription').should('have.value', '')
+      cy.get('#priorityCode').should('have.value', '')
 
       // Select SOR code with priority attached
       cy.get('input[id="rateScheduleItems[0][code]"]')
         .clear()
         .type('DES5R003 - Immediate call outs')
+
       // Autopopulates priority description
-      cy.get('#priorityDescription').should('have.value', '1 [I] IMMEDIATE')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '1 [I] IMMEDIATE')
+
       // Removes Task Priority validation errors
-      cy.get('#priorityDescription-form-group .govuk-error-message').should(
+      cy.get('#priorityCode-form-group .govuk-error-message').should(
         'not.exist'
       )
 
@@ -221,7 +223,9 @@ describe('Raise repair form', () => {
         .clear()
         .type('DES5R004 - Emergency call out')
       // Autopopulates priority description
-      cy.get('#priorityDescription').should('have.value', '2 [E] EMERGENCY')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '2 [E] EMERGENCY')
 
       // Assigns description and contractor ref to hidden field
       cy.get('input[id="rateScheduleItems[0][description]"]').should(
@@ -315,32 +319,47 @@ describe('Raise repair form', () => {
         .clear()
         .type('DES5R013 - Inspect additional sec entrance')
       // Priority description should remain same because inspection is a lower priority than normal
-      cy.get('#priorityDescription').should('have.value', '5 [N] NORMAL')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '5 [N] NORMAL')
+
       // Add another SOR code with higher priority
       cy.contains('+ Add another SOR code').click()
       cy.get('input[id="rateScheduleItems[2][code]"]').type(
         'DES5R003 - Immediate call outs'
       )
       // Autopopulates priority description with the highest priority
-      cy.get('#priorityDescription').should('have.value', '1 [I] IMMEDIATE')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '1 [I] IMMEDIATE')
+
       // Add another SOR code with an emergency priority
       cy.contains('+ Add another SOR code').click()
       cy.get('input[id="rateScheduleItems[3][code]"]')
         .clear()
         .type('DES5R004 - Emergency call out')
-      cy.get('#priorityDescription').should('have.value', '1 [I] IMMEDIATE')
+
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '1 [I] IMMEDIATE')
       // Remove SOR code at index 2
       cy.get('button[id="remove-rate-schedule-item-2"]').click()
       // Autopopulates priority description with the remaining highest priority
-      cy.get('#priorityDescription').should('have.value', '2 [E] EMERGENCY')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '2 [E] EMERGENCY')
       cy.get('button[id="remove-rate-schedule-item-3"]').click()
       // Autopopulates priority description with the remaining highest priority
-      cy.get('#priorityDescription').should('have.value', '5 [N] NORMAL')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '5 [N] NORMAL')
       // Select SOR code with emergency priority at index 1
       cy.get('input[id="rateScheduleItems[1][code]"]')
         .clear()
         .type('DES5R004 - Emergency call out')
-      cy.get('#priorityDescription').should('have.value', '2 [E] EMERGENCY')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '2 [E] EMERGENCY')
 
       // Try to submit form without quantity for this SOR code at index 1
       cy.get('[type="submit"]')
@@ -405,7 +424,9 @@ describe('Raise repair form', () => {
         'have.value',
         '2'
       )
-      cy.get('#priorityDescription').should('have.value', '2 [E] EMERGENCY')
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '2 [E] EMERGENCY')
       cy.get('button[id="remove-rate-schedule-item-2"]').contains('-')
 
       // No warning if within raise limit

--- a/src/components/Property/RaiseWorkOrder/RateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/RateScheduleItemView.js
@@ -70,7 +70,7 @@ const RateScheduleItemView = ({
   }
 
   const onRateScheduleItemSelect = (index, event) => {
-    document.getElementById('priorityDescription').disabled = false
+    document.getElementById('priorityCode').disabled = false
 
     const value = event.target.value.split(' - ')[0]
     const sorCodeObject = getSorCodeObject(value)

--- a/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
+++ b/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
@@ -236,11 +236,11 @@ exports[`RaiseWorkOrderForm component should render properly 1`] = `
         </div>
         <div
           class="govuk-form-group lbh-form-group"
-          id="priorityDescription-form-group"
+          id="priorityCode-form-group"
         >
           <label
             class="govuk-label lbh-label"
-            for="priorityDescription"
+            for="priorityCode"
           >
             Task priority 
             <span
@@ -251,43 +251,36 @@ exports[`RaiseWorkOrderForm component should render properly 1`] = `
           </label>
           <select
             class="govuk-select lbh-select govuk-!-width-full"
-            data-testid="priorityDescription"
+            data-testid="priorityCode"
             disabled=""
-            id="priorityDescription"
-            name="priorityDescription"
+            id="priorityCode"
+            name="priorityCode"
           >
             <option
               value=""
             />
             <option
-              value="1 [I] IMMEDIATE"
+              value="1"
             >
               1 [I] IMMEDIATE
             </option>
             <option
-              value="2 [E] EMERGENCY"
+              value="2"
             >
               2 [E] EMERGENCY
             </option>
             <option
-              value="4 [U] URGENT"
+              value="3"
             >
               4 [U] URGENT
             </option>
             <option
-              value="5 [N] NORMAL"
+              value="4"
             >
               5 [N] NORMAL
             </option>
           </select>
         </div>
-        <input
-          id="priorityCode"
-          label="priorityCode"
-          name="priorityCode"
-          type="hidden"
-          value=""
-        />
         <div
           class="govuk-form-group lbh-form-group"
           id="descriptionOfWork-form-group"


### PR DESCRIPTION
### Description of change

Previously the priority select part of the form had both its value and text value set to the priority description we get from the API for each priority.

This required some logic and a hidden field to track both the selected description and its code. By levereging the ability of the select to hold a text value different from its internal value (description and code respectively), we can simplify some of this form and its state.

### Story Link

This is groundwork which should hopefully make https://www.pivotaltracker.com/n/projects/2500129/stories/180645774 more straightforward.