### PR TITLE
Use correct function prop name

### DIFF
--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -6,7 +6,6 @@ describe('Updating a work order', () => {
     beforeEach(() => {
       cy.loginWithContractorRole()
 
-      // Viewing the home page
       cy.intercept(
         { method: 'GET', path: '/api/filter/WorkOrder' },
         {
@@ -22,7 +21,6 @@ describe('Updating a work order', () => {
         { fixture: 'workOrders/workOrders.json' }
       )
 
-      // Viewing the work order page
       cy.fixture('workOrders/workOrder.json').then((workOrder) => {
         workOrder.reference = 10000040
         cy.intercept(
@@ -43,7 +41,6 @@ describe('Updating a work order', () => {
         { body: [] }
       )
 
-      // Updating the work order
       cy.fixture('workOrders/tasksAndSors.json').then((tasksAndSors) => {
         tasksAndSors.splice(1, 2)
 

--- a/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
+++ b/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
@@ -83,7 +83,7 @@ const AddedRateScheduleItems = ({
             onRateScheduleItemChange={(index, code) =>
               updateRateScheduleItem(item.id, 'code', code)
             }
-            onInputChange={() => {
+            onQuantityChange={() => {
               updateRateScheduleItem(
                 item.id,
                 'quantity',


### PR DESCRIPTION
Match the function prop name in the child component. I'm not sure why, but the absence of this didn't seem to have caused problems. Perhaps this is only relevant in some edge cases.