### PR TITLE
Show correct codes in variation summary

### DIFF
--- a/cypress/integration/work-order/update.spec.js
+++ b/cypress/integration/work-order/update.spec.js
@@ -387,7 +387,9 @@ describe('Updating a work order', () => {
             cy.contains('0')
           })
           cy.get('tr[id="added-task-0"]').within(() => {
-            cy.contains('PLP5R082 - RE ENAMEL ANY SIZE BATH')
+            cy.get('.govuk-table__header').contains(
+              /^PLP5R082 - RE ENAMEL ANY SIZE BATH$/
+            )
             cy.contains('5')
             cy.contains('148.09')
           })

--- a/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
+++ b/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
@@ -103,7 +103,7 @@ const AddedRateScheduleItems = ({
                 parseFloat(event.target.value)
               )
             }}
-            code={item.code}
+            {...(item.code && { code: `${item.code} - ${item.description}` })}
             sorSearchRequest={sorSearchRequest}
             setSorCodes={(sorCodes) => {
               setSorCodeArrays((sorCodeArrays) => [

--- a/src/components/WorkOrder/RateScheduleItems/UpdateSummaryRateScheduleItems.js
+++ b/src/components/WorkOrder/RateScheduleItems/UpdateSummaryRateScheduleItems.js
@@ -75,6 +75,7 @@ const UpdateSummaryRateScheduleItems = ({
         <th scope="row" className="govuk-table__header">
           {[task.code, task.description].filter(Boolean).join(' - ')}
         </th>
+
         <td className="govuk-table__cell">
           {dataAttribute === 'original-task'
             ? task.originalQuantity

--- a/src/components/WorkOrder/Update/Form.test.js
+++ b/src/components/WorkOrder/Update/Form.test.js
@@ -31,6 +31,7 @@ describe('WorkOrderUpdateForm component', () => {
       {
         code: 'DES5R004',
         quantity: 2,
+        description: 'Immediate call outs',
       },
     ],
     onGetToSummary: jest.fn(),

--- a/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
+++ b/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
@@ -505,7 +505,7 @@ exports[`WorkOrderUpdateForm component should render properly with 250 character
             id="rateScheduleItems[undefined][code]"
             list="autocomplete-list-rateScheduleItems[undefined][code]"
             name="rateScheduleItems[undefined][code]"
-            value="DES5R004"
+            value="DES5R004 - Immediate call outs"
           />
           <datalist
             id="autocomplete-list-rateScheduleItems[undefined][code]"
@@ -522,7 +522,7 @@ exports[`WorkOrderUpdateForm component should render properly with 250 character
           id="rateScheduleItems[undefined][description]"
           name="rateScheduleItems[undefined][description]"
           type="hidden"
-          value=""
+          value="Immediate call outs"
         />
         <input
           id="rateScheduleItems[undefined][cost]"
@@ -857,7 +857,7 @@ exports[`WorkOrderUpdateForm component should render properly with unlimited cha
             id="rateScheduleItems[undefined][code]"
             list="autocomplete-list-rateScheduleItems[undefined][code]"
             name="rateScheduleItems[undefined][code]"
-            value="DES5R004"
+            value="DES5R004 - Immediate call outs"
           />
           <datalist
             id="autocomplete-list-rateScheduleItems[undefined][code]"
@@ -874,7 +874,7 @@ exports[`WorkOrderUpdateForm component should render properly with unlimited cha
           id="rateScheduleItems[undefined][description]"
           name="rateScheduleItems[undefined][description]"
           type="hidden"
-          value=""
+          value="Immediate call outs"
         />
         <input
           id="rateScheduleItems[undefined][cost]"

--- a/src/components/WorkOrder/Update/index.js
+++ b/src/components/WorkOrder/Update/index.js
@@ -43,7 +43,7 @@ const WorkOrderUpdateView = ({ reference }) => {
         ? e.rateScheduleItems
             .filter((e) => e != null)
             .map((e, index) => {
-              return { id: index, ...e }
+              return { id: index, ...e, code: e.code.split(' - ')[0] }
             })
         : []
     )


### PR DESCRIPTION
### Description of change

Fix an issue where SOR descriptions were shown twice on the variation summary page.

### Story Link

https://www.pivotaltracker.com/story/show/181508986/comments/230892225

### Automated test checklist

If a type of test isn't included, add note explaining why.

- [ ] Unit tests (Jest) - N/A
- [x] Integration tests (Cypress)

