### PR TITLE
Revert "Update repsonse from api/properties/propertyRef"

### DIFF
--- a/cypress/fixtures/properties/property.json
+++ b/cypress/fixtures/properties/property.json
@@ -40,14 +40,16 @@
     "typeCode": "SEC",
     "typeDescription": "Secure"
   },
-  "contactDetails": [
+  "contacts": [
     {
-      "fullName": "Mark Gardner",
-      "phoneNumbers": [{ "value": "00000111111" }, { "value": "00000222222" }]
+      "firstName": "Mark",
+      "lastName": "Gardner",
+      "phoneNumbers": ["00000111111", "00000222222"]
     },
     {
-      "fullName": "Luam Berhane",
-      "phoneNumbers": [{ "value": "00000666666" }]
+      "firstName": "Luam",
+      "lastName": "Berhane",
+      "phoneNumbers": ["00000666666"]
     }
   ]
 }

--- a/src/components/Property/Contacts/Contacts.test.js
+++ b/src/components/Property/Contacts/Contacts.test.js
@@ -15,16 +15,14 @@ describe('Contacts component', () => {
   describe('when supplied with a list of contacts', () => {
     const contacts = [
       {
-        fullName: 'Mark Gardner',
-        phoneNumbers: [
-          { value: '00000111111' },
-          { value: '00000222222' },
-          { value: '00000333333' },
-        ],
+        firstName: 'Mark',
+        lastName: 'Gardner',
+        phoneNumbers: ['00000111111', '00000222222', '00000333333'],
       },
       {
-        fullName: 'Luam Berhane',
-        phoneNumbers: [{ value: '' }, { value: '' }, { value: '00000333333' }],
+        firstName: 'Luam',
+        lastName: 'Berhane',
+        phoneNumbers: ['', '', '00000333333'],
       },
     ]
 

--- a/src/components/Property/Contacts/ContactsRow.js
+++ b/src/components/Property/Contacts/ContactsRow.js
@@ -4,10 +4,10 @@ import { TR, TD } from '../../Layout/Table'
 const Row = ({ contact }) => {
   return (
     <TR>
-      <TD>{[contact?.fullName]}</TD>
-      <TD>{contact.phoneNumbers[0]?.value}</TD>
-      <TD>{contact.phoneNumbers[1]?.value}</TD>
-      <TD>{contact.phoneNumbers[2]?.value}</TD>
+      <TD>{[contact?.firstName, contact?.lastName].join(' ')}</TD>
+      <TD>{contact.phoneNumbers[0]}</TD>
+      <TD>{contact.phoneNumbers[1]}</TD>
+      <TD>{contact.phoneNumbers[2]}</TD>
     </TR>
   )
 }

--- a/src/components/Property/Contacts/ContactsRow.test.js
+++ b/src/components/Property/Contacts/ContactsRow.test.js
@@ -3,12 +3,9 @@ import ContactsRow from './ContactsRow'
 
 describe('ContactsRow component', () => {
   const contact = {
-    fullName: 'Hugo Neves Ferreira',
-    phoneNumbers: [
-      { value: '00000111111' },
-      { value: '' },
-      { value: '00000333333' },
-    ],
+    firstName: 'Hugo Neves',
+    lastName: 'Ferreira',
+    phoneNumbers: ['00000111111', '', '00000333333'],
   }
 
   it('renders the name and available phone numbers in a row', async () => {

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
@@ -72,7 +72,7 @@ describe('RaiseWorkOrderForm component', () => {
         name: 'Plumbing',
       },
     ],
-    contactDetails: [],
+    contacts: [],
     onFormSubmit: jest.fn(),
   }
 
@@ -88,7 +88,7 @@ describe('RaiseWorkOrderForm component', () => {
         personAlerts={props.alerts.personAlert}
         priorities={props.priorities}
         trades={props.trades}
-        contacts={props.contactDetails}
+        contacts={props.contacts}
         onFormSubmit={props.onFormSubmit}
       />
     )

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -126,7 +126,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
       setPersonAlerts(data.alerts.personAlert)
       setPriorities(priorities)
       setTrades(trades)
-      setContacts(data.contactDetails)
+      setContacts(data.contacts)
       setCurrentUser(user)
     } catch (e) {
       setProperty(null)

--- a/src/pages/api/properties/[id].js
+++ b/src/pages/api/properties/[id].js
@@ -17,6 +17,6 @@ export default authoriseServiceAPIRequest(async (req, res, user) => {
   ) {
     res.status(HttpStatus.OK).json(data)
   } else {
-    res.status(HttpStatus.OK).json({ ...data, contactDetails: ['REMOVED'] })
+    res.status(HttpStatus.OK).json({ ...data, contacts: ['REMOVED'] })
   }
 })

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -28,16 +28,20 @@ describe('GET /api/properties/[id] contact information redaction', () => {
           property: {},
           alerts: {},
           tenure: {},
-          contactDetails: [
-            {
-              fullName: 'FirstName LastName',
-              phoneNumbers: ['0123456789', '0123456789'],
-            },
-            {
-              fullName: 'FirstName LastName',
-              phoneNumbers: ['0123456789', '0123456789'],
-            },
-          ],
+          contacts: {
+            contacts: [
+              {
+                firstName: 'FirstName',
+                lastName: 'LastName',
+                phoneNumbers: ['0123456789', '0123456789'],
+              },
+              {
+                firstName: 'FirstName',
+                lastName: 'LastName',
+                phoneNumbers: ['0123456789', '0123456789'],
+              },
+            ],
+          },
         },
       })
     )
@@ -86,16 +90,20 @@ describe('GET /api/properties/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData['contactDetails']).toEqual([
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-      ])
+      expect(parsedData['contacts']).toEqual({
+        contacts: [
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+        ],
+      })
     })
   })
 
@@ -142,16 +150,20 @@ describe('GET /api/properties/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData['contactDetails']).toEqual([
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-      ])
+      expect(parsedData['contacts']).toEqual({
+        contacts: [
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+          {
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            phoneNumbers: ['0123456789', '0123456789'],
+          },
+        ],
+      })
     })
   })
 
@@ -197,7 +209,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData['contactDetails']).toEqual(['REMOVED'])
+      expect(parsedData['contacts']).toEqual(['REMOVED'])
     })
   })
 })


### PR DESCRIPTION
Reverts LBHackney-IT/repairs-hub-frontend#536

This has been temporarily reverted because we need to deploy the frontend independently of the backend with some urgency (in order to apply new certificate config - see https://github.com/LBHackney-IT/repairs-hub-frontend/pull/561).

There will be a follow-up PR to re-apply this change once the backend deployment can proceed again.