### PR TITLE
Ignore absent fields in close summary table

### DIFF
--- a/cypress/integration/work-order/attend/close-by-proxy.spec.js
+++ b/cypress/integration/work-order/attend/close-by-proxy.spec.js
@@ -1081,7 +1081,8 @@ describe('Closing a work order on behalf of an operative', () => {
         cy.get('[type="submit"]').contains('Close work order').click()
       })
 
-      cy.contains('th', 'Payment type').parent().contains('N/A')
+      cy.contains('th', 'Payment type').should('not.exist')
+      cy.contains('th', 'Operatives').should('not.exist')
 
       cy.get('[type="submit"]').contains('Confirm and close').click()
 

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.js
@@ -36,21 +36,19 @@ const SummaryCloseWorkOrder = ({
               </TD>
             </TR>
 
-            <TR>
-              <TH scope="row">Payment type</TH>
-              <TD>
-                {paymentType
-                  ? PAYMENT_TYPE_FORM_DESCRIPTIONS[paymentType].text
-                  : 'N/A'}
-              </TD>
-              <TD>
-                <a className="lbh-link" onClick={changeStep} href="#">
-                  Edit
-                </a>
-              </TD>
-            </TR>
+            {paymentType && (
+              <TR>
+                <TH scope="row">Payment type</TH>
+                <TD>{PAYMENT_TYPE_FORM_DESCRIPTIONS[paymentType].text}</TD>
+                <TD>
+                  <a className="lbh-link" onClick={changeStep} href="#">
+                    Edit
+                  </a>
+                </TD>
+              </TR>
+            )}
 
-            {operativeNames && (
+            {operativeNames?.length > 0 && (
               <TR>
                 <TH scope="row">Operatives</TH>
                 <TD>{operativeNames.join(', ')}</TD>

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
@@ -29,4 +29,19 @@ describe('SummaryCloseWorkOrder component', () => {
     )
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('does not show rows for operatives and payment type if absent', () => {
+    const { asFragment } = render(
+      <SummaryCloseWorkOrder
+        reference={props.reference}
+        notes={props.notes}
+        time={props.time}
+        date={props.date}
+        reason={props.reason}
+        onJobSubmit={props.onJobSubmit}
+        changeStep={props.changeStep}
+      />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 })

--- a/src/components/WorkOrders/__snapshots__/SummaryCloseWorkOrder.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/SummaryCloseWorkOrder.test.js.snap
@@ -1,5 +1,120 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SummaryCloseWorkOrder component does not show rows for operatives and payment type if absent 1`] = `
+<DocumentFragment>
+  <div>
+    <h1
+      class="lbh-heading-h1"
+    >
+      Close work order: 10000012
+    </h1>
+    <form
+      role="form"
+    >
+      <h4
+        class="lbh-heading-h4"
+      >
+        Summary of updates to work order
+      </h4>
+      <table
+        class="govuk-table lbh-table"
+      >
+        <tbody
+          class="govuk-table__body"
+        >
+          <tr
+            class="govuk-table__row"
+          >
+            <th
+              class="govuk-table__header"
+              scope="row"
+            >
+              Completion time
+            </th>
+            <td
+              class="govuk-table__cell"
+            >
+              2021/02/03T11:33:35.757339 14:30
+            </td>
+            <td
+              class="govuk-table__cell"
+            >
+              <a
+                class="lbh-link"
+                href="#"
+              >
+                Edit
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="govuk-table__row"
+          >
+            <th
+              class="govuk-table__header"
+              scope="row"
+            >
+              Reason
+            </th>
+            <td
+              class="govuk-table__cell"
+            >
+              No Access
+            </td>
+            <td
+              class="govuk-table__cell"
+            >
+              <a
+                class="lbh-link"
+                href="#"
+              >
+                Edit
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="govuk-table__row"
+          >
+            <th
+              class="govuk-table__header"
+              scope="row"
+            >
+              Notes
+            </th>
+            <td
+              class="govuk-table__cell"
+            >
+              this is a note
+            </td>
+            <td
+              class="govuk-table__cell"
+            >
+              <a
+                class="lbh-link"
+                href="#"
+              >
+                Edit
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <button
+          class="govuk-button lbh-button"
+          data-module="govuk-button"
+          type="submit"
+        >
+          Confirm and close
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SummaryCloseWorkOrder component should render properly 1`] = `
 <DocumentFragment>
   <div>


### PR DESCRIPTION
### Description of change

No longer show anything in the table if the payment type or operatives were not set on closure.

### Story Link

https://www.pivotaltracker.com/n/projects/2500129/stories/181524041

### UI

No longer show payment or operative rows if not applicable

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/1370570/158436843-84f1de3f-8475-47ee-919f-1b7e94435d8b.png">


### Automated test checklist

- [x] Unit tests (Jest)
- [x] Integration tests (Cypress)