### PR TITLE
Payment type selection for DLO closures only

### DIFF
--- a/cypress/integration/work-order/attend/close-by-proxy.spec.js
+++ b/cypress/integration/work-order/attend/close-by-proxy.spec.js
@@ -26,6 +26,7 @@ describe('Closing a work order on behalf of an operative', () => {
     cy.fixture('workOrders/workOrder.json')
       .then((workOrder) => {
         workOrder.reference = 10000040
+        workOrder.paymentType = null
         cy.intercept(
           { method: 'GET', path: '/api/workOrders/10000040' },
           { body: workOrder }
@@ -115,14 +116,6 @@ describe('Closing a work order on behalf of an operative', () => {
 
       cy.get('[data-testid=completionTime-hour]').type('12')
       cy.get('[data-testid=completionTime-minutes]').type('45')
-
-      cy.contains('Payment type')
-        .parent()
-        .within(() => {
-          cy.get('[value="Bonus"]').should('be.checked')
-          cy.get('[value="Overtime"]').should('not.be.checked')
-          cy.get('[value="CloseToBase"]').should('not.be.checked')
-        })
 
       cy.get('#notes').type('test')
       cy.get('[type="submit"]').contains('Close work order').click()
@@ -227,9 +220,8 @@ describe('Closing a work order on behalf of an operative', () => {
             typeCode: '0',
             otherType: 'completed',
             comments:
-              'Work order closed - This has been repaired and I forgot I did it on a completely different date and time. - Bonus calculation',
+              'Work order closed - This has been repaired and I forgot I did it on a completely different date and time.',
             eventTime: '2021-02-19T13:01:00.000Z',
-            paymentType: 'Bonus',
           },
         ],
       })
@@ -264,16 +256,6 @@ describe('Closing a work order on behalf of an operative', () => {
       cy.get('[data-testid=completionTime-hour]').type('13')
       cy.get('[data-testid=completionTime-minutes]').type('01')
 
-      cy.contains('Payment type')
-        .parent()
-        .within(() => {
-          cy.get('[value="Bonus"]').should('be.checked')
-          cy.get('[value="Overtime"]').should('not.be.checked')
-          cy.get('[value="CloseToBase"]').should('not.be.checked')
-
-          cy.contains('label', 'Close to base').click()
-        })
-
       cy.get('#notes').type('Tenant was not at home')
       cy.get('[type="submit"]').contains('Close work order').click()
     })
@@ -285,8 +267,6 @@ describe('Closing a work order on behalf of an operative', () => {
     cy.get('.govuk-table__row').contains('No Access')
     cy.get('.govuk-table__row').contains('Notes')
     cy.get('.govuk-table__row').contains('Tenant was not at home')
-
-    cy.contains('th', 'Payment type').parent().contains('Close to base')
 
     cy.get('[type="submit"]').contains('Confirm and close').click()
 
@@ -304,13 +284,14 @@ describe('Closing a work order on behalf of an operative', () => {
           {
             typeCode: '70',
             otherType: 'completed',
-            comments:
-              'Work order closed - Tenant was not at home - Close to base (Operative payment made)',
+            comments: 'Work order closed - Tenant was not at home',
             eventTime: '2021-01-19T13:01:00.000Z',
-            paymentType: 'CloseToBase',
           },
         ],
       })
+
+    // no operative assignment request made
+    cy.requestsCountByUrl('/api/jobStatusUpdate').should('eq', 0)
 
     cy.wait(['@workOrderFilters', '@workOrders'])
 
@@ -320,118 +301,23 @@ describe('Closing a work order on behalf of an operative', () => {
     cy.audit()
   })
 
-  it('allows specifying a payment type of overtime', () => {
-    cy.visit('/work-orders/10000040/close')
+  describe('when the work allows operative and payment type selection', () => {
+    beforeEach(() => {
+      cy.fixture('workOrders/workOrder.json').then((workOrder) => {
+        workOrder.reference = 10000040
+        workOrder.contractorReference = 'H10' // DLO contractor reference
+        workOrder.canAssignOperative = true
+        workOrder.operatives = []
+        cy.intercept(
+          { method: 'GET', path: '/api/workOrders/10000040' },
+          { body: workOrder }
+        ).as('workOrder')
+      })
 
-    cy.wait(['@workOrder'])
-
-    cy.get('.operatives').should('not.exist')
-
-    cy.get('form').within(() => {
-      cy.contains('Select reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Completed').click()
-        })
-
-      cy.get('#date').type('2021-01-23')
-
-      cy.get('[data-testid=completionTime-hour]').type('12')
-      cy.get('[data-testid=completionTime-minutes]').type('00')
-
-      cy.contains('Payment type')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Overtime').click()
-        })
-
-      cy.get('#notes').type('This has been repaired during overtime.')
-      cy.get('[type="submit"]').contains('Close work order').click()
-    })
-
-    cy.contains('th', 'Payment type').parent().contains('Overtime')
-
-    cy.get('[type="submit"]').contains('Confirm and close').click()
-
-    cy.wait('@apiCheck')
-
-    cy.get('@apiCheck')
-      .its('request.body')
-      .should(
-        'have.deep.nested.property',
-        'jobStatusUpdates[0].comments',
-        'Work order closed - This has been repaired during overtime. - Overtime work order (SMVs not included in Bonus)'
-      )
-
-    cy.get('@apiCheck')
-      .its('request.body')
-      .should(
-        'have.deep.nested.property',
-        'jobStatusUpdates[0].paymentType',
-        'Overtime'
-      )
-  })
-
-  it('allows specifying a payment type of close to base', () => {
-    cy.visit('/work-orders/10000040/close')
-
-    cy.wait(['@workOrder'])
-
-    cy.get('.operatives').should('not.exist')
-
-    cy.get('form').within(() => {
-      cy.contains('Select reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Completed').click()
-        })
-
-      cy.get('#date').type('2021-01-23')
-
-      cy.get('[data-testid=completionTime-hour]').type('12')
-      cy.get('[data-testid=completionTime-minutes]').type('00')
-
-      cy.contains('Payment type')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Close to base').click()
-        })
-
-      cy.get('#notes').type('A note')
-      cy.get('[type="submit"]').contains('Close work order').click()
-    })
-
-    cy.contains('th', 'Payment type').parent().contains('Close to base')
-
-    cy.get('[type="submit"]').contains('Confirm and close').click()
-
-    cy.wait('@apiCheck')
-
-    cy.get('@apiCheck')
-      .its('request.body')
-      .should(
-        'have.deep.nested.property',
-        'jobStatusUpdates[0].comments',
-        'Work order closed - A note - Close to base (Operative payment made)'
-      )
-
-    cy.get('@apiCheck')
-      .its('request.body')
-      .should(
-        'have.deep.nested.property',
-        'jobStatusUpdates[0].paymentType',
-        'CloseToBase'
-      )
-  })
-
-  describe('When the order requires operative assignment', () => {
-    describe('And the workorder has existing operatives assigned', () => {
-      beforeEach(() => {
-        cy.fixture('workOrders/workOrder.json').then((workOrder) => {
-          workOrder.reference = 10000040
-          workOrder.canAssignOperative = true
-          workOrder.totalSMVs = 76
-          workOrder.operatives = [
+      cy.intercept(
+        { method: 'GET', path: '/api/operatives' },
+        {
+          body: [
             {
               id: 1,
               name: 'Operative A',
@@ -444,72 +330,35 @@ describe('Closing a work order on behalf of an operative', () => {
               id: 3,
               name: 'Operative C',
             },
-          ]
-          cy.intercept(
-            { method: 'GET', path: '/api/workOrders/10000040' },
-            { body: workOrder }
-          ).as('workOrder')
-        })
+            {
+              id: 25,
+              name: 'Operative Y',
+            },
+            {
+              id: 26,
+              name: 'Operative Z',
+            },
+          ],
+        }
+      ).as('operatives')
+    })
 
-        cy.intercept(
-          { method: 'GET', path: '/api/operatives' },
-          {
-            body: [
-              {
-                id: 1,
-                name: 'Operative A',
-              },
-              {
-                id: 2,
-                name: 'Operative B',
-              },
-              {
-                id: 3,
-                name: 'Operative C',
-              },
-              {
-                id: 25,
-                name: 'Operative Y',
-              },
-              {
-                id: 26,
-                name: 'Operative Z',
-              },
-            ],
-          }
-        ).as('operatives')
+    it('allows specifying a payment type of bonus by default', () => {
+      cy.visit('/work-orders/10000040/close')
 
-        cy.intercept(
-          { method: 'POST', path: '/api/workOrderComplete' },
-          { body: '' }
-        ).as('workOrderCompleteRequest')
+      cy.wait(['@workOrder', '@operatives'])
 
-        cy.intercept(
-          { method: 'POST', path: '/api/jobStatusUpdate' },
-          { body: '' }
-        ).as('jobStatusUpdateRequest')
-      })
-
-      it('requires total value of split % to be 100', () => {
-        cy.visit('/work-orders/10000040/close')
-
-        cy.wait(['@workOrder', '@operatives'])
-
+      cy.get('form').within(() => {
         cy.contains('Select reason for closing')
           .parent()
           .within(() => {
-            cy.contains('label', 'No access').click()
+            cy.contains('label', 'Completed').click()
           })
 
-        cy.get('#date').type('2021-01-19')
+        cy.get('#date').type('2021-01-23')
 
-        cy.get('[data-testid=completionTime-hour]').clear()
-        cy.get('[data-testid=completionTime-minutes]').clear()
-
-        cy.get('[data-testid=completionTime-hour]').type('13')
-        cy.get('[data-testid=completionTime-minutes]').type('01')
-
-        cy.get('#notes').type('A note')
+        cy.get('[data-testid=completionTime-hour]').type('12')
+        cy.get('[data-testid=completionTime-minutes]').type('00')
 
         cy.contains('Payment type')
           .parent()
@@ -517,231 +366,156 @@ describe('Closing a work order on behalf of an operative', () => {
             cy.get('[value="Bonus"]').should('be.checked')
             cy.get('[value="Overtime"]').should('not.be.checked')
             cy.get('[value="CloseToBase"]').should('not.be.checked')
+          })
 
+        cy.get('.operatives').within(() => {
+          cy.get('input[list]').eq(0).type('Operative A [1]')
+        })
+
+        cy.get('#notes').type('A note')
+        cy.get('[type="submit"]').contains('Close work order').click()
+      })
+
+      cy.contains('th', 'Payment type').parent().contains('Bonus')
+
+      cy.get('[type="submit"]').contains('Confirm and close').click()
+
+      cy.wait('@apiCheck')
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'have.deep.nested.property',
+          'jobStatusUpdates[0].comments',
+          'Work order closed - A note - Assigned operatives Operative A : 100% - Bonus calculation'
+        )
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'have.deep.nested.property',
+          'jobStatusUpdates[0].paymentType',
+          'Bonus'
+        )
+    })
+
+    it('allows specifying a payment type of overtime', () => {
+      cy.visit('/work-orders/10000040/close')
+
+      cy.wait(['@workOrder', '@operatives'])
+
+      cy.get('form').within(() => {
+        cy.contains('Select reason for closing')
+          .parent()
+          .within(() => {
+            cy.contains('label', 'Completed').click()
+          })
+
+        cy.get('#date').type('2021-01-23')
+
+        cy.get('[data-testid=completionTime-hour]').type('12')
+        cy.get('[data-testid=completionTime-minutes]').type('00')
+
+        cy.contains('Payment type')
+          .parent()
+          .within(() => {
             cy.contains('label', 'Overtime').click()
           })
 
         cy.get('.operatives').within(() => {
-          cy.get('input[list]').should('have.length', 3)
-
-          cy.get('input[list]').eq(0).should('have.value', 'Operative A [1]')
-          cy.get('input[list]').eq(1).should('have.value', 'Operative B [2]')
-          cy.get('input[list]').eq(2).should('have.value', 'Operative C [3]')
+          cy.get('input[list]').eq(0).type('Operative A [1]')
         })
 
-        cy.get('.select-percentage').within(() => {
-          cy.get('select').should('have.length', 3)
-
-          cy.get('select').eq(0).should('have.value', '33.3%')
-          cy.get('select').eq(1).should('have.value', '33.3%')
-          cy.get('select').eq(2).should('have.value', '33.3%')
-        })
-
-        cy.get('.smv-read-only').should('have.length', 3)
-
-        cy.get('.smv-read-only').eq(0).contains('25.31')
-        cy.get('.smv-read-only').eq(1).contains('25.31')
-        cy.get('.smv-read-only').eq(2).contains('25.31')
-
+        cy.get('#notes').type('A note')
         cy.get('[type="submit"]').contains('Close work order').click()
-
-        cy.get('.govuk-table__row')
-          .contains('Operatives')
-          .parent()
-          .within(() => {
-            cy.contains(
-              'Operative A : 33.3%, Operative B : 33.3%, Operative C : 33.3%'
-            )
-            cy.get('a').contains('Edit').click()
-          })
-
-        cy.get('.operatives').within(() => {
-          cy.get('input[list]').eq(0).clear()
-          cy.get('input[list]').eq(1).clear()
-          cy.get('input[list]').eq(2).clear()
-        })
-
-        cy.get('[type="submit"]').contains('Close work order').click()
-
-        cy.get('.operatives').within(() => {
-          cy.get('#operative-0-form-group').contains(
-            'Please select an operative'
-          )
-          cy.get('#operative-1-form-group').contains(
-            'Please select an operative'
-          )
-          cy.get('#operative-2-form-group').contains(
-            'Please select an operative'
-          )
-        })
-
-        cy.get('.operatives').within(() => {
-          cy.get('input[list]').eq(0).type('Operative Y [25]')
-          cy.get('input[list]').eq(1).type('Operative A [1]')
-          cy.get('input[list]').eq(2).type('Operative B [2]')
-
-          cy.get('a')
-            .contains(/Add operative from list/)
-            .click()
-
-          cy.get('input[list]').eq(3).type('Operative Z [26]')
-
-          cy.get('input[list]').should('have.length', 4)
-        })
-
-        // total of split percentages is more than 100
-        cy.get('.select-percentage').within(() => {
-          cy.get('select').eq(0).select('70%')
-          cy.get('select').eq(1).select('20%')
-          cy.get('select').eq(2).select('30%')
-          cy.get('select').eq(3).select('10%')
-        })
-
-        cy.get('.smv-read-only').should('have.length', 4)
-
-        cy.get('.smv-read-only').eq(0).contains('53.20')
-        cy.get('.smv-read-only').eq(1).contains('15.20')
-        cy.get('.smv-read-only').eq(2).contains('22.80')
-        cy.get('.smv-read-only').eq(3).contains('7.60')
-
-        cy.get('[type="submit"]').contains('Close work order').click()
-
-        cy.get('.operatives').within(() => {
-          cy.contains('Work done total across operatives must be equal to 100%')
-        })
-
-        // now total is 100
-        cy.get('.select-percentage').within(() => {
-          cy.get('select').eq(0).select('70%')
-          cy.get('select').eq(1).select('20%')
-          cy.get('select').eq(2).select('10%')
-          cy.get('select').eq(3).select('-')
-        })
-
-        cy.get('.smv-read-only').should('have.length', 4)
-
-        cy.get('.smv-read-only').eq(0).contains('53.20')
-        cy.get('.smv-read-only').eq(1).contains('15.20')
-        cy.get('.smv-read-only').eq(2).contains('7.60')
-        cy.get('.smv-read-only').eq(3).contains('-')
-
-        cy.get('[type="submit"]').contains('Close work order').click()
-
-        cy.get('.govuk-table__row')
-          .contains('Operatives')
-          .parent()
-          .within(() => {
-            cy.contains(
-              'Operative Y : 70%, Operative A : 20%, Operative B : 10%, Operative Z : -'
-            )
-          })
-
-        cy.get('[type="submit"]').contains('Confirm and close').click()
-
-        cy.wait('@jobStatusUpdateRequest', { requestTimeout: 6000 })
-          .its('request.body')
-          .should('deep.equal', {
-            relatedWorkOrderReference: {
-              id: '10000040',
-            },
-            operativesAssigned: [
-              {
-                identification: {
-                  number: 25,
-                },
-                calculatedBonus: 70,
-              },
-              {
-                identification: {
-                  number: 1,
-                },
-                calculatedBonus: 20,
-              },
-              {
-                identification: {
-                  number: 2,
-                },
-                calculatedBonus: 10,
-              },
-              {
-                identification: {
-                  number: 26,
-                },
-                calculatedBonus: 0,
-              },
-            ],
-            typeCode: '10',
-          })
-
-        cy.wait('@workOrderCompleteRequest')
-
-        cy.get('@workOrderCompleteRequest')
-          .its('request.body')
-          .should('deep.equal', {
-            workOrderReference: {
-              id: '10000040',
-              description: '',
-              allocatedBy: '',
-            },
-            jobStatusUpdates: [
-              {
-                typeCode: '70',
-                otherType: 'completed',
-                comments:
-                  'Work order closed - A note - Assigned operatives Operative Y, Operative A, Operative B, Operative Z - Overtime work order (SMVs not included in Bonus)',
-                eventTime: '2021-01-19T13:01:00.000Z',
-                paymentType: 'Overtime',
-              },
-            ],
-          })
-
-        cy.requestsCountByUrl('api/jobStatusUpdate').should('eq', 1)
-
-        cy.audit()
       })
+
+      cy.contains('th', 'Payment type').parent().contains('Overtime')
+
+      cy.get('[type="submit"]').contains('Confirm and close').click()
+
+      cy.wait('@apiCheck')
+
+      // Notes when closing with overtime do not include work percentage values
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'have.deep.nested.property',
+          'jobStatusUpdates[0].comments',
+          'Work order closed - A note - Assigned operatives Operative A - Overtime work order (SMVs not included in Bonus)'
+        )
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'have.deep.nested.property',
+          'jobStatusUpdates[0].paymentType',
+          'Overtime'
+        )
     })
 
-    describe('And has existing operatives assigned and job split was done by operative', () => {
-      beforeEach(() => {
-        cy.intercept(
-          { method: 'GET', path: '/api/filter/WorkOrder' },
-          {
-            fixture: 'filter/workOrder.json',
-          }
-        ).as('workOrderFilters')
+    it('allows specifying a payment type of close to base', () => {
+      cy.visit('/work-orders/10000040/close')
 
-        cy.intercept(
-          { method: 'GET', path: '/api/workOrders/?PageSize=10&PageNumber=1' },
-          { fixture: 'workOrders/workOrders.json' }
-        ).as('workOrders')
+      cy.wait(['@workOrder', '@operatives'])
 
-        cy.fixture('workOrders/workOrder.json').then((workOrder) => {
-          workOrder.reference = 10000040
-          workOrder.canAssignOperative = true
-          workOrder.totalSMVs = 76
-          workOrder.isSplit = true
-          workOrder.operatives = [
-            {
-              id: 1,
-              jobPercentage: 40,
-              name: 'Operative A',
-            },
-            {
-              id: 2,
-              jobPercentage: 60,
-              name: 'Operative B',
-            },
-          ]
-          cy.intercept(
-            { method: 'GET', path: '/api/workOrders/10000040' },
-            { body: workOrder }
-          ).as('workOrder')
+      cy.get('form').within(() => {
+        cy.contains('Select reason for closing')
+          .parent()
+          .within(() => {
+            cy.contains('label', 'Completed').click()
+          })
+
+        cy.get('#date').type('2021-01-23')
+
+        cy.get('[data-testid=completionTime-hour]').type('12')
+        cy.get('[data-testid=completionTime-minutes]').type('00')
+
+        cy.contains('Payment type')
+          .parent()
+          .within(() => {
+            cy.contains('label', 'Close to base').click()
+          })
+
+        cy.get('.operatives').within(() => {
+          cy.get('input[list]').eq(0).type('Operative A [1]')
         })
 
-        cy.intercept(
-          { method: 'GET', path: '/api/operatives' },
-          {
-            body: [
+        cy.get('#notes').type('A note')
+        cy.get('[type="submit"]').contains('Close work order').click()
+      })
+
+      cy.contains('th', 'Payment type').parent().contains('Close to base')
+
+      cy.get('[type="submit"]').contains('Confirm and close').click()
+
+      cy.wait('@apiCheck')
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'have.deep.nested.property',
+          'jobStatusUpdates[0].comments',
+          'Work order closed - A note - Assigned operatives Operative A : 100% - Close to base (Operative payment made)'
+        )
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'have.deep.nested.property',
+          'jobStatusUpdates[0].paymentType',
+          'CloseToBase'
+        )
+    })
+
+    describe('When the order requires operative assignment', () => {
+      describe('And the workorder has existing operatives assigned', () => {
+        beforeEach(() => {
+          cy.fixture('workOrders/workOrder.json').then((workOrder) => {
+            workOrder.reference = 10000040
+            workOrder.canAssignOperative = true
+            workOrder.totalSMVs = 76
+            workOrder.operatives = [
               {
                 id: 1,
                 name: 'Operative A',
@@ -754,271 +528,582 @@ describe('Closing a work order on behalf of an operative', () => {
                 id: 3,
                 name: 'Operative C',
               },
-              {
-                id: 25,
-                name: 'Operative Y',
-              },
-              {
-                id: 26,
-                name: 'Operative Z',
-              },
-            ],
-          }
-        ).as('operatives')
+            ]
+            cy.intercept(
+              { method: 'GET', path: '/api/workOrders/10000040' },
+              { body: workOrder }
+            ).as('workOrder')
+          })
 
-        cy.intercept(
-          { method: 'POST', path: '/api/workOrderComplete' },
-          { body: '' }
-        ).as('workOrderCompleteRequest')
+          cy.intercept(
+            { method: 'POST', path: '/api/workOrderComplete' },
+            { body: '' }
+          ).as('workOrderCompleteRequest')
 
-        cy.intercept(
-          { method: 'POST', path: '/api/jobStatusUpdate' },
-          { body: '' }
-        ).as('jobStatusUpdateRequest')
+          cy.intercept(
+            { method: 'POST', path: '/api/jobStatusUpdate' },
+            { body: '' }
+          ).as('jobStatusUpdateRequest')
+        })
+
+        it('requires total value of split % to be 100', () => {
+          cy.visit('/work-orders/10000040/close')
+
+          cy.wait(['@workOrder', '@operatives'])
+
+          cy.contains('Select reason for closing')
+            .parent()
+            .within(() => {
+              cy.contains('label', 'No access').click()
+            })
+
+          cy.get('#date').type('2021-01-19')
+
+          cy.get('[data-testid=completionTime-hour]').clear()
+          cy.get('[data-testid=completionTime-minutes]').clear()
+
+          cy.get('[data-testid=completionTime-hour]').type('13')
+          cy.get('[data-testid=completionTime-minutes]').type('01')
+
+          cy.get('#notes').type('A note')
+
+          cy.contains('Payment type')
+            .parent()
+            .within(() => {
+              cy.get('[value="Bonus"]').should('be.checked')
+              cy.get('[value="Overtime"]').should('not.be.checked')
+              cy.get('[value="CloseToBase"]').should('not.be.checked')
+
+              cy.contains('label', 'Overtime').click()
+            })
+
+          cy.get('.operatives').within(() => {
+            cy.get('input[list]').should('have.length', 3)
+
+            cy.get('input[list]').eq(0).should('have.value', 'Operative A [1]')
+            cy.get('input[list]').eq(1).should('have.value', 'Operative B [2]')
+            cy.get('input[list]').eq(2).should('have.value', 'Operative C [3]')
+          })
+
+          cy.get('.select-percentage').within(() => {
+            cy.get('select').should('have.length', 3)
+
+            cy.get('select').eq(0).should('have.value', '33.3%')
+            cy.get('select').eq(1).should('have.value', '33.3%')
+            cy.get('select').eq(2).should('have.value', '33.3%')
+          })
+
+          cy.get('.smv-read-only').should('have.length', 3)
+
+          cy.get('.smv-read-only').eq(0).contains('25.31')
+          cy.get('.smv-read-only').eq(1).contains('25.31')
+          cy.get('.smv-read-only').eq(2).contains('25.31')
+
+          cy.get('[type="submit"]').contains('Close work order').click()
+
+          cy.get('.govuk-table__row')
+            .contains('Operatives')
+            .parent()
+            .within(() => {
+              cy.contains(
+                'Operative A : 33.3%, Operative B : 33.3%, Operative C : 33.3%'
+              )
+              cy.get('a').contains('Edit').click()
+            })
+
+          cy.get('.operatives').within(() => {
+            cy.get('input[list]').eq(0).clear()
+            cy.get('input[list]').eq(1).clear()
+            cy.get('input[list]').eq(2).clear()
+          })
+
+          cy.get('[type="submit"]').contains('Close work order').click()
+
+          cy.get('.operatives').within(() => {
+            cy.get('#operative-0-form-group').contains(
+              'Please select an operative'
+            )
+            cy.get('#operative-1-form-group').contains(
+              'Please select an operative'
+            )
+            cy.get('#operative-2-form-group').contains(
+              'Please select an operative'
+            )
+          })
+
+          cy.get('.operatives').within(() => {
+            cy.get('input[list]').eq(0).type('Operative Y [25]')
+            cy.get('input[list]').eq(1).type('Operative A [1]')
+            cy.get('input[list]').eq(2).type('Operative B [2]')
+
+            cy.get('a')
+              .contains(/Add operative from list/)
+              .click()
+
+            cy.get('input[list]').eq(3).type('Operative Z [26]')
+
+            cy.get('input[list]').should('have.length', 4)
+          })
+
+          // total of split percentages is more than 100
+          cy.get('.select-percentage').within(() => {
+            cy.get('select').eq(0).select('70%')
+            cy.get('select').eq(1).select('20%')
+            cy.get('select').eq(2).select('30%')
+            cy.get('select').eq(3).select('10%')
+          })
+
+          cy.get('.smv-read-only').should('have.length', 4)
+
+          cy.get('.smv-read-only').eq(0).contains('53.20')
+          cy.get('.smv-read-only').eq(1).contains('15.20')
+          cy.get('.smv-read-only').eq(2).contains('22.80')
+          cy.get('.smv-read-only').eq(3).contains('7.60')
+
+          cy.get('[type="submit"]').contains('Close work order').click()
+
+          cy.get('.operatives').within(() => {
+            cy.contains(
+              'Work done total across operatives must be equal to 100%'
+            )
+          })
+
+          // now total is 100
+          cy.get('.select-percentage').within(() => {
+            cy.get('select').eq(0).select('70%')
+            cy.get('select').eq(1).select('20%')
+            cy.get('select').eq(2).select('10%')
+            cy.get('select').eq(3).select('-')
+          })
+
+          cy.get('.smv-read-only').should('have.length', 4)
+
+          cy.get('.smv-read-only').eq(0).contains('53.20')
+          cy.get('.smv-read-only').eq(1).contains('15.20')
+          cy.get('.smv-read-only').eq(2).contains('7.60')
+          cy.get('.smv-read-only').eq(3).contains('-')
+
+          cy.get('[type="submit"]').contains('Close work order').click()
+
+          cy.get('.govuk-table__row')
+            .contains('Operatives')
+            .parent()
+            .within(() => {
+              cy.contains(
+                'Operative Y : 70%, Operative A : 20%, Operative B : 10%, Operative Z : -'
+              )
+            })
+
+          cy.get('[type="submit"]').contains('Confirm and close').click()
+
+          cy.wait('@jobStatusUpdateRequest', { requestTimeout: 6000 })
+            .its('request.body')
+            .should('deep.equal', {
+              relatedWorkOrderReference: {
+                id: '10000040',
+              },
+              operativesAssigned: [
+                {
+                  identification: {
+                    number: 25,
+                  },
+                  calculatedBonus: 70,
+                },
+                {
+                  identification: {
+                    number: 1,
+                  },
+                  calculatedBonus: 20,
+                },
+                {
+                  identification: {
+                    number: 2,
+                  },
+                  calculatedBonus: 10,
+                },
+                {
+                  identification: {
+                    number: 26,
+                  },
+                  calculatedBonus: 0,
+                },
+              ],
+              typeCode: '10',
+            })
+
+          cy.wait('@workOrderCompleteRequest')
+
+          cy.get('@workOrderCompleteRequest')
+            .its('request.body')
+            .should('deep.equal', {
+              workOrderReference: {
+                id: '10000040',
+                description: '',
+                allocatedBy: '',
+              },
+              jobStatusUpdates: [
+                {
+                  typeCode: '70',
+                  otherType: 'completed',
+                  comments:
+                    'Work order closed - A note - Assigned operatives Operative Y, Operative A, Operative B, Operative Z - Overtime work order (SMVs not included in Bonus)',
+                  eventTime: '2021-01-19T13:01:00.000Z',
+                  paymentType: 'Overtime',
+                },
+              ],
+            })
+
+          cy.requestsCountByUrl('api/jobStatusUpdate').should('eq', 1)
+
+          cy.audit()
+        })
       })
 
-      it('closes work order with existing pre-split by operative', () => {
-        cy.visit('/work-orders/10000040/close')
+      describe('And has existing operatives assigned and job split was done by operative', () => {
+        beforeEach(() => {
+          cy.intercept(
+            { method: 'GET', path: '/api/filter/WorkOrder' },
+            {
+              fixture: 'filter/workOrder.json',
+            }
+          ).as('workOrderFilters')
 
-        cy.wait(['@workOrder', '@operatives'])
+          cy.intercept(
+            {
+              method: 'GET',
+              path: '/api/workOrders/?PageSize=10&PageNumber=1',
+            },
+            { fixture: 'workOrders/workOrders.json' }
+          ).as('workOrders')
 
+          cy.fixture('workOrders/workOrder.json').then((workOrder) => {
+            workOrder.reference = 10000040
+            workOrder.canAssignOperative = true
+            workOrder.totalSMVs = 76
+            workOrder.isSplit = true
+            workOrder.operatives = [
+              {
+                id: 1,
+                jobPercentage: 40,
+                name: 'Operative A',
+              },
+              {
+                id: 2,
+                jobPercentage: 60,
+                name: 'Operative B',
+              },
+            ]
+            cy.intercept(
+              { method: 'GET', path: '/api/workOrders/10000040' },
+              { body: workOrder }
+            ).as('workOrder')
+          })
+
+          cy.intercept(
+            { method: 'POST', path: '/api/workOrderComplete' },
+            { body: '' }
+          ).as('workOrderCompleteRequest')
+
+          cy.intercept(
+            { method: 'POST', path: '/api/jobStatusUpdate' },
+            { body: '' }
+          ).as('jobStatusUpdateRequest')
+        })
+
+        it('closes work order with existing pre-split by operative', () => {
+          cy.visit('/work-orders/10000040/close')
+
+          cy.wait(['@workOrder', '@operatives'])
+
+          cy.contains('Select reason for closing')
+            .parent()
+            .within(() => {
+              cy.contains('label', 'Completed').click()
+            })
+
+          cy.get('#date').type('2021-01-19')
+
+          cy.get('[data-testid=completionTime-hour]').clear()
+          cy.get('[data-testid=completionTime-minutes]').clear()
+
+          cy.get('[data-testid=completionTime-hour]').type('13')
+          cy.get('[data-testid=completionTime-minutes]').type('01')
+
+          cy.get('#notes').type('A note')
+
+          cy.get('.operatives').within(() => {
+            cy.get('input[list]').should('have.length', 2)
+
+            cy.get('input[list]').eq(0).should('have.value', 'Operative A [1]')
+            cy.get('input[list]').eq(1).should('have.value', 'Operative B [2]')
+          })
+
+          cy.get('.select-percentage').within(() => {
+            cy.get('select').should('have.length', 2)
+
+            cy.get('select').eq(0).should('have.value', '40%')
+            cy.get('select').eq(1).should('have.value', '60%')
+          })
+
+          cy.get('.smv-read-only').should('have.length', 2)
+
+          cy.get('.smv-read-only').eq(0).contains('30.40')
+          cy.get('.smv-read-only').eq(1).contains('45.60')
+
+          cy.get('[type="submit"]').contains('Close work order').click()
+
+          cy.get('.govuk-table__row')
+            .contains('Operatives')
+            .parent()
+            .within(() => {
+              cy.contains('Operative A : 40%, Operative B : 60%')
+            })
+
+          cy.get('[type="submit"]').contains('Confirm and close').click()
+
+          cy.wait('@jobStatusUpdateRequest')
+            .its('request.body')
+            .should('deep.equal', {
+              relatedWorkOrderReference: {
+                id: '10000040',
+              },
+              operativesAssigned: [
+                {
+                  identification: {
+                    number: 1,
+                  },
+                  calculatedBonus: 40,
+                },
+                {
+                  identification: {
+                    number: 2,
+                  },
+                  calculatedBonus: 60,
+                },
+              ],
+              typeCode: '10',
+            })
+
+          cy.wait('@workOrderCompleteRequest')
+
+          cy.get('@workOrderCompleteRequest')
+            .its('request.body')
+            .should('deep.equal', {
+              workOrderReference: {
+                id: '10000040',
+                description: '',
+                allocatedBy: '',
+              },
+              jobStatusUpdates: [
+                {
+                  typeCode: '0',
+                  otherType: 'completed',
+                  comments:
+                    'Work order closed - A note - Assigned operatives Operative A : 40%, Operative B : 60% - Bonus calculation',
+                  eventTime: '2021-01-19T13:01:00.000Z',
+                  paymentType: 'Bonus',
+                },
+              ],
+            })
+
+          cy.requestsCountByUrl('api/jobStatusUpdate').should('eq', 1)
+
+          cy.audit()
+        })
+      })
+
+      describe('And the workorder has no existing operatives assigned', () => {
+        beforeEach(() => {
+          // Viewing the work order page
+          cy.fixture('workOrders/workOrder.json').then((workOrder) => {
+            workOrder.reference = 10000040
+            workOrder.contractorReference = 'H10' // DLO contractor reference
+            workOrder.canAssignOperative = true
+            workOrder.operatives = []
+            cy.intercept(
+              { method: 'GET', path: '/api/workOrders/10000040' },
+              { body: workOrder }
+            ).as('workOrder')
+          })
+
+          cy.intercept(
+            { method: 'POST', path: '/api/workOrderComplete' },
+            { body: '' }
+          ).as('workOrderCompleteRequest')
+
+          cy.intercept(
+            { method: 'POST', path: '/api/jobStatusUpdate' },
+            { body: '' }
+          ).as('jobStatusUpdateRequest')
+        })
+
+        it('requires the submission of at least one operative', () => {
+          cy.visit('/work-orders/10000040/close')
+
+          cy.wait(['@workOrder', '@operatives'])
+
+          cy.get('.operatives').within(() => {
+            cy.get('input[list]').should('have.length', 1)
+
+            cy.get('input[list]').eq(0).should('have.value', '')
+          })
+
+          cy.get('[type="submit"]').contains('Close work order').click()
+
+          cy.get('.operatives').within(() => {
+            cy.get('#operative-0-form-group').contains(
+              'Please select an operative'
+            )
+          })
+
+          cy.contains('Select reason for closing')
+            .parent()
+            .within(() => {
+              cy.contains('label', 'No access').click()
+            })
+
+          cy.get('#date').type('2021-01-19')
+
+          cy.get('[data-testid=completionTime-hour]').clear()
+          cy.get('[data-testid=completionTime-minutes]').clear()
+
+          cy.get('[data-testid=completionTime-hour]').type('13')
+          cy.get('[data-testid=completionTime-minutes]').type('01')
+
+          cy.get('#notes').type('A note')
+
+          cy.get('.operatives').within(() => {
+            cy.get('input[list]').eq(0).type('Operative Y [25]')
+            cy.get('input[list]').should('have.length', 1)
+          })
+
+          // should add 100% by default
+          cy.get('.select-percentage').within(() => {
+            cy.get('select').eq(0).should('have.value', '100%')
+          })
+
+          cy.get('.smv-read-only').should('have.length', 1)
+
+          cy.get('.smv-read-only').eq(0).contains('76')
+
+          cy.get('[type="submit"]').contains('Close work order').click()
+
+          cy.get('.govuk-table__row')
+            .contains('Operatives')
+            .parent()
+            .within(() => {
+              cy.contains('Operative Y : 100%')
+            })
+
+          cy.get('[type="submit"]').contains('Confirm and close').click()
+
+          cy.wait('@jobStatusUpdateRequest')
+            .its('request.body')
+            .should('deep.equal', {
+              relatedWorkOrderReference: {
+                id: '10000040',
+              },
+              operativesAssigned: [
+                {
+                  identification: {
+                    number: 25,
+                  },
+                  calculatedBonus: 100,
+                },
+              ],
+              typeCode: '10',
+            })
+
+          cy.wait('@workOrderCompleteRequest')
+
+          cy.get('@workOrderCompleteRequest')
+            .its('request.body')
+            .should('deep.equal', {
+              workOrderReference: {
+                id: '10000040',
+                description: '',
+                allocatedBy: '',
+              },
+              jobStatusUpdates: [
+                {
+                  typeCode: '70',
+                  otherType: 'completed',
+                  comments:
+                    'Work order closed - A note - Assigned operatives Operative Y : 100% - Bonus calculation',
+                  eventTime: '2021-01-19T13:01:00.000Z',
+                  paymentType: 'Bonus',
+                },
+              ],
+            })
+
+          cy.requestsCountByUrl('api/jobStatusUpdate').should('eq', 1)
+
+          cy.audit()
+        })
+      })
+    })
+  })
+
+  describe('when the work does not allow operative and payment type selection', () => {
+    beforeEach(() => {
+      cy.fixture('workOrders/workOrder.json').then((workOrder) => {
+        workOrder.reference = 10000040
+        workOrder.canAssignOperative = false
+
+        cy.intercept(
+          { method: 'GET', path: '/api/workOrders/10000040' },
+          { body: workOrder }
+        ).as('workOrder')
+      })
+    })
+
+    it('payment type and operative selection is not possible', () => {
+      cy.visit('/work-orders/10000040/close')
+
+      cy.wait(['@workOrder'])
+
+      cy.get('form').within(() => {
         cy.contains('Select reason for closing')
           .parent()
           .within(() => {
             cy.contains('label', 'Completed').click()
           })
 
-        cy.get('#date').type('2021-01-19')
+        cy.get('#date').type('2021-01-23')
 
-        cy.get('[data-testid=completionTime-hour]').clear()
-        cy.get('[data-testid=completionTime-minutes]').clear()
+        cy.get('[data-testid=completionTime-hour]').type('12')
+        cy.get('[data-testid=completionTime-minutes]').type('00')
 
-        cy.get('[data-testid=completionTime-hour]').type('13')
-        cy.get('[data-testid=completionTime-minutes]').type('01')
-
-        cy.get('#notes').type('A note')
-
-        cy.get('.operatives').within(() => {
-          cy.get('input[list]').should('have.length', 2)
-
-          cy.get('input[list]').eq(0).should('have.value', 'Operative A [1]')
-          cy.get('input[list]').eq(1).should('have.value', 'Operative B [2]')
-        })
-
-        cy.get('.select-percentage').within(() => {
-          cy.get('select').should('have.length', 2)
-
-          cy.get('select').eq(0).should('have.value', '40%')
-          cy.get('select').eq(1).should('have.value', '60%')
-        })
-
-        cy.get('.smv-read-only').should('have.length', 2)
-
-        cy.get('.smv-read-only').eq(0).contains('30.40')
-        cy.get('.smv-read-only').eq(1).contains('45.60')
-
-        cy.get('[type="submit"]').contains('Close work order').click()
-
-        cy.get('.govuk-table__row')
-          .contains('Operatives')
-          .parent()
-          .within(() => {
-            cy.contains('Operative A : 40%, Operative B : 60%')
-          })
-
-        cy.get('[type="submit"]').contains('Confirm and close').click()
-
-        cy.wait('@jobStatusUpdateRequest')
-          .its('request.body')
-          .should('deep.equal', {
-            relatedWorkOrderReference: {
-              id: '10000040',
-            },
-            operativesAssigned: [
-              {
-                identification: {
-                  number: 1,
-                },
-                calculatedBonus: 40,
-              },
-              {
-                identification: {
-                  number: 2,
-                },
-                calculatedBonus: 60,
-              },
-            ],
-            typeCode: '10',
-          })
-
-        cy.wait('@workOrderCompleteRequest')
-
-        cy.get('@workOrderCompleteRequest')
-          .its('request.body')
-          .should('deep.equal', {
-            workOrderReference: {
-              id: '10000040',
-              description: '',
-              allocatedBy: '',
-            },
-            jobStatusUpdates: [
-              {
-                typeCode: '0',
-                otherType: 'completed',
-                comments:
-                  'Work order closed - A note - Assigned operatives Operative A : 40%, Operative B : 60% - Bonus calculation',
-                eventTime: '2021-01-19T13:01:00.000Z',
-                paymentType: 'Bonus',
-              },
-            ],
-          })
-
-        cy.requestsCountByUrl('api/jobStatusUpdate').should('eq', 1)
-
-        cy.audit()
-      })
-    })
-
-    describe('And the workorder has no existing operatives assigned', () => {
-      beforeEach(() => {
-        // Viewing the work order page
-        cy.fixture('workOrders/workOrder.json').then((workOrder) => {
-          workOrder.reference = 10000040
-          workOrder.contractorReference = 'H10' // DLO contractor reference
-          workOrder.canAssignOperative = true
-          workOrder.operatives = []
-          cy.intercept(
-            { method: 'GET', path: '/api/workOrders/10000040' },
-            { body: workOrder }
-          ).as('workOrder')
-        })
-
-        cy.intercept(
-          { method: 'GET', path: '/api/operatives' },
-          {
-            body: [
-              {
-                id: 25,
-                name: 'Operative Y',
-              },
-            ],
-          }
-        ).as('operatives')
-
-        cy.intercept(
-          { method: 'POST', path: '/api/workOrderComplete' },
-          { body: '' }
-        ).as('workOrderCompleteRequest')
-
-        cy.intercept(
-          { method: 'POST', path: '/api/jobStatusUpdate' },
-          { body: '' }
-        ).as('jobStatusUpdateRequest')
-      })
-
-      it('requires the submission of at least one operative', () => {
-        cy.visit('/work-orders/10000040/close')
-
-        cy.wait(['@workOrder', '@operatives'])
-
-        cy.get('.operatives').within(() => {
-          cy.get('input[list]').should('have.length', 1)
-
-          cy.get('input[list]').eq(0).should('have.value', '')
-        })
-
-        cy.get('[type="submit"]').contains('Close work order').click()
-
-        cy.get('.operatives').within(() => {
-          cy.get('#operative-0-form-group').contains(
-            'Please select an operative'
-          )
-        })
-
-        cy.contains('Select reason for closing')
-          .parent()
-          .within(() => {
-            cy.contains('label', 'No access').click()
-          })
-
-        cy.get('#date').type('2021-01-19')
-
-        cy.get('[data-testid=completionTime-hour]').clear()
-        cy.get('[data-testid=completionTime-minutes]').clear()
-
-        cy.get('[data-testid=completionTime-hour]').type('13')
-        cy.get('[data-testid=completionTime-minutes]').type('01')
+        cy.contains('operative', { matchCase: false }).should('not.exist')
+        cy.contains('payment type', { matchCase: false }).should('not.exist')
 
         cy.get('#notes').type('A note')
-
-        cy.get('.operatives').within(() => {
-          cy.get('input[list]').eq(0).type('Operative Y [25]')
-          cy.get('input[list]').should('have.length', 1)
-        })
-
-        // should add 100% by default
-        cy.get('.select-percentage').within(() => {
-          cy.get('select').eq(0).should('have.value', '100%')
-        })
-
-        cy.get('.smv-read-only').should('have.length', 1)
-
-        cy.get('.smv-read-only').eq(0).contains('76')
-
         cy.get('[type="submit"]').contains('Close work order').click()
-
-        cy.get('.govuk-table__row')
-          .contains('Operatives')
-          .parent()
-          .within(() => {
-            cy.contains('Operative Y : 100%')
-          })
-
-        cy.get('[type="submit"]').contains('Confirm and close').click()
-
-        cy.wait('@jobStatusUpdateRequest')
-          .its('request.body')
-          .should('deep.equal', {
-            relatedWorkOrderReference: {
-              id: '10000040',
-            },
-            operativesAssigned: [
-              {
-                identification: {
-                  number: 25,
-                },
-                calculatedBonus: 100,
-              },
-            ],
-            typeCode: '10',
-          })
-
-        cy.wait('@workOrderCompleteRequest')
-
-        cy.get('@workOrderCompleteRequest')
-          .its('request.body')
-          .should('deep.equal', {
-            workOrderReference: {
-              id: '10000040',
-              description: '',
-              allocatedBy: '',
-            },
-            jobStatusUpdates: [
-              {
-                typeCode: '70',
-                otherType: 'completed',
-                comments:
-                  'Work order closed - A note - Assigned operatives Operative Y : 100% - Bonus calculation',
-                eventTime: '2021-01-19T13:01:00.000Z',
-                paymentType: 'Bonus',
-              },
-            ],
-          })
-
-        cy.requestsCountByUrl('api/jobStatusUpdate').should('eq', 1)
-
-        cy.audit()
       })
+
+      cy.contains('th', 'Payment type').parent().contains('N/A')
+
+      cy.get('[type="submit"]').contains('Confirm and close').click()
+
+      cy.wait('@apiCheck')
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'have.deep.nested.property',
+          'jobStatusUpdates[0].comments',
+          'Work order closed - A note'
+        )
+
+      // no operative assignment request made
+      cy.requestsCountByUrl('/api/jobStatusUpdate').should('eq', 0)
+
+      cy.get('@apiCheck')
+        .its('request.body')
+        .should(
+          'not.have.deep.nested.property',
+          'jobStatusUpdates[0].paymentType'
+        )
     })
   })
 })

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -28,7 +28,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
   const [error, setError] = useState()
   const [notes, setNotes] = useState('')
   const [reason, setReason] = useState('')
-  const [paymentType, setPaymentType] = useState('')
+  const [paymentType, setPaymentType] = useState(null)
   const [availableOperatives, setAvailableOperatives] = useState([])
   const [selectedOperatives, setSelectedOperatives] = useState([])
   const [workOrder, setWorkOrder] = useState()
@@ -84,9 +84,10 @@ const CloseWorkOrderByProxy = ({ reference }) => {
       })
 
       setWorkOrder(new WorkOrder(workOrder))
-      workOrder.paymentType && setPaymentType(workOrder.paymentType)
 
       if (workOrder.canAssignOperative) {
+        workOrder.paymentType && setPaymentType(workOrder.paymentType)
+
         setSelectedOperatives(workOrder.operatives)
 
         const operatives = await frontEndApiRequest({
@@ -181,7 +182,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     setReason(formData.reason)
     setNotes(formData.notes)
     setDateToShow(formData.date)
-    setPaymentType(formData.paymentType)
+    formData.paymentType && setPaymentType(formData.paymentType)
     changeCurrentPage()
     setCompletionTime(formData.completionTime)
   }

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -98,35 +98,39 @@ const CloseWorkOrderForm = ({
           />
 
           {operativeAssignmentMandatory && (
-            <SelectOperatives
-              assignedOperativesToWorkOrder={assignedOperativesToWorkOrder}
-              availableOperatives={availableOperatives}
-              register={register}
-              errors={errors}
-              selectedPercentagesToShowOnEdit={selectedPercentagesToShowOnEdit}
-              trigger={trigger}
-              getValues={getValues}
-              totalSMV={totalSMV}
-              jobIsSplitByOperative={jobIsSplitByOperative}
-            />
-          )}
+            <>
+              <SelectOperatives
+                assignedOperativesToWorkOrder={assignedOperativesToWorkOrder}
+                availableOperatives={availableOperatives}
+                register={register}
+                errors={errors}
+                selectedPercentagesToShowOnEdit={
+                  selectedPercentagesToShowOnEdit
+                }
+                trigger={trigger}
+                getValues={getValues}
+                totalSMV={totalSMV}
+                jobIsSplitByOperative={jobIsSplitByOperative}
+              />
 
-          <Radios
-            label="Payment type"
-            name="paymentType"
-            options={optionsForPaymentType({
-              paymentTypes: [
-                BONUS_PAYMENT_TYPE,
-                OVERTIME_PAYMENT_TYPE,
-                CLOSE_TO_BASE_PAYMENT_TYPE,
-              ],
-              currentPaymentType: paymentType,
-            })}
-            register={register({
-              required: 'Provide payment type',
-            })}
-            error={errors && errors.paymentType}
-          />
+              <Radios
+                label="Payment type"
+                name="paymentType"
+                options={optionsForPaymentType({
+                  paymentTypes: [
+                    BONUS_PAYMENT_TYPE,
+                    OVERTIME_PAYMENT_TYPE,
+                    CLOSE_TO_BASE_PAYMENT_TYPE,
+                  ],
+                  currentPaymentType: paymentType,
+                })}
+                register={register({
+                  required: 'Provide payment type',
+                })}
+                error={errors && errors.paymentType}
+              />
+            </>
+          )}
 
           <TextArea
             name="notes"

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.js
@@ -35,15 +35,21 @@ const SummaryCloseWorkOrder = ({
                 </a>
               </TD>
             </TR>
+
             <TR>
               <TH scope="row">Payment type</TH>
-              <TD>{PAYMENT_TYPE_FORM_DESCRIPTIONS[paymentType].text}</TD>
+              <TD>
+                {paymentType
+                  ? PAYMENT_TYPE_FORM_DESCRIPTIONS[paymentType].text
+                  : 'N/A'}
+              </TD>
               <TD>
                 <a className="lbh-link" onClick={changeStep} href="#">
                   Edit
                 </a>
               </TD>
             </TR>
+
             {operativeNames && (
               <TR>
                 <TH scope="row">Operatives</TH>
@@ -55,6 +61,7 @@ const SummaryCloseWorkOrder = ({
                 </TD>
               </TR>
             )}
+
             <TR>
               <TH scope="row">Reason</TH>
               <TD>{reason}</TD>
@@ -64,6 +71,7 @@ const SummaryCloseWorkOrder = ({
                 </a>
               </TD>
             </TR>
+
             <TR>
               <TH scope="row">Notes</TH>
               <TD>{notes}</TD>
@@ -89,7 +97,7 @@ SummaryCloseWorkOrder.propTypes = {
   date: PropTypes.string,
   changeStep: PropTypes.func.isRequired,
   reason: PropTypes.string.isRequired,
-  paymentType: PropTypes.string.isRequired,
+  paymentType: PropTypes.string,
 }
 
 export default SummaryCloseWorkOrder

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.js
@@ -22,7 +22,7 @@ export const buildCloseWorkOrderData = (
         otherType: 'completed',
         comments: `Work order closed - ${notes}`,
         eventTime: completionDate,
-        paymentType,
+        ...(paymentType && { paymentType }),
       },
     ],
   }
@@ -60,5 +60,7 @@ export const buildWorkOrderCompleteNotes = (
           .join(' - ')
       : notes
 
-  return [notes, workOrderNoteFragmentForPaymentType(paymentType)].join(' - ')
+  return [notes, workOrderNoteFragmentForPaymentType(paymentType)]
+    .filter((x) => x)
+    .join(' - ')
 }

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
@@ -100,13 +100,11 @@ describe('buildWorkOrderCompleteNotes', () => {
   })
 
   describe('when there are no operative percentages', () => {
-    describe('and paymentType is Overtime', () => {
-      it('mentions overtime in the notes', () => {
+    describe('and paymentType is null', () => {
+      it('returns the notes only', () => {
         expect(
-          buildWorkOrderCompleteNotes('Comment from user', {}, 'Overtime')
-        ).toEqual(
-          'Comment from user - Overtime work order (SMVs not included in Bonus)'
-        )
+          buildWorkOrderCompleteNotes('Comment from user', {}, null)
+        ).toEqual('Comment from user')
       })
     })
   })

--- a/src/utils/paymentTypes.js
+++ b/src/utils/paymentTypes.js
@@ -34,6 +34,10 @@ export const optionsForPaymentType = ({
 }
 
 export const workOrderNoteFragmentForPaymentType = (paymentType) => {
+  if (!paymentType) {
+    return ''
+  }
+
   const paymentTypeText = PAYMENT_TYPE_FORM_DESCRIPTIONS[paymentType]
 
   return [


### PR DESCRIPTION
### Description of change

Make payment type selection only available when a manager is closing a DLO work order.

This is detected by using the `canAssignOperative` field in the work order response.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/181416900

### Automated test checklist

If a type of test isn't included, add note explaining why.

- [x] Unit tests (Jest)
- [x] Integration tests (Cypress)

### UI Changes

Closing a work order that does not require operative assignment no longer includes payment type selection

![image](https://user-images.githubusercontent.com/1370570/156606456-5f258c46-bc68-4291-ada4-8fad55daa914.png)


Closing a work order that requires operative assignment still includes payment type selection

![image](https://user-images.githubusercontent.com/1370570/156606371-398276a8-175c-468d-899e-c85d4d21328d.png)
