### PR TITLE
Remove uppercase class on the mobile status

### DIFF
--- a/src/components/WorkOrder/MobileWorkingWorkOrderListItem.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderListItem.js
@@ -33,7 +33,7 @@ const MobileWorkingWorkOrderListItem = ({
             {statusText && (
               <Status
                 text={statusText}
-                className="work-order-status govuk-!-margin-top-0 govuk-!-margin-left-2 uppercase"
+                className="work-order-status govuk-!-margin-top-0 govuk-!-margin-left-2"
               />
             )}
           </div>

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,7 +1,3 @@
 .capitalize {
   text-transform: capitalize;
 }
-
-.uppercase {
-  text-transform: uppercase;
-}


### PR DESCRIPTION
Remove uppercase class on the mobile status to be consistant with design requirements 