### PR TITLE
Design changes follow up pr

### DIFF
--- a/src/components/WorkOrder/Status.js
+++ b/src/components/WorkOrder/Status.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import { convertToSentenceCases } from '@/utils/helpers/textConverter'
 
 const Status = ({ text, className }) => (
   <>
@@ -11,7 +12,7 @@ const Status = ({ text, className }) => (
         className
       )}
     >
-      {text.charAt(0) + text.slice(1).toLocaleLowerCase()}
+      {convertToSentenceCases(text)}
     </span>
   </>
 )

--- a/src/components/WorkOrders/Filter/WorkOrdersFilter.js
+++ b/src/components/WorkOrders/Filter/WorkOrdersFilter.js
@@ -7,6 +7,7 @@ import { STATUS_AUTHORISATION_PENDING_APPROVAL } from '@/utils/statusCodes'
 import Collapsible from '../../Layout/Collapsible'
 import FilterTag from '../../Tag/FilterTag'
 import { canSeeAllFilters } from '@/utils/userPermissions'
+import { convertToSentenceCases } from '@/utils/helpers/textConverter'
 
 const WorkOrdersFilter = ({
   loading,
@@ -219,7 +220,7 @@ const WorkOrdersFilter = ({
                   labelClassName="lbh-body-xs"
                   key={index}
                   name={`StatusCode.${status.key}`}
-                  label={status.description}
+                  label={convertToSentenceCases(status.description)}
                   register={register}
                   checked={appliedFilters?.StatusCode?.includes(status.key)}
                   hidden={index >= CHECKBOX_NUMBER}

--- a/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
+++ b/src/components/WorkOrders/Filter/__snapshots__/WorkOrdersFilter.test.js.snap
@@ -275,7 +275,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.80"
                 >
-                  In Progress
+                  In progress
                 </label>
               </div>
               <div
@@ -309,7 +309,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.30"
                 >
-                  Work Cancelled
+                  Work cancelled
                 </label>
               </div>
               <div
@@ -326,7 +326,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1010"
                 >
-                  Authorisation Pending Approval
+                  Authorisation pending approval
                 </label>
               </div>
               <div
@@ -343,7 +343,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.90"
                 >
-                  Variation Pending Approval
+                  Variation pending approval
                 </label>
               </div>
               <div
@@ -360,7 +360,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1080"
                 >
-                  Variation Approved
+                  Variation approved
                 </label>
               </div>
               <div
@@ -377,7 +377,7 @@ exports[`WorkOrdersFilter component when logged in as a combined agent/contracto
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1090"
                 >
-                  Variation Rejected
+                  Variation rejected
                 </label>
               </div>
             </div>
@@ -743,7 +743,7 @@ exports[`WorkOrdersFilter component when logged in as a combined authorisation m
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.80"
                 >
-                  In Progress
+                  In progress
                 </label>
               </div>
               <div
@@ -777,7 +777,7 @@ exports[`WorkOrdersFilter component when logged in as a combined authorisation m
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.30"
                 >
-                  Work Cancelled
+                  Work cancelled
                 </label>
               </div>
               <div
@@ -794,7 +794,7 @@ exports[`WorkOrdersFilter component when logged in as a combined authorisation m
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1010"
                 >
-                  Authorisation Pending Approval
+                  Authorisation pending approval
                 </label>
               </div>
               <div
@@ -811,7 +811,7 @@ exports[`WorkOrdersFilter component when logged in as a combined authorisation m
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.90"
                 >
-                  Variation Pending Approval
+                  Variation pending approval
                 </label>
               </div>
               <div
@@ -828,7 +828,7 @@ exports[`WorkOrdersFilter component when logged in as a combined authorisation m
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1080"
                 >
-                  Variation Approved
+                  Variation approved
                 </label>
               </div>
               <div
@@ -845,7 +845,7 @@ exports[`WorkOrdersFilter component when logged in as a combined authorisation m
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1090"
                 >
-                  Variation Rejected
+                  Variation rejected
                 </label>
               </div>
             </div>
@@ -1211,7 +1211,7 @@ exports[`WorkOrdersFilter component when logged in as a combined contract manage
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.80"
                 >
-                  In Progress
+                  In progress
                 </label>
               </div>
               <div
@@ -1245,7 +1245,7 @@ exports[`WorkOrdersFilter component when logged in as a combined contract manage
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.30"
                 >
-                  Work Cancelled
+                  Work cancelled
                 </label>
               </div>
               <div
@@ -1262,7 +1262,7 @@ exports[`WorkOrdersFilter component when logged in as a combined contract manage
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.90"
                 >
-                  Variation Pending Approval
+                  Variation pending approval
                 </label>
               </div>
               <div
@@ -1279,7 +1279,7 @@ exports[`WorkOrdersFilter component when logged in as a combined contract manage
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1080"
                 >
-                  Variation Approved
+                  Variation approved
                 </label>
               </div>
               <div
@@ -1296,7 +1296,7 @@ exports[`WorkOrdersFilter component when logged in as a combined contract manage
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1090"
                 >
-                  Variation Rejected
+                  Variation rejected
                 </label>
               </div>
             </div>
@@ -1733,7 +1733,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.80"
                 >
-                  In Progress
+                  In progress
                 </label>
               </div>
               <div
@@ -1767,7 +1767,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.30"
                 >
-                  Work Cancelled
+                  Work cancelled
                 </label>
               </div>
               <div
@@ -1784,7 +1784,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1010"
                 >
-                  Authorisation Pending Approval
+                  Authorisation pending approval
                 </label>
               </div>
               <div
@@ -1801,7 +1801,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.90"
                 >
-                  Variation Pending Approval
+                  Variation pending approval
                 </label>
               </div>
               <div
@@ -1818,7 +1818,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1080"
                 >
-                  Variation Approved
+                  Variation approved
                 </label>
               </div>
               <div
@@ -1835,7 +1835,7 @@ exports[`WorkOrdersFilter component when logged in as a contract manager should 
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1090"
                 >
-                  Variation Rejected
+                  Variation rejected
                 </label>
               </div>
             </div>
@@ -2272,7 +2272,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.80"
                 >
-                  In Progress
+                  In progress
                 </label>
               </div>
               <div
@@ -2306,7 +2306,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.30"
                 >
-                  Work Cancelled
+                  Work cancelled
                 </label>
               </div>
               <div
@@ -2323,7 +2323,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.90"
                 >
-                  Variation Pending Approval
+                  Variation pending approval
                 </label>
               </div>
               <div
@@ -2340,7 +2340,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1080"
                 >
-                  Variation Approved
+                  Variation approved
                 </label>
               </div>
               <div
@@ -2357,7 +2357,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with more tha
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1090"
                 >
-                  Variation Rejected
+                  Variation rejected
                 </label>
               </div>
             </div>
@@ -2723,7 +2723,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.80"
                 >
-                  In Progress
+                  In progress
                 </label>
               </div>
               <div
@@ -2757,7 +2757,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.30"
                 >
-                  Work Cancelled
+                  Work cancelled
                 </label>
               </div>
               <div
@@ -2774,7 +2774,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.90"
                 >
-                  Variation Pending Approval
+                  Variation pending approval
                 </label>
               </div>
               <div
@@ -2791,7 +2791,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1080"
                 >
-                  Variation Approved
+                  Variation approved
                 </label>
               </div>
               <div
@@ -2808,7 +2808,7 @@ exports[`WorkOrdersFilter component when logged in as a contractor with one cont
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1090"
                 >
-                  Variation Rejected
+                  Variation rejected
                 </label>
               </div>
             </div>
@@ -3245,7 +3245,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.80"
                 >
-                  In Progress
+                  In progress
                 </label>
               </div>
               <div
@@ -3279,7 +3279,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.30"
                 >
-                  Work Cancelled
+                  Work cancelled
                 </label>
               </div>
               <div
@@ -3296,7 +3296,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1010"
                 >
-                  Authorisation Pending Approval
+                  Authorisation pending approval
                 </label>
               </div>
               <div
@@ -3313,7 +3313,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.90"
                 >
-                  Variation Pending Approval
+                  Variation pending approval
                 </label>
               </div>
               <div
@@ -3330,7 +3330,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1080"
                 >
-                  Variation Approved
+                  Variation approved
                 </label>
               </div>
               <div
@@ -3347,7 +3347,7 @@ exports[`WorkOrdersFilter component when logged in as an authorisation manager s
                   class="govuk-label govuk-checkboxes__label lbh-body-xs"
                   for="StatusCode.1090"
                 >
-                  Variation Rejected
+                  Variation rejected
                 </label>
               </div>
             </div>

--- a/src/styles/components/work-orders/work-orders.scss
+++ b/src/styles/components/work-orders/work-orders.scss
@@ -21,7 +21,6 @@
       background-color: repairs-hub-colour('blue');
       color: repairs-hub-colour('white');
     }
-    &--status-work-complete,
     &--status-locked {
       background-color: repairs-hub-colour('white');
       color: repairs-hub-colour('black');
@@ -49,6 +48,11 @@
     &--status-closed,
     &--status-completed {
       background-color: repairs-hub-colour('dark-grey');
+    }
+    &--status-work-complete {
+      background-color: repairs-hub-colour('white');
+      color: repairs-hub-colour('black');
+      border: 2px solid black;
     }
   }
 }

--- a/src/utils/helpers/textConverter.js
+++ b/src/utils/helpers/textConverter.js
@@ -1,0 +1,3 @@
+export const convertToSentenceCases = (text) => {
+  return text.charAt(0) + text.slice(1).toLocaleLowerCase()
+}

--- a/src/utils/helpers/textConverter.test.js
+++ b/src/utils/helpers/textConverter.test.js
@@ -1,0 +1,5 @@
+import { convertToSentenceCases } from './textConverter'
+
+it('Converts text into sentence case', () => {
+  expect(convertToSentenceCases('HELLO WORLD')).toEqual('Hello world')
+})


### PR DESCRIPTION
Addressed design comments from this ticket --> https://www.pivotaltracker.com/story/show/180915752
What was addressed: 
- `status options on the left hand side to also be "Sentence case" (in filters section)`
- `The "Completed" tag should have a black border and a white background on both RH and mobile`
------------------------------------------------------------------------------------------------------

`Can we remove "Work" from "Work cancelled" and change "Complete" to "Completed" in both the table results and the left hand side option and on mobile.`Will addressed in separate PR after b/e makes changes

------------------------------------------------------------------------------------------------------

Screenshot:


![Screenshot 2022-02-04 at 12 37 10](https://user-images.githubusercontent.com/51852726/152530660-8fc40e9e-579a-4a02-928e-4b467543858e.png)
