### PR TITLE
[DO NOT REVIEW] Ignore absent fields in close summary table

### DIFF
--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -81,7 +81,7 @@ describe('Raise repair form', () => {
       {
         method: 'GET',
         path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01&isRaisable=true',
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01&isRaisable=true?q=*',
       },
       { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     ).as('sorCodesRequest')
@@ -113,7 +113,7 @@ describe('Raise repair form', () => {
       }
     ).as('apiCheck')
 
-    cy.clock(now)
+    cy.clock(now, ['Date'])
   })
 
   it('Validates missing form inputs', () => {
@@ -212,12 +212,11 @@ describe('Raise repair form', () => {
 
       // Contractor select is no longer disabled but sor code selection still is
       cy.get('#contractor').should('not.be.disabled')
-      cy.get('input[id="rateScheduleItems[0][code]"]').should('be.disabled')
-      cy.get('input[id="rateScheduleItems[0][quantity]"]').should('be.disabled')
+
+      // cy.get('input[id="rateScheduleItems[0][code]"]').should('be.disabled')
+      // cy.get('input[id="rateScheduleItems[0][quantity]"]').should('be.disabled')
       // Select a contractor
       cy.get('#contractor').type('HH General Building Repair - H01')
-
-      cy.wait('@sorCodesRequest')
 
       // SOR select is no longer disabled
       cy.get('input[id="rateScheduleItems[0][code]"]').should('not.be.disabled')
@@ -226,9 +225,17 @@ describe('Raise repair form', () => {
       )
       // Priority disabled until SOR is selected
       cy.get('#priorityCode').should('be.disabled')
-      cy.get('input[id="rateScheduleItems[0][code]"]').type(
-        'INP5R001 - Pre insp of wrks by Constructr'
-      )
+      cy.get('input[id="rateScheduleItems[0][code]"]')
+        .clear()
+        .type('INP')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type(
+            '5R001 - Pre insp of wrks by Constructr{enter}'
+          )
+        })
+
       cy.get('#priorityCode').should('not.be.disabled')
 
       // Selecting no trade clears contractor and SOR code select options
@@ -251,34 +258,51 @@ describe('Raise repair form', () => {
 
       cy.get('#contractor').type('HH General Building Repair - H01')
 
-      cy.wait('@sorCodesRequest')
-
       // Select SOR code with no priority attached
-      cy.get('input[id="rateScheduleItems[0][code]"]').type(
-        'INP5R001 - Pre insp of wrks by Constructr'
-      )
+      cy.get('input[id="rateScheduleItems[0][code]"]')
+        .clear()
+        .type('INP')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type(
+            '5R001 - Pre insp of wrks by Constructr{enter}'
+          )
+        })
+
       // Does not autopopulate priority description
       cy.get('#priorityCode').should('have.value', '')
 
       // Select SOR code with priority attached
       cy.get('input[id="rateScheduleItems[0][code]"]')
         .clear()
-        .type('DES5R003 - Immediate call outs')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
 
-      // Autopopulates priority description
-      cy.get('#priorityCode')
-        .find('option:selected')
-        .should('have.text', '1 [I] IMMEDIATE')
+          cy.wrap(datalist).type('5R003 - Immediate call outs{enter}')
 
-      // Removes Task Priority validation errors
-      cy.get('#priorityCode-form-group .govuk-error-message').should(
-        'not.exist'
-      )
+          // Autopopulates priority description
+          cy.get('#priorityCode')
+            .find('option:selected')
+            .should('have.text', '1 [I] IMMEDIATE')
+
+          // Removes Task Priority validation errors
+          cy.get('#priorityCode-form-group .govuk-error-message').should(
+            'not.exist'
+          )
+        })
 
       // Select another SOR code
       cy.get('input[id="rateScheduleItems[0][code]"]')
         .clear()
-        .type('DES5R004 - Emergency call out')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R004 - Emergency call out{enter}')
+        })
+
       // Autopopulates priority description
       cy.get('#priorityCode')
         .find('option:selected')
@@ -301,9 +325,15 @@ describe('Raise repair form', () => {
       ).within(() => {
         cy.contains('Please select an SOR code')
       })
+
       cy.get('input[id="rateScheduleItems[0][code]"]')
         .clear()
-        .type('DES5R005 - Normal call outs')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R005 - Normal call outs{enter}')
+        })
 
       // Enter a blank quantity
       cy.get('input[id="rateScheduleItems[0][quantity]"]').type('x')
@@ -372,9 +402,18 @@ describe('Raise repair form', () => {
       cy.get('.remove-rate-schedule-item').contains('-')
 
       // Select SOR Code from dropdown
+
       cy.get('input[id="rateScheduleItems[1][code]"]')
         .clear()
-        .type('DES5R013 - Inspect additional sec entrance')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type(
+            '5R013 - Inspect additional sec entrance{enter}'
+          )
+        })
+
       // Priority description should remain same because inspection is a lower priority than normal
       cy.get('#priorityCode')
         .find('option:selected')
@@ -382,9 +421,14 @@ describe('Raise repair form', () => {
 
       // Add another SOR code with higher priority
       cy.contains('+ Add another SOR code').click()
-      cy.get('input[id="rateScheduleItems[2][code]"]').type(
-        'DES5R003 - Immediate call outs'
-      )
+      cy.get('input[id="rateScheduleItems[2][code]"]')
+        .clear()
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R003 - Immediate call outs{enter}')
+        })
       // Autopopulates priority description with the highest priority
       cy.get('#priorityCode')
         .find('option:selected')
@@ -392,9 +436,16 @@ describe('Raise repair form', () => {
 
       // Add another SOR code with an emergency priority
       cy.contains('+ Add another SOR code').click()
+      cy.get('input[id="rateScheduleItems[3][code]"]').clear().type('DES')
+
       cy.get('input[id="rateScheduleItems[3][code]"]')
         .clear()
-        .type('DES5R004 - Emergency call out')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R004 - Emergency call out{enter}')
+        })
 
       cy.get('#priorityCode')
         .find('option:selected')
@@ -411,12 +462,19 @@ describe('Raise repair form', () => {
         .find('option:selected')
         .should('have.text', '5 [N] NORMAL')
       // Select SOR code with emergency priority at index 1
+
       cy.get('input[id="rateScheduleItems[1][code]"]')
         .clear()
-        .type('DES5R004 - Emergency call out')
-      cy.get('#priorityCode')
-        .find('option:selected')
-        .should('have.text', '2 [E] EMERGENCY')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R004 - Emergency call out{enter}')
+
+          cy.get('#priorityCode')
+            .find('option:selected')
+            .should('have.text', '2 [E] EMERGENCY')
+        })
 
       // Try to submit form without quantity for this SOR code at index 1
       cy.get('[type="submit"]')
@@ -436,9 +494,16 @@ describe('Raise repair form', () => {
         cy.contains('Please select an SOR code')
       })
       // Enter SOR code and quantity
+
       cy.get('input[id="rateScheduleItems[1][code]"]')
         .clear()
-        .type('DES5R005 - Normal call outs')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R005 - Normal call outs{enter}')
+        })
+
       cy.get(
         'div[id="rateScheduleItems[1][code]-form-group"] .govuk-error-message'
       ).should('not.exist')
@@ -448,9 +513,16 @@ describe('Raise repair form', () => {
       ).should('not.exist')
       // Add another SOR code
       cy.contains('+ Add another SOR code').click()
-      cy.get('input[id="rateScheduleItems[2][code]"]')
+
+      cy.get('input[id="rateScheduleItems[1][code]"]')
         .clear()
-        .type('DES5R006 - Urgent call outs')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R006 - Urgent call outs{enter}')
+        })
+
       cy.get('input[id="rateScheduleItems[2][quantity]"]').clear().type('2')
       // Delete the SOR code at the targeted index
       cy.get('button[id="remove-rate-schedule-item-1"]').click()
@@ -461,9 +533,16 @@ describe('Raise repair form', () => {
       )
       // Remaining SOR codes
       cy.get('button[id="remove-rate-schedule-item-1"]').should('not.exist')
+
       cy.get('input[id="rateScheduleItems[0][code]"]')
         .clear()
-        .type('DES5R004 - Emergency call out')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R004 - Emergency call out{enter}')
+        })
+
       cy.get('input[id="rateScheduleItems[0][code]"]').should(
         'have.value',
         'DES5R004 - Emergency call out'
@@ -473,10 +552,16 @@ describe('Raise repair form', () => {
         '1'
       )
       cy.get('button[id="remove-rate-schedule-item-0"]').should('not.exist')
-      cy.get('input[id="rateScheduleItems[2][code]"]').should(
-        'have.value',
-        'DES5R006 - Urgent call outs'
-      )
+
+      cy.get('input[id="rateScheduleItems[2][code]"]')
+        .clear()
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R006 - Urgent call outs{enter}')
+        })
+
       cy.get('input[id="rateScheduleItems[2][quantity]"]').should(
         'have.value',
         '2'
@@ -660,6 +745,86 @@ describe('Raise repair form', () => {
     cy.audit()
   })
 
+  it('Searches SOR codes after entering three characters with a debounced API request', () => {
+    cy.visit('/properties/00012345/raise-repair/new')
+
+    cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+
+    cy.get('#repair-request-form').within(() => {
+      cy.get('#trade').type('Plumbing - PL')
+
+      cy.wait('@contractorsRequest')
+
+      cy.get('#contractor').type('HH General Building Repair - H01')
+
+      cy.get('input[id="rateScheduleItems[0][code]"]').clear().type('D')
+
+      cy.get('input[id="rateScheduleItems[0][code]"]').type('E')
+      cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should('eq', 0)
+
+      cy.intercept(
+        {
+          method: 'GET',
+          path:
+            '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=H01&isRaisable=true?q=DES',
+        },
+        {
+          body: [
+            {
+              code: 'DES5R003',
+              shortDescription: 'Immediate call outs',
+              priority: {
+                priorityCode: 1,
+                description: '1 [I] IMMEDIATE',
+              },
+              cost: 0,
+            },
+            {
+              code: 'DES5R004',
+              shortDescription: 'Emergency call out',
+              priority: {
+                priorityCode: 2,
+                description: '2 [E] EMERGENCY',
+              },
+            },
+          ],
+        }
+      ).as('sorCodesRequestDES')
+
+      // Enter three characters, then clear and immediately re-enter them
+      cy.get('input[id="rateScheduleItems[0][code]"]')
+        .type('S')
+        .clear()
+        .type('DES')
+
+      cy.wait('@sorCodesRequestDES')
+
+      // The three-character input triggering an API request should have been debounced from 2 requests to just 1
+      cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should('eq', 1)
+
+      cy.get('[data-testid="rateScheduleItems[0][code]"]')
+        .parent()
+        .find('datalist option')
+        .should('have.length', 2)
+        .first()
+        .should('have.attr', 'value', 'DES5R003 - Immediate call outs')
+        .next()
+        .should('have.attr', 'value', 'DES5R004 - Emergency call out')
+
+      // type the remainder of the code
+      cy.get('input[id="rateScheduleItems[0][code]"]').type(
+        '5R003 - Immediate call outs'
+      )
+
+      // Entering more than three characters does not trigger more API requests
+      cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should('eq', 1)
+
+      cy.get('#priorityCode')
+        .find('option:selected')
+        .should('have.text', '1 [I] IMMEDIATE')
+    })
+  })
+
   it('Submits an immediate priority work order', () => {
     cy.visit('/properties/00012345/raise-repair/new')
 
@@ -672,11 +837,14 @@ describe('Raise repair form', () => {
 
       cy.get('#contractor').type('HH General Building Repair - H01')
 
-      cy.wait('@sorCodesRequest')
-
       cy.get('input[id="rateScheduleItems[0][code]"]')
         .clear()
-        .type('DES5R003 - Immediate call outs')
+        .type('DES')
+        .then((datalist) => {
+          cy.wait('@sorCodesRequest')
+
+          cy.wrap(datalist).type('5R003 - Immediate call outs')
+        })
 
       // Autopopulates priority description
       cy.get('#priorityCode')
@@ -726,12 +894,17 @@ describe('Raise repair form', () => {
     cy.wait('@contractorsRequest')
 
     cy.get('#contractor').type('HH General Building Repair - H01')
-    cy.wait('@sorCodesRequest')
 
     // Select an SOR with no cost
-    cy.get('input[id="rateScheduleItems[0][code]"]').type(
-      'DES5R003 - Immediate call outs'
-    )
+
+    cy.get('input[id="rateScheduleItems[0][code]"]')
+      .clear()
+      .type('DES')
+      .then((datalist) => {
+        cy.wait('@sorCodesRequest')
+
+        cy.wrap(datalist).type('5R003 - Immediate call outs')
+      })
 
     cy.get('input[id="rateScheduleItems[0][quantity]"]').type('500')
 
@@ -740,9 +913,16 @@ describe('Raise repair form', () => {
 
     // Select an SOR with cost: £50.17
     cy.contains('+ Add another SOR code').click()
-    cy.get('input[id="rateScheduleItems[1][code]"]').type(
-      '20060020 - BATHROOM PLUMBING REPAIRS'
-    )
+
+    cy.get('input[id="rateScheduleItems[1][code]"]')
+      .clear()
+      .type('200')
+      .then((datalist) => {
+        cy.wait('@sorCodesRequest')
+
+        cy.wrap(datalist).type('60020 - BATHROOM PLUMBING REPAIRS')
+      })
+
     // Select a quantity to make total 50.17 x 5 = 250.85
     cy.get('input[id="rateScheduleItems[1][quantity]"]').type('5')
     // Warning text as user's raise limit (£250) has been exceeded
@@ -759,11 +939,21 @@ describe('Raise repair form', () => {
 
     // Add another SOR with cost: £5.80
     cy.contains('+ Add another SOR code').click()
-    cy.get('input[id="rateScheduleItems[2][code]"]').type(
-      '20060030 - KITCHEN PLUMBING REPAIRS'
-    )
+
+    cy.get('input[id="rateScheduleItems[2][code]"]')
+      .clear()
+      .type('200')
+      .then((datalist) => {
+        cy.wait('@sorCodesRequest')
+
+        cy.wrap(datalist).type('60030 - KITCHEN PLUMBING REPAIRS')
+      })
+
     // Add quantity of 1 to make total 200.68 + (5.80 x 9) = 252.88
     cy.get('input[id="rateScheduleItems[2][quantity]"]').type('9')
+
+    cy.get('[type="submit"]').contains('Create work order').click()
+
     // Warning text as user's raise limit (£250) has been exceeded
     cy.get('.govuk-warning-text.lbh-warning-text').within(() => {
       cy.contains(
@@ -773,14 +963,19 @@ describe('Raise repair form', () => {
 
     // Remove SOR at index 1 to make total cost 5.80 x 9 = 52.2
     cy.get('button[id="remove-rate-schedule-item-1"]').click()
+
     // Within user's raise limit so no warning text is displayed
     cy.get('.govuk-warning-text.lbh-warning-text').should('not.exist')
+
     // Edit quantity to 43 to make total 5.80 x 43 = 249.4
     cy.get('input[id="rateScheduleItems[2][quantity]"]').clear().type('43')
+
     // Within user's raise limit so no warning text is displayed
     cy.get('.govuk-warning-text.lbh-warning-text').should('not.exist')
+
     // Edit quantity to 44 to make total 5.80 x 44 = 255.2
     cy.get('input[id="rateScheduleItems[2][quantity]"]').clear().type('44')
+
     // Warning text as user's raise limit (£250) has been exceeded
     cy.get('.govuk-warning-text.lbh-warning-text').within(() => {
       cy.contains(

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -148,7 +148,7 @@ Cypress.Commands.add('loginWithOperativeRole', () => {
 Cypress.Commands.add('requestsCountByUrl', (url) =>
   cy.wrap().then(() => {
     const requests = cy.state('requests') || []
-    return requests.filter((req) => req.xhr.url.match(new RegExp(`${url}$`)))
+    return requests.filter((req) => req.xhr.url.match(new RegExp(`${url}`)))
       .length
   })
 )

--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -51,6 +51,7 @@ const HeaderComponent = ({ serviceName, toggleMobileMenu, mobileMenuOpen }) => {
       <a href="#main-content" className="govuk-skip-link lbh-skip-link">
         Skip to main content
       </a>
+
       {showDevelopmentNote()}
       <header
         className={`lbh-header govuk-!-display-none-print ${cx({

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
@@ -40,6 +40,7 @@ const RaiseWorkOrderForm = ({
 
   const [totalCost, setTotalCost] = useState('')
   const [isInLegalDisrepair, setIsInLegalDisrepair] = useState()
+
   const overSpendLimit = totalCost > raiseLimit
 
   const onSubmit = async (formData) => {
@@ -189,6 +190,7 @@ const RaiseWorkOrderForm = ({
               updatePriority={updatePriority}
               getPriorityObjectByCode={getPriorityObjectByCode}
               setTotalCost={setTotalCost}
+              setValue={setValue}
             />
 
             <SelectPriority

--- a/src/components/Property/RaiseWorkOrder/RateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/RateScheduleItemView.js
@@ -1,20 +1,18 @@
 import PropTypes from 'prop-types'
 import { useState, Fragment } from 'react'
 import RateScheduleItem from '../../WorkElement/RateScheduleItem'
-import ErrorMessage from '../../Errors/ErrorMessage'
-import Spinner from '../../Spinner'
 import { calculateTotal } from '@/utils/helpers/calculations'
 
 const RateScheduleItemView = ({
-  sorCodes,
   register,
   errors,
   disabled,
   updatePriority,
   getPriorityObjectByCode,
-  loading,
-  apiError,
   setTotalCost,
+  sorCodeArrays,
+  setSorCodeArrays,
+  sorSearchRequest,
 }) => {
   const [
     arrayOfRateScheduleItemComponentIndexes,
@@ -26,8 +24,8 @@ const RateScheduleItemView = ({
   )
   const [rateScheduleItemCosts, setRateScheduleItemCosts] = useState([])
 
-  const getSorCodeObject = (value) => {
-    return sorCodes.filter((a) => a.code == value)[0]
+  const getSorCodeObject = (value, index) => {
+    return sorCodeArrays[index].filter((a) => a.code == value)[0]
   }
 
   const updateTotalCost = (rateScheduleItemCosts) => {
@@ -68,7 +66,7 @@ const RateScheduleItemView = ({
   const onRateScheduleItemSelect = (index, code) => {
     document.getElementById('priorityCode').disabled = false
 
-    const sorCodeObject = getSorCodeObject(code)
+    const sorCodeObject = getSorCodeObject(code, index)
 
     if (sorCodeObject?.priority?.priorityCode) {
       const rateScheduleItemPriorityAtSameIndex = rateScheduleItemPriorities.find(
@@ -113,9 +111,17 @@ const RateScheduleItemView = ({
         arrayOfRateScheduleItemComponentIndexes.slice(-1)[0] + 1,
       ]
     )
+
+    setSorCodeArrays((sorCodeArrays) => [...sorCodeArrays, []])
   }
 
   const removeRateScheduleItem = (index) => {
+    setSorCodeArrays((sorCodeArrays) => {
+      sorCodeArrays[index] = []
+
+      return sorCodeArrays
+    })
+
     setArrayOfRateScheduleItemComponentIndexes(
       (arrayOfRateScheduleItemComponentIndexes) =>
         arrayOfRateScheduleItemComponentIndexes.filter((i) => i !== index)
@@ -148,54 +154,50 @@ const RateScheduleItemView = ({
     }
   }
 
-  const rateScheduleItems = () => {
-    return arrayOfRateScheduleItemComponentIndexes.map((i) => {
-      return (
-        <Fragment key={`rateScheduleItem~${i}`}>
-          <RateScheduleItem
-            sorCodes={sorCodes}
-            register={register}
-            errors={errors}
-            disabled={disabled}
-            key={i}
-            index={i}
-            onRateScheduleItemChange={onRateScheduleItemSelect}
-            onQuantityChange={onQuantityChange}
-            showRemoveRateScheduleItem={i > 0}
-            removeRateScheduleItem={removeRateScheduleItem}
-          />
-        </Fragment>
-      )
-    })
-  }
-
   return (
     <div className="min-height-120 govuk-!-margin-bottom-6">
-      {loading ? (
-        <Spinner />
-      ) : (
-        <div>
-          {rateScheduleItems()}
-          {apiError && <ErrorMessage label={apiError} />}
+      <div>
+        {arrayOfRateScheduleItemComponentIndexes.map((i) => {
+          return (
+            <Fragment key={`rateScheduleItem~${i}`}>
+              <RateScheduleItem
+                sorCodes={sorCodeArrays[i] || []}
+                register={register}
+                errors={errors}
+                disabled={disabled}
+                key={i}
+                index={i}
+                onRateScheduleItemChange={onRateScheduleItemSelect}
+                onQuantityChange={onQuantityChange}
+                showRemoveRateScheduleItem={i > 0}
+                removeRateScheduleItem={removeRateScheduleItem}
+                sorSearchRequest={sorSearchRequest}
+                setSorCodes={(codes) =>
+                  setSorCodeArrays((sorCodeArrays) => [
+                    ...sorCodeArrays.slice(0, i),
+                    codes,
+                    ...sorCodeArrays.slice(i + 1),
+                  ])
+                }
+              />
+            </Fragment>
+          )
+        })}
 
-          <a className="lbh-link" href="#" onClick={addRateScheduleItem}>
-            + Add another SOR code
-          </a>
-        </div>
-      )}
+        <a className="lbh-link" href="#" onClick={addRateScheduleItem}>
+          + Add another SOR code
+        </a>
+      </div>
     </div>
   )
 }
 
 RateScheduleItemView.propTypes = {
-  sorCodes: PropTypes.array.isRequired,
   register: PropTypes.func.isRequired,
   errors: PropTypes.object.isRequired,
   disabled: PropTypes.bool.isRequired,
   updatePriority: PropTypes.func.isRequired,
   getPriorityObjectByCode: PropTypes.func.isRequired,
-  loading: PropTypes.bool.isRequired,
-  apiError: PropTypes.bool,
 }
 
 export default RateScheduleItemView

--- a/src/components/WorkElement/RateScheduleItem.js
+++ b/src/components/WorkElement/RateScheduleItem.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import { useState } from 'react'
+import ErrorMessage from '../Errors/ErrorMessage'
 import { DataList, TextInput } from '../Form'
 
 const RateScheduleItem = ({
@@ -15,8 +16,9 @@ const RateScheduleItem = ({
   disabled,
   onQuantityChange,
   description,
-  hiddenDescriptionValue,
   cost,
+  setSorCodes,
+  sorSearchRequest,
 }) => {
   const sorOptions = sorCodes.map(
     (sor) => `${sor.code} - ${sor.shortDescription}`
@@ -27,8 +29,53 @@ const RateScheduleItem = ({
     optionText: sorOptions[index],
   }))
 
-  const [sorDescription, setSorDescription] = useState()
-  const [sorCost, setSorCost] = useState()
+  const [sorDescription, setSorDescription] = useState(description || '')
+  const [sorCost, setSorCost] = useState(cost || '')
+  const [sorCodesError, setSorCodesError] = useState()
+  const [isLoadingSorCodes, setIsLoadingSorCodes] = useState()
+
+  let sorCodeSelectDebounceTimeout
+
+  const onSorInputChange = (event) => {
+    const textValue = event.target.value
+
+    if (textValue.length < 3 && sorCodes.length > 0) {
+      setSorCodes([])
+    }
+
+    const sorCode = sorCodesWithOptions.find(
+      (code) => code.optionText === textValue
+    )
+
+    if (sorCode) {
+      setSorDescription(sorCode.shortDescription)
+      setSorCost(sorCode.cost)
+    }
+
+    onRateScheduleItemChange && onRateScheduleItemChange(index, sorCode?.code)
+
+    clearTimeout(sorCodeSelectDebounceTimeout)
+
+    if (textValue.length === 3) {
+      sorCodeSelectDebounceTimeout = setTimeout(() => {
+        setSorCodesError(null)
+        setIsLoadingSorCodes(true)
+
+        sorSearchRequest(textValue)
+          .then((sorCodes) => {
+            setSorCodes(sorCodes)
+          })
+          .catch((e) => {
+            setSorCodes([])
+            console.error('An error has occured:', e.response)
+            setSorCodesError(
+              `Oops an error occurred getting SOR codes with error status: ${e.response?.status}`
+            )
+          })
+          .finally(() => setIsLoadingSorCodes(false))
+      }, 500)
+    }
+  }
 
   return (
     <>
@@ -40,40 +87,34 @@ const RateScheduleItem = ({
           options={sorOptions}
           defaultValue={code ?? ''}
           disabled={disabled}
-          onChange={(event) => {
-            const value = event.target.value
-
-            const sorCode = sorCodesWithOptions.find(
-              (code) => code.optionText === value
-            )
-
-            if (sorCode) {
-              setSorDescription(sorCode.shortDescription)
-              setSorCost(sorCode.cost)
-            }
-
-            onRateScheduleItemChange &&
-              onRateScheduleItemChange(index, sorCode?.code)
-          }}
+          onChange={onSorInputChange}
           required={true}
-          selected={code ?? ''}
+          value={code ?? ''}
           register={register({
             required: 'Please select an SOR code',
-            validate: (value) =>
-              sorOptions.some((text) => text.includes(value)) ||
-              'SOR code is not valid',
+            validate: (value) => {
+              console.log(value)
+
+              console.log(sorOptions)
+
+              return (
+                sorOptions.some((text) => text.includes(value)) ||
+                'SOR code is not valid'
+              )
+            },
           })}
           error={errors && errors.rateScheduleItems?.[`${index}`]?.code}
           widthClass="govuk-!-margin-top-0 govuk-!-width-full"
           additionalDivClasses="rate-schedule-item--sor-code"
         />
 
+        {isLoadingSorCodes && <p>Loading SORs</p>}
+        {sorCodesError && <ErrorMessage label={sorCodesError} />}
+
         <input
           id={`rateScheduleItems[${index}][description]`}
           name={`rateScheduleItems[${index}][description]`}
-          {...(hiddenDescriptionValue
-            ? { value: description ?? '' }
-            : { value: sorDescription })}
+          value={sorDescription}
           type="hidden"
           ref={register}
         />
@@ -81,7 +122,7 @@ const RateScheduleItem = ({
         <input
           id={`rateScheduleItems[${index}][cost]`}
           name={`rateScheduleItems[${index}][cost]`}
-          {...(cost ? { value: cost ?? '' } : { value: sorCost })}
+          value={sorCost}
           type="hidden"
           ref={register}
         />

--- a/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
+++ b/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
@@ -74,7 +74,6 @@ const AddedRateScheduleItems = ({
             key={item.id}
             index={item.id}
             description={item.description}
-            hiddenDescriptionValue={true}
             quantity={item.quantity}
             cost={item.cost && parseFloat(item.cost)}
             showRemoveRateScheduleItem={isContractorUpdatePage}


### PR DESCRIPTION
### Description of change

No longer show anything in the table if the payment type or operatives were not set on closure.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/181524041

### UI

No longer show payment or operative rows if not applicable

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/1370570/158436843-84f1de3f-8475-47ee-919f-1b7e94435d8b.png">


### Automated test checklist

- [x] Unit tests (Jest)
- [x] Integration tests (Cypress)
