### PR TITLE
Improve use of config API

### DIFF
--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -3,6 +3,7 @@
 import 'cypress-audit/commands'
 import { addHours } from 'date-fns'
 import { addDays } from 'date-fns/esm'
+import { MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY } from '../../../../src/utils/constants'
 import {
   EMERGENCY_PRIORITY_CODE,
   IMMEDIATE_PRIORITY_CODE,
@@ -119,7 +120,9 @@ describe('Raise repair form', () => {
       {
         body: [
           {
-            featureToggles: { MultiTradeSORIncrementalSearch: true },
+            featureToggles: {
+              [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: true,
+            },
           },
         ],
       }
@@ -799,7 +802,9 @@ describe('Raise repair form', () => {
             {
               body: [
                 {
-                  featureToggles: { MultiTradeSORIncrementalSearch: true },
+                  featureToggles: {
+                    [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: true,
+                  },
                 },
               ],
             }
@@ -1019,7 +1024,9 @@ describe('Raise repair form', () => {
             {
               body: [
                 {
-                  featureToggles: { MultiTradeSORIncrementalSearch: false },
+                  featureToggles: {
+                    [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: false,
+                  },
                 },
               ],
             }
@@ -1095,6 +1102,63 @@ describe('Raise repair form', () => {
                 'value',
                 'INP5R001 - Pre insp of wrks by Constructr'
               )
+          })
+        })
+      })
+
+      context('when the toggle API request errors', () => {
+        beforeEach(() => {
+          cy.intercept(
+            { method: 'GET', path: '/api/toggles' },
+            {
+              statusCode: 500,
+            }
+          ).as('featureToggle')
+
+          cy.intercept(
+            {
+              method: 'GET',
+              path:
+                '/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
+            },
+            { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
+          ).as('sorCodesRequestMultiTrade')
+        })
+
+        it('does not prevent loading of the form', () => {
+          cy.visit('/properties/00012345')
+
+          cy.wait(['@propertyRequest', '@workOrdersRequest'])
+
+          cy.get('.lbh-heading-h2')
+            .contains('Raise a work order on this dwelling')
+            .click()
+
+          cy.wait([
+            '@propertyRequest',
+            '@sorPrioritiesRequest',
+            '@tradesRequest',
+          ])
+
+          cy.get('#repair-request-form').within(() => {
+            cy.get('#trade').type('Multi Trade - MU')
+
+            cy.wait('@multiTradeContractorsRequest')
+
+            cy.get('#contractor').type('Purdy Contracts (P) Ltd - PCL')
+
+            cy.wait('@budgetCodesRequest')
+
+            cy.get('[data-testid=budgetCode]').type(
+              'H2555 - 200031 - Lifts Breakdown'
+            )
+
+            cy.wait('@sorCodesRequestMultiTrade')
+
+            cy.get('[data-testid="rateScheduleItems[0][code]"]')
+              .parent()
+              .find('datalist option')
+              .should('have.length', 7)
           })
         })
       })

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -3,11 +3,15 @@ import { useState, useContext } from 'react'
 import RateScheduleItemView from './RateScheduleItemView'
 import TradeDataList from '../../WorkElement/TradeDataList'
 import ContractorDataList from './ContractorDataList'
-import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
+import {
+  fetchFeatureToggles,
+  frontEndApiRequest,
+} from '@/utils/frontEndApiClient/requests'
 import BudgetCodeItemView from './BudgetCodeItemView'
 import UserContext from '@/components/UserContext'
 import { canAssignBudgetCode } from '@/utils/userPermissions'
 import {
+  MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY,
   MULTITRADE_TRADE_CODE,
   PURDY_CONTRACTOR_REFERENCE,
 } from '@/utils/constants'
@@ -90,16 +94,11 @@ const TradeContractorRateScheduleItemView = ({
     }
 
     if (multiTradeSORIncrementalSearchEnabled === null) {
-      const configurationData = await frontEndApiRequest({
-        method: 'GET',
-        path: '/api/toggles',
-      })
+      const featureToggles = await fetchFeatureToggles()
 
-      ;({
-        featureToggles: {
-          MultiTradeSORIncrementalSearch: multiTradeSORIncrementalSearchEnabled = false,
-        } = {},
-      } = configurationData[0] || {})
+      multiTradeSORIncrementalSearchEnabled = !!featureToggles[
+        MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY
+      ]
     }
 
     setOrderRequiresIncrementalSearch(

--- a/src/components/WorkOrder/Update/index.js
+++ b/src/components/WorkOrder/Update/index.js
@@ -3,13 +3,19 @@ import { useState, useEffect } from 'react'
 import Spinner from '../../Spinner'
 import BackButton from '../../Layout/BackButton'
 import ErrorMessage from '../../Errors/ErrorMessage'
-import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
+import {
+  fetchFeatureToggles,
+  frontEndApiRequest,
+} from '@/utils/frontEndApiClient/requests'
 import { updateExistingTasksQuantities } from '@/utils/updateTasks'
 import { isSpendLimitReachedResponse } from '@/utils/helpers/apiResponses'
 import WorkOrderUpdateForm from './Form'
 import WorkOrderUpdateSummary from './Summary'
 import WorkOrderUpdateSuccess from './Success'
-import { PURDY_CONTRACTOR_REFERENCE } from '@/utils/constants'
+import {
+  MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY,
+  PURDY_CONTRACTOR_REFERENCE,
+} from '@/utils/constants'
 
 const WorkOrderUpdateView = ({ reference }) => {
   const [loading, setLoading] = useState(false)
@@ -105,16 +111,11 @@ const WorkOrderUpdateView = ({ reference }) => {
       return false
     }
 
-    const configurationData = await frontEndApiRequest({
-      method: 'GET',
-      path: '/api/toggles',
-    })
+    const featureToggles = await fetchFeatureToggles()
 
-    const {
-      featureToggles: {
-        MultiTradeSORIncrementalSearch: multiTradeSORIncrementalSearchEnabled = false,
-      } = {},
-    } = configurationData[0] || {}
+    const multiTradeSORIncrementalSearchEnabled = !!featureToggles[
+      MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY
+    ]
 
     setOrderRequiresIncrementalSearch(
       orderApplicable && multiTradeSORIncrementalSearchEnabled

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,2 +1,6 @@
 export const PURDY_CONTRACTOR_REFERENCE = 'PCL'
 export const MULTITRADE_TRADE_CODE = 'MU'
+
+// Feature toggle keys
+export const MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY =
+  'MultiTradeSORIncrementalSearch'

--- a/src/utils/frontEndApiClient/requests.js
+++ b/src/utils/frontEndApiClient/requests.js
@@ -17,3 +17,20 @@ export const frontEndApiRequest = async ({
 
   return data
 }
+
+export const fetchFeatureToggles = async () => {
+  try {
+    const configurationData = await frontEndApiRequest({
+      method: 'GET',
+      path: '/api/toggles',
+    })
+
+    return configurationData?.[0]?.featureToggles || {}
+  } catch (e) {
+    console.error(
+      `Error fetching toggles from configuration API: ${JSON.stringify(e)}`
+    )
+
+    return {}
+  }
+}


### PR DESCRIPTION
There's an issue with the current config API configuration where the [entire page would fail to load](https://hackit-lbh.slack.com/archives/C017N5GA8P8/p1651152111783529) in the event of an error response, such as a 4XX error from the config API. This PR updates the behaviour so that the error is logged but does not otherwise block the page. 

It also extracts a function to get feature toggles as well as adding a constant for the toggle key, both of which should help to establish a pattern for future use of this API.