### PR TITLE
Show warning info box when raising a repair if property is in legal disrepair

### DIFF
--- a/cypress/fixtures/properties/propertyInLegalDisrepair.json
+++ b/cypress/fixtures/properties/propertyInLegalDisrepair.json
@@ -1,0 +1,3 @@
+{
+  "propertyIsInLegalDisrepair": true
+}

--- a/cypress/integration/work-order/create/appointment-form.spec.js
+++ b/cypress/integration/work-order/create/appointment-form.spec.js
@@ -41,6 +41,11 @@ describe('Schedule appointment form', () => {
       { fixture: 'scheduleOfRates/trades.json' }
     )
 
+    cy.intercept(
+      { method: 'GET', path: '/api/properties/legalDisrepair/00012345' },
+      { body: false }
+    ).as('propertyIsNotInLegalDisrepair')
+
     cy.fixture('workOrders/workOrder.json')
       .then((workOrder) => {
         workOrder.target = targetTime

--- a/cypress/integration/work-order/create/create-with-appointment.spec.js
+++ b/cypress/integration/work-order/create/create-with-appointment.spec.js
@@ -77,6 +77,11 @@ describe('Schedule appointment form', () => {
     ).as('availableAppointments')
 
     cy.intercept(
+      { method: 'GET', path: '/api/properties/legalDisrepair/00012345' },
+      { body: false }
+    ).as('propertyIsNotInLegalDisrepair')
+
+    cy.intercept(
       { method: 'POST', path: '/api/appointments' },
       { body: '' }
     ).as('apiCheckAppointment')

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -55,6 +55,11 @@ describe('Raise repair form', () => {
     ).as('tradesRequest')
 
     cy.intercept(
+      { method: 'GET', path: '/api/api/properties/legalDisrepair/00012345' },
+      { fixture: 'properties/propertyInLegalDisrepair' }
+    ).as('propertyInLegalDisrepair')
+
+    cy.intercept(
       { method: 'POST', path: '/api/workOrders/schedule' },
       {
         body: {
@@ -790,6 +795,23 @@ describe('Raise repair form', () => {
       )
       cy.contains('Start a new search').should('have.attr', 'href', '/')
     })
+  })
+
+  it.only('Shows warning text if property is in legal disrepair', () => {
+    cy.visit('/properties/00012345')
+
+    cy.wait(['@propertyRequest', '@workOrdersRequest'])
+
+    cy.get('.lbh-heading-h2')
+      .contains('Raise a work order on this dwelling')
+      .click()
+
+    cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest', '@propertyInLegalDisrepair'])
+
+    cy.get('#repair-request-form').within(() => {
+
+    })
+
   })
 })
 

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
@@ -11,6 +11,7 @@ import {
 import TradeContractorRateScheduleItemView from './TradeContractorRateScheduleItemView'
 import Contacts from '../Contacts/Contacts'
 import WarningText from '../../Template/WarningText'
+import WarningInfoBox from '../../Template/WarningInfoBox'
 import { buildScheduleWorkOrderFormData } from '@/utils/hact/workOrderSchedule/raiseWorkOrderForm'
 import { IMMEDIATE_PRIORITY_CODE } from '@/utils/helpers/priorities'
 import { daysInHours } from '@/utils/time'
@@ -30,6 +31,7 @@ const RaiseWorkOrderForm = ({
   contacts,
   onFormSubmit,
   raiseLimit,
+  isInLegalDisrepair,
 }) => {
   const { register, handleSubmit, errors, setValue } = useForm()
   const [priorityCode, setPriorityCode] = useState()
@@ -119,7 +121,12 @@ const RaiseWorkOrderForm = ({
           <h1 className="lbh-heading-h1 govuk-!-margin-bottom-2">
             {hierarchyType.subTypeDescription}: {address.addressLine}
           </h1>
-
+          {isInLegalDisrepair && (
+            <WarningInfoBox
+              header="This property is currently under legal disrepair"
+              text="Before raising a work order you must call the Legal Disrepair Team"
+            />
+          )}
           <div className="lbh-body-s">
             <TenureDetails
               canRaiseRepair={canRaiseRepair}
@@ -240,6 +247,7 @@ RaiseWorkOrderForm.propTypes = {
   trades: PropTypes.array.isRequired,
   priorities: PropTypes.array.isRequired,
   onFormSubmit: PropTypes.func.isRequired,
+  isInLegalDisrepair: PropTypes.bool.isRequired,
 }
 
 export default RaiseWorkOrderForm

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -13,7 +13,6 @@ import {
 import { STATUS_AUTHORISATION_PENDING_APPROVAL } from '@/utils/statusCodes'
 import Meta from '../../Meta'
 import router from 'next/router'
-import WarningInfoBox from '../../Template/WarningInfoBox'
 
 const RaiseWorkOrderFormView = ({ propertyReference }) => {
   const [property, setProperty] = useState({})
@@ -195,28 +194,21 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
             personAlerts &&
             priorities &&
             trades && (
-              <>
-                {isInLegalDisrepair && (
-                  <WarningInfoBox
-                    header="This priority is currently under legal disrepair"
-                    text="Before raising a work order you must call the Legal Disrepair Team"
-                  />
-                )}
-                <RaiseWorkOrderForm
-                  propertyReference={propertyReference}
-                  address={property.address}
-                  hierarchyType={property.hierarchyType}
-                  canRaiseRepair={property.canRaiseRepair}
-                  tenure={tenure}
-                  locationAlerts={locationAlerts}
-                  personAlerts={personAlerts}
-                  priorities={priorities}
-                  trades={trades}
-                  contacts={contacts}
-                  onFormSubmit={onFormSubmit}
-                  raiseLimit={currentUser?.raiseLimit}
-                />
-              </>
+              <RaiseWorkOrderForm
+                propertyReference={propertyReference}
+                address={property.address}
+                hierarchyType={property.hierarchyType}
+                canRaiseRepair={property.canRaiseRepair}
+                tenure={tenure}
+                locationAlerts={locationAlerts}
+                personAlerts={personAlerts}
+                priorities={priorities}
+                trades={trades}
+                contacts={contacts}
+                onFormSubmit={onFormSubmit}
+                raiseLimit={currentUser?.raiseLimit}
+                isInLegalDisrepair={isInLegalDisrepair}
+              />
             )}
           {error && <ErrorMessage label={error} />}
         </>

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -13,6 +13,7 @@ import {
 import { STATUS_AUTHORISATION_PENDING_APPROVAL } from '@/utils/statusCodes'
 import Meta from '../../Meta'
 import router from 'next/router'
+import WarningInfoBox from '../../Template/WarningInfoBox'
 
 const RaiseWorkOrderFormView = ({ propertyReference }) => {
   const [property, setProperty] = useState({})
@@ -187,20 +188,26 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
             personAlerts &&
             priorities &&
             trades && (
-              <RaiseWorkOrderForm
-                propertyReference={propertyReference}
-                address={property.address}
-                hierarchyType={property.hierarchyType}
-                canRaiseRepair={property.canRaiseRepair}
-                tenure={tenure}
-                locationAlerts={locationAlerts}
-                personAlerts={personAlerts}
-                priorities={priorities}
-                trades={trades}
-                contacts={contacts}
-                onFormSubmit={onFormSubmit}
-                raiseLimit={currentUser?.raiseLimit}
-              />
+              <>
+                <WarningInfoBox
+                  header="This priority is currently under legal disrepair"
+                  text="Before raising a work order you must call the Legal Disrepair Team"
+                />
+                <RaiseWorkOrderForm
+                  propertyReference={propertyReference}
+                  address={property.address}
+                  hierarchyType={property.hierarchyType}
+                  canRaiseRepair={property.canRaiseRepair}
+                  tenure={tenure}
+                  locationAlerts={locationAlerts}
+                  personAlerts={personAlerts}
+                  priorities={priorities}
+                  trades={trades}
+                  contacts={contacts}
+                  onFormSubmit={onFormSubmit}
+                  raiseLimit={currentUser?.raiseLimit}
+                />
+              </>
             )}
           {error && <ErrorMessage label={error} />}
         </>

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -44,6 +44,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
   ] = useState(false)
   const [workOrderReference, setWorkOrderReference] = useState()
   const [currentUser, setCurrentUser] = useState()
+  const [isInLegalDisrepair, setIsInLegalDisrepair] = useState()
 
   const onFormSubmit = async (formData) => {
     setLoading(true)
@@ -121,6 +122,11 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
         path: '/api/hub-user',
       })
 
+      const isInLegalDisrepair = await frontEndApiRequest({
+        method: 'get',
+        path: `/api/properties/legalDisrepair/${propertyReference}`,
+      })
+
       setTenure(data.tenure)
       setProperty(data.property)
       setLocationAlerts(data.alerts.locationAlert)
@@ -129,6 +135,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
       setTrades(trades)
       setContacts(data.contactDetails)
       setCurrentUser(user)
+      setIsInLegalDisrepair(isInLegalDisrepair)
     } catch (e) {
       setProperty(null)
       setPriorities(null)
@@ -189,10 +196,12 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
             priorities &&
             trades && (
               <>
-                <WarningInfoBox
-                  header="This priority is currently under legal disrepair"
-                  text="Before raising a work order you must call the Legal Disrepair Team"
-                />
+                {isInLegalDisrepair && (
+                  <WarningInfoBox
+                    header="This priority is currently under legal disrepair"
+                    text="Before raising a work order you must call the Legal Disrepair Team"
+                  />
+                )}
                 <RaiseWorkOrderForm
                   propertyReference={propertyReference}
                   address={property.address}


### PR DESCRIPTION
Story: 
https://www.pivotaltracker.com/story/show/180646211

new end point to check if property is in legal disrepair

`properties/legalDisrepair/{propertyReference}`
response : 
`{
  propertyIsInLegalDisrepair: true
}`


![Screenshot 2022-02-25 at 16 06 06](https://user-images.githubusercontent.com/51852726/155748302-9e6b4533-bd3a-4962-9cc7-c6163b0c0f1d.png)


