### PR TITLE
Avoid caching requests to filter endpoint

### DIFF
--- a/src/pages/api/[...path].test.js
+++ b/src/pages/api/[...path].test.js
@@ -222,7 +222,6 @@ describe('/api/[...path]', () => {
 
     describe('caching the API responses in memory', () => {
       ;[
-        'api/filter/workOrder',
         'api/properties',
         'api/properties/01234567',
         'api/properties/01234567/alerts',

--- a/src/utils/middleware/cache.js
+++ b/src/utils/middleware/cache.js
@@ -19,7 +19,6 @@ const validateCacheRequest = (url) => {
   return Boolean(
     url.match(new RegExp('^.*/properties.*$')) ||
       url.match(new RegExp('^.*/schedule-of-rates/.*$')) ||
-      url.match(new RegExp('^.*/filter/.*$')) ||
       url.match(new RegExp('^.*/contractors.*$'))
   )
 }


### PR DESCRIPTION
Requests can of course come from different users and therefore have different filter configurations - occasionally a user is seeing the previous user's filters.

Fix for https://www.pivotaltracker.com/story/show/180247139