### PR TITLE
Remove overtime check in variation spec

### DIFF
--- a/cypress/integration/work-order/attend/variation.spec.js
+++ b/cypress/integration/work-order/attend/variation.spec.js
@@ -38,10 +38,6 @@ context('when a variation is made', () => {
 
       cy.get('textarea').type('More work was needed')
 
-      cy.get('[data-testid=isOvertime]').should('not.be.checked')
-
-      cy.get('[data-testid=isOvertime]').check()
-
       cy.contains('button', 'Confirm').click()
     })
 


### PR DESCRIPTION
This is a remnant of when overtime was sent as part of a jobstatusupdate and was failing because the new spec file had no fixed time.

This is tested quite thoroughly in the close specs so we can just delete it.
