### PR TITLE
Update frontend 'Completed' work order status but remain backwards compatible with API

### DIFF
--- a/src/models/workOrder.js
+++ b/src/models/workOrder.js
@@ -7,7 +7,7 @@ import {
 import {
   CLOSED_STATUS_DESCRIPTIONS,
   CLOSED_STATUS_DESCRIPTIONS_FOR_OPERATIVES,
-  STATUS_COMPLETE,
+  STATUS_COMPLETED,
 } from '@/utils/statusCodes'
 
 export class WorkOrder {
@@ -28,7 +28,7 @@ export class WorkOrder {
   }
 
   completionReason = () => {
-    return this.status === STATUS_COMPLETE.description
+    return this.status === STATUS_COMPLETED.description
       ? 'Completed'
       : this.status
   }

--- a/src/models/workOrder.js
+++ b/src/models/workOrder.js
@@ -7,7 +7,6 @@ import {
 import {
   CLOSED_STATUS_DESCRIPTIONS,
   CLOSED_STATUS_DESCRIPTIONS_FOR_OPERATIVES,
-  STATUS_COMPLETED,
 } from '@/utils/statusCodes'
 
 export class WorkOrder {
@@ -28,9 +27,7 @@ export class WorkOrder {
   }
 
   completionReason = () => {
-    return this.status === STATUS_COMPLETED.description
-      ? 'Completed'
-      : this.status
+    return this.status === 'Work Completed' ? 'Completed' : this.status
   }
 
   appointmentISODatePassed = () => {

--- a/src/models/workOrder.test.js
+++ b/src/models/workOrder.test.js
@@ -11,7 +11,7 @@ import {
 import {
   CLOSED_STATUS_DESCRIPTIONS,
   CLOSED_STATUS_DESCRIPTIONS_FOR_OPERATIVES,
-  STATUS_COMPLETE,
+  STATUS_COMPLETED,
   WORK_ORDERS_STATUSES,
 } from '@/utils/statusCodes'
 import { WorkOrder } from './workOrder'
@@ -153,13 +153,13 @@ describe('WorkOrder', () => {
 
   describe('completionReason()', () => {
     it('returns Completed when the status is work complete', () => {
-      const workOrder = new WorkOrder({ status: STATUS_COMPLETE.description })
+      const workOrder = new WorkOrder({ status: STATUS_COMPLETED.description })
 
       expect(workOrder.completionReason()).toBe('Completed')
     })
 
     WORK_ORDERS_STATUSES.filter(
-      (status) => status !== STATUS_COMPLETE.description
+      (status) => status !== STATUS_COMPLETED.description
     ).forEach((status) => {
       it(`returns the status description when the status is ${status}`, () => {
         const workOrder = new WorkOrder({ status })

--- a/src/models/workOrder.test.js
+++ b/src/models/workOrder.test.js
@@ -159,7 +159,8 @@ describe('WorkOrder', () => {
     })
 
     WORK_ORDERS_STATUSES.filter(
-      (status) => status !== STATUS_COMPLETED.description
+      (status) =>
+        status !== STATUS_COMPLETED.description && status !== 'Work Completed'
     ).forEach((status) => {
       it(`returns the status description when the status is ${status}`, () => {
         const workOrder = new WorkOrder({ status })

--- a/src/utils/statusCodes.js
+++ b/src/utils/statusCodes.js
@@ -58,6 +58,7 @@ export const WORK_ORDERS_STATUSES = [
   STATUS_VARIATION_APPROVED.description,
   STATUS_VARIATION_REJECTED.description,
   STATUS_NO_ACCESS.description,
+  'Work Completed', // can be deleted following backend release of PR #641
 ]
 
 export const CLOSED_STATUS_DESCRIPTIONS = [
@@ -65,9 +66,11 @@ export const CLOSED_STATUS_DESCRIPTIONS = [
   STATUS_AUTHORISATION_PENDING_APPROVAL.description,
   STATUS_COMPLETED.description,
   STATUS_NO_ACCESS.description,
+  'Work Completed', // can be deleted following backend release of PR #641
 ]
 
 export const CLOSED_STATUS_DESCRIPTIONS_FOR_OPERATIVES = [
   STATUS_COMPLETED.description,
   STATUS_NO_ACCESS.description,
+  'Work Completed', // can be deleted following backend release of PR #641
 ]

--- a/src/utils/statusCodes.js
+++ b/src/utils/statusCodes.js
@@ -3,7 +3,7 @@ export const STATUS_IN_PROGRESS = {
   description: 'In Progress',
 }
 
-export const STATUS_COMPLETE = {
+export const STATUS_COMPLETED = {
   code: 50,
   description: 'Work Completed',
 }
@@ -51,7 +51,7 @@ export const CLOSURE_STATUS_OPTIONS = [
 
 export const WORK_ORDERS_STATUSES = [
   STATUS_IN_PROGRESS.description,
-  STATUS_COMPLETE.description,
+  STATUS_COMPLETED.description,
   STATUS_CANCELLED.description,
   STATUS_VARIATION_PENDING_APPROVAL.description,
   STATUS_AUTHORISATION_PENDING_APPROVAL.description,
@@ -63,11 +63,11 @@ export const WORK_ORDERS_STATUSES = [
 export const CLOSED_STATUS_DESCRIPTIONS = [
   STATUS_CANCELLED.description,
   STATUS_AUTHORISATION_PENDING_APPROVAL.description,
-  STATUS_COMPLETE.description,
+  STATUS_COMPLETED.description,
   STATUS_NO_ACCESS.description,
 ]
 
 export const CLOSED_STATUS_DESCRIPTIONS_FOR_OPERATIVES = [
-  STATUS_COMPLETE.description,
+  STATUS_COMPLETED.description,
   STATUS_NO_ACCESS.description,
 ]

--- a/src/utils/statusCodes.js
+++ b/src/utils/statusCodes.js
@@ -5,7 +5,7 @@ export const STATUS_IN_PROGRESS = {
 
 export const STATUS_COMPLETED = {
   code: 50,
-  description: 'Work Completed',
+  description: 'Completed',
 }
 
 export const STATUS_CANCELLED = {


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/n/projects/2500129/stories/181170856

PR https://github.com/LBHackney-IT/repairs-api-dotnet/pull/641 on the backend will modify all relevant statuses to new copy 'Completed'.

Since the frontend has and uses knowledge of specific work status strings, including this one, this PR includes a [commit](https://github.com/LBHackney-IT/repairs-hub-frontend/pull/611/commits/7abbc66427ad95dca35ad226a05d80d8b23c660b) which allows the frontend to work with both strings. This is so there isn't unexpected behaviour between deploying the backend and frontend.

Having the backend deployed before the frontend shouldn't affect any important workflows, but this has been done as a precaution.

That [commit](https://github.com/LBHackney-IT/repairs-hub-frontend/commit/e0b8532e97e4d32d557c7d1ed82bc64b8b6420df) can be reverted once the above backend PR is on production.