### PR TITLE
Serverless version pin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
             export NEXT_PUBLIC_OPERATIVE_MANAGEMENT_MOBILE_ENABLED=$NEXT_PUBLIC_OPERATIVE_MANAGEMENT_MOBILE_ENABLED_DEVELOPMENT
             export NEXT_PUBLIC_CAN_CHOOSE_OVERTIME=$NEXT_PUBLIC_CAN_CHOOSE_OVERTIME_STAGING
             export NEXT_PUBLIC_PROPERTIES_PAGE_SIZE=$NEXT_PUBLIC_PROPERTIES_PAGE_SIZE
-            yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage development
+            yarn build && yarn --production=true && sudo npm i -g serverless@"<3" && sls deploy --stage development
 
   build-deploy-staging:
     executor: aws-cli/default
@@ -110,7 +110,7 @@ jobs:
             export NEXT_PUBLIC_CAN_CHOOSE_OVERTIME=$NEXT_PUBLIC_CAN_CHOOSE_OVERTIME_STAGING
             export NEXT_PUBLIC_PROPERTIES_PAGE_SIZE=$NEXT_PUBLIC_PROPERTIES_PAGE_SIZE
             export NEXT_PUBLIC_USE_DEPRECATED_PROPERTY_SEARCH=$NEXT_PUBLIC_USE_DEPRECATED_PROPERTY_SEARCH_PRODUCTION
-            yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
+            yarn build && yarn --production=true && sudo npm i -g serverless@"<3" && sls deploy --stage staging
 
   build-deploy-production:
     executor: aws-cli/default
@@ -130,7 +130,7 @@ jobs:
             export NEXT_PUBLIC_CAN_CHOOSE_OVERTIME=$NEXT_PUBLIC_CAN_CHOOSE_OVERTIME_PRODUCTION
             export NEXT_PUBLIC_PROPERTIES_PAGE_SIZE=$NEXT_PUBLIC_PROPERTIES_PAGE_SIZE
             export NEXT_PUBLIC_USE_DEPRECATED_PROPERTY_SEARCH=$NEXT_PUBLIC_USE_DEPRECATED_PROPERTY_SEARCH_PRODUCTION
-            yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production
+            yarn build && yarn --production=true && sudo npm i -g serverless@"<3" && sls deploy --stage production
 
   assume-role-development:
     executor: docker-python

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ provider:
   timeout: 10
   region: eu-west-2
   stage: ${opt:stage}
+  lambdaHashingVersion: 20201221
   apiGateway:
     shouldStartNameWithService: true
 


### PR DESCRIPTION
Prevents use of latest version on every deploy, which can cause unexpected failures due to deprecated features.