### PR TITLE
Configure JS excludes for VSCode

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,5 +10,11 @@
       "@/styles/*": ["src/styles/*"],
       "@/utils/*": ["src/utils/*"]
     }
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "build",
+    "dist",
+    ".next"
+  ]
 }


### PR DESCRIPTION
Exclude directories such as builds from JS analysis so that VSCode stops complaining. Should make "Intellisense" e.g. cmd-click function navigation more reliable. See https://code.visualstudio.com/docs/languages/jsconfig#_using-the-exclude-property

