### PR TITLE
More flexible frontend support for priorities

### DIFF
--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -6,7 +6,7 @@ import Spinner from '../../Spinner'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import { getOrCreateSchedulerSessionId } from '@/utils/frontEndApiClient/users/schedulerSession'
 import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
-import { priorityCodesRequiringAppointments } from '@/utils/helpers/priorities'
+import { PRIORITY_CODES_REQUIRING_APPOINTMENTS } from '@/utils/helpers/priorities'
 import { STATUS_AUTHORISATION_PENDING_APPROVAL } from '@/utils/statusCodes'
 import Meta from '../../Meta'
 import router from 'next/router'
@@ -63,7 +63,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
         // Emergency and immediate DLO repairs are sent directly to the Planners
         // We display no link to open DRS
         if (
-          !priorityCodesRequiringAppointments.includes(
+          !PRIORITY_CODES_REQUIRING_APPOINTMENTS.includes(
             formData.priority.priorityCode
           )
         ) {
@@ -77,7 +77,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
           )
         }
       } else if (
-        priorityCodesRequiringAppointments.includes(
+        PRIORITY_CODES_REQUIRING_APPOINTMENTS.includes(
           formData.priority.priorityCode
         )
       ) {

--- a/src/utils/hact/workOrderSchedule/raiseWorkOrderForm.js
+++ b/src/utils/hact/workOrderSchedule/raiseWorkOrderForm.js
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { calculateCompletionDateTime } from '../../helpers/completionDateTimes'
-import { LOW_PRIORITY_CODES } from '@/utils/helpers/priorities'
+import { HIGH_PRIORITY_CODES } from '@/utils/helpers/priorities'
 
 export const buildScheduleWorkOrderFormData = (workOrderData) => {
   return {
@@ -16,7 +16,7 @@ export const buildScheduleWorkOrderFormData = (workOrderData) => {
       requiredCompletionDateTime: calculateCompletionDateTime({
         workingDays: workOrderData.daysToComplete,
         workingHours: workOrderData.hoursToComplete,
-        lowPriority: LOW_PRIORITY_CODES.includes(
+        lowPriority: !HIGH_PRIORITY_CODES.includes(
           Number.parseInt(workOrderData.priorityCode)
         ),
       }),

--- a/src/utils/helpers/priorities.js
+++ b/src/utils/helpers/priorities.js
@@ -3,6 +3,12 @@ export const EMERGENCY_PRIORITY_CODE = 2
 export const URGENT_PRIORITY_CODE = 3
 export const NORMAL_PRIORITY_CODE = 4
 
-export const LOW_PRIORITY_CODES = [URGENT_PRIORITY_CODE, NORMAL_PRIORITY_CODE]
+export const HIGH_PRIORITY_CODES = [
+  IMMEDIATE_PRIORITY_CODE,
+  EMERGENCY_PRIORITY_CODE,
+]
 
-export const priorityCodesRequiringAppointments = LOW_PRIORITY_CODES
+export const priorityCodesRequiringAppointments = [
+  URGENT_PRIORITY_CODE,
+  NORMAL_PRIORITY_CODE,
+]

--- a/src/utils/helpers/priorities.js
+++ b/src/utils/helpers/priorities.js
@@ -8,7 +8,9 @@ export const HIGH_PRIORITY_CODES = [
   EMERGENCY_PRIORITY_CODE,
 ]
 
-export const priorityCodesRequiringAppointments = [
+// These are codes which should result in using the RH
+// booking calendar if the order is for an external contractor
+export const PRIORITY_CODES_REQUIRING_APPOINTMENTS = [
   URGENT_PRIORITY_CODE,
   NORMAL_PRIORITY_CODE,
 ]


### PR DESCRIPTION
Second half of the effort to reduce frontend knowledge of priorities separate to that of the backend.

We still need to know which orders are low priority because it's sometimes used in target time calculation and that is not information currently available in the backend response.

However we can probably reduce the maintenance burden by instead asking if the order is not high priority for the above. Newly added priorities to the backend all seem to be low priority - and those would otherwise all need to be added to our low priority list. This takes the inverse approach and assumes future additions of high priority orders (a day or less) is very unlikely, and that everything else should be treated as low priority when calculating target times.

Follows from https://github.com/LBHackney-IT/repairs-hub-frontend/pull/542