### PR TITLE
Avoid submitting partial SORs

### DIFF
--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -348,6 +348,14 @@ describe('Raise repair form', () => {
 
         cy.wait('@sorCodesRequest')
 
+        cy.get('input[id="rateScheduleItems[0][code]"]').type('INP')
+
+        cy.get(
+          'div[id="rateScheduleItems[0][code]-form-group"] .govuk-error-message'
+        ).within(() => {
+          cy.contains('SOR code is not valid')
+        })
+
         // Select SOR code with no priority attached
         cy.get('input[id="rateScheduleItems[0][code]"]').type(
           'INP5R001 - Pre insp of wrks by Constructr'

--- a/src/components/WorkElement/RateScheduleItem.js
+++ b/src/components/WorkElement/RateScheduleItem.js
@@ -60,7 +60,7 @@ const RateScheduleItem = ({
           register={register({
             required: 'Please select an SOR code',
             validate: (value) =>
-              sorOptions.some((text) => text.includes(value)) ||
+              sorOptions.some((text) => text === value) ||
               'SOR code is not valid',
           })}
           error={errors && errors.rateScheduleItems?.[`${index}`]?.code}


### PR DESCRIPTION
By using `.includes` we were accepting partial SORs as valid.