### PR TITLE
Revert "Revert "Update repsonse from api/properties/propertyRef""

### DIFF
--- a/cypress/fixtures/properties/property.json
+++ b/cypress/fixtures/properties/property.json
@@ -40,16 +40,14 @@
     "typeCode": "SEC",
     "typeDescription": "Secure"
   },
-  "contacts": [
+  "contactDetails": [
     {
-      "firstName": "Mark",
-      "lastName": "Gardner",
-      "phoneNumbers": ["00000111111", "00000222222"]
+      "fullName": "Mark Gardner",
+      "phoneNumbers": [{ "value": "00000111111" }, { "value": "00000222222" }]
     },
     {
-      "firstName": "Luam",
-      "lastName": "Berhane",
-      "phoneNumbers": ["00000666666"]
+      "fullName": "Luam Berhane",
+      "phoneNumbers": [{ "value": "00000666666" }]
     }
   ]
 }

--- a/src/components/Property/Contacts/Contacts.test.js
+++ b/src/components/Property/Contacts/Contacts.test.js
@@ -15,14 +15,16 @@ describe('Contacts component', () => {
   describe('when supplied with a list of contacts', () => {
     const contacts = [
       {
-        firstName: 'Mark',
-        lastName: 'Gardner',
-        phoneNumbers: ['00000111111', '00000222222', '00000333333'],
+        fullName: 'Mark Gardner',
+        phoneNumbers: [
+          { value: '00000111111' },
+          { value: '00000222222' },
+          { value: '00000333333' },
+        ],
       },
       {
-        firstName: 'Luam',
-        lastName: 'Berhane',
-        phoneNumbers: ['', '', '00000333333'],
+        fullName: 'Luam Berhane',
+        phoneNumbers: [{ value: '' }, { value: '' }, { value: '00000333333' }],
       },
     ]
 

--- a/src/components/Property/Contacts/ContactsRow.js
+++ b/src/components/Property/Contacts/ContactsRow.js
@@ -4,10 +4,10 @@ import { TR, TD } from '../../Layout/Table'
 const Row = ({ contact }) => {
   return (
     <TR>
-      <TD>{[contact?.firstName, contact?.lastName].join(' ')}</TD>
-      <TD>{contact.phoneNumbers[0]}</TD>
-      <TD>{contact.phoneNumbers[1]}</TD>
-      <TD>{contact.phoneNumbers[2]}</TD>
+      <TD>{[contact?.fullName]}</TD>
+      <TD>{contact.phoneNumbers[0]?.value}</TD>
+      <TD>{contact.phoneNumbers[1]?.value}</TD>
+      <TD>{contact.phoneNumbers[2]?.value}</TD>
     </TR>
   )
 }

--- a/src/components/Property/Contacts/ContactsRow.test.js
+++ b/src/components/Property/Contacts/ContactsRow.test.js
@@ -3,9 +3,12 @@ import ContactsRow from './ContactsRow'
 
 describe('ContactsRow component', () => {
   const contact = {
-    firstName: 'Hugo Neves',
-    lastName: 'Ferreira',
-    phoneNumbers: ['00000111111', '', '00000333333'],
+    fullName: 'Hugo Neves Ferreira',
+    phoneNumbers: [
+      { value: '00000111111' },
+      { value: '' },
+      { value: '00000333333' },
+    ],
   }
 
   it('renders the name and available phone numbers in a row', async () => {

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
@@ -72,7 +72,7 @@ describe('RaiseWorkOrderForm component', () => {
         name: 'Plumbing',
       },
     ],
-    contacts: [],
+    contactDetails: [],
     onFormSubmit: jest.fn(),
   }
 
@@ -88,7 +88,7 @@ describe('RaiseWorkOrderForm component', () => {
         personAlerts={props.alerts.personAlert}
         priorities={props.priorities}
         trades={props.trades}
-        contacts={props.contacts}
+        contacts={props.contactDetails}
         onFormSubmit={props.onFormSubmit}
       />
     )

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -126,7 +126,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
       setPersonAlerts(data.alerts.personAlert)
       setPriorities(priorities)
       setTrades(trades)
-      setContacts(data.contacts)
+      setContacts(data.contactDetails)
       setCurrentUser(user)
     } catch (e) {
       setProperty(null)

--- a/src/pages/api/properties/[id].js
+++ b/src/pages/api/properties/[id].js
@@ -17,6 +17,6 @@ export default authoriseServiceAPIRequest(async (req, res, user) => {
   ) {
     res.status(HttpStatus.OK).json(data)
   } else {
-    res.status(HttpStatus.OK).json({ ...data, contacts: ['REMOVED'] })
+    res.status(HttpStatus.OK).json({ ...data, contactDetails: ['REMOVED'] })
   }
 })

--- a/src/pages/api/properties/[id].test.js
+++ b/src/pages/api/properties/[id].test.js
@@ -28,20 +28,16 @@ describe('GET /api/properties/[id] contact information redaction', () => {
           property: {},
           alerts: {},
           tenure: {},
-          contacts: {
-            contacts: [
-              {
-                firstName: 'FirstName',
-                lastName: 'LastName',
-                phoneNumbers: ['0123456789', '0123456789'],
-              },
-              {
-                firstName: 'FirstName',
-                lastName: 'LastName',
-                phoneNumbers: ['0123456789', '0123456789'],
-              },
-            ],
-          },
+          contactDetails: [
+            {
+              fullName: 'FirstName LastName',
+              phoneNumbers: ['0123456789', '0123456789'],
+            },
+            {
+              fullName: 'FirstName LastName',
+              phoneNumbers: ['0123456789', '0123456789'],
+            },
+          ],
         },
       })
     )
@@ -90,20 +86,16 @@ describe('GET /api/properties/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData['contacts']).toEqual({
-        contacts: [
-          {
-            firstName: 'FirstName',
-            lastName: 'LastName',
-            phoneNumbers: ['0123456789', '0123456789'],
-          },
-          {
-            firstName: 'FirstName',
-            lastName: 'LastName',
-            phoneNumbers: ['0123456789', '0123456789'],
-          },
-        ],
-      })
+      expect(parsedData['contactDetails']).toEqual([
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+      ])
     })
   })
 
@@ -150,20 +142,16 @@ describe('GET /api/properties/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData['contacts']).toEqual({
-        contacts: [
-          {
-            firstName: 'FirstName',
-            lastName: 'LastName',
-            phoneNumbers: ['0123456789', '0123456789'],
-          },
-          {
-            firstName: 'FirstName',
-            lastName: 'LastName',
-            phoneNumbers: ['0123456789', '0123456789'],
-          },
-        ],
-      })
+      expect(parsedData['contactDetails']).toEqual([
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+      ])
     })
   })
 
@@ -209,7 +197,7 @@ describe('GET /api/properties/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData['contacts']).toEqual(['REMOVED'])
+      expect(parsedData['contactDetails']).toEqual(['REMOVED'])
     })
   })
 })


### PR DESCRIPTION
Reverts LBHackney-IT/repairs-hub-frontend#565

Re-applies the integration with the new contact details endpoint.

This was reverted in https://github.com/LBHackney-IT/repairs-hub-frontend/pull/565 as part of the preparation to deploy the frontend independently of the backend.