### PR TITLE
Show all trades even if search is disabled

### DIFF
--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -1017,96 +1017,99 @@ describe('Raise repair form', () => {
         })
       })
 
-      context('and the incremental multitrade SOR search toggle is off', () => {
-        beforeEach(() => {
-          cy.intercept(
-            { method: 'GET', path: '/api/toggles' },
-            {
-              body: [
-                {
-                  featureToggles: {
-                    [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: false,
+      context.only(
+        'and the incremental multitrade SOR search toggle is off',
+        () => {
+          beforeEach(() => {
+            cy.intercept(
+              { method: 'GET', path: '/api/toggles' },
+              {
+                body: [
+                  {
+                    featureToggles: {
+                      [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: false,
+                    },
                   },
-                },
-              ],
-            }
-          )
-
-          cy.intercept(
-            {
-              method: 'GET',
-              path:
-                '/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
-            },
-            { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
-          ).as('sorCodesRequestMultiTrade')
-        })
-
-        it('searches SOR codes after loading them all into a list', () => {
-          cy.visit('/properties/00012345')
-
-          cy.wait(['@propertyRequest', '@workOrdersRequest'])
-
-          cy.get('.lbh-heading-h2')
-            .contains('Raise a work order on this dwelling')
-            .click()
-
-          cy.wait([
-            '@propertyRequest',
-            '@sorPrioritiesRequest',
-            '@tradesRequest',
-          ])
-
-          cy.get('#repair-request-form').within(() => {
-            cy.get('#trade').type('Multi Trade - MU')
-
-            cy.wait('@multiTradeContractorsRequest')
-
-            cy.get('#contractor').type('Purdy Contracts (P) Ltd - PCL')
-
-            cy.wait('@budgetCodesRequest')
-
-            cy.get('[data-testid=budgetCode]').type(
-              'H2555 - 200031 - Lifts Breakdown'
+                ],
+              }
             )
 
-            cy.wait('@sorCodesRequestMultiTrade')
-
-            cy.get('[data-testid="rateScheduleItems[0][code]"]')
-              .parent()
-              .find('datalist option')
-              .should('have.length', 7)
-              .first()
-              .should(
-                'have.attr',
-                'value',
-                '20060020 - BATHROOM PLUMBING REPAIRS'
-              )
-              .next()
-              .should(
-                'have.attr',
-                'value',
-                '20060030 - KITCHEN PLUMBING REPAIRS'
-              )
-              .next()
-              .should('have.attr', 'value', 'DES5R003 - Immediate call outs')
-              .next()
-              .should('have.attr', 'value', 'DES5R004 - Emergency call out')
-              .next()
-              .should('have.attr', 'value', 'DES5R005 - Normal call outs')
-              .next()
-              .should('have.attr', 'value', 'DES5R006 - Urgent call outs')
-              .next()
-              .should(
-                'have.attr',
-                'value',
-                'INP5R001 - Pre insp of wrks by Constructr'
-              )
+            cy.intercept(
+              {
+                method: 'GET',
+                path:
+                  '/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=PCL&isRaisable=true&showAllTrades=true',
+              },
+              { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
+            ).as('sorCodesRequestMultiTrade')
           })
-        })
-      })
 
-      context('when the toggle API request errors', () => {
+          it('searches SOR codes after loading them all into a list', () => {
+            cy.visit('/properties/00012345')
+
+            cy.wait(['@propertyRequest', '@workOrdersRequest'])
+
+            cy.get('.lbh-heading-h2')
+              .contains('Raise a work order on this dwelling')
+              .click()
+
+            cy.wait([
+              '@propertyRequest',
+              '@sorPrioritiesRequest',
+              '@tradesRequest',
+            ])
+
+            cy.get('#repair-request-form').within(() => {
+              cy.get('#trade').type('Multi Trade - MU')
+
+              cy.wait('@multiTradeContractorsRequest')
+
+              cy.get('#contractor').type('Purdy Contracts (P) Ltd - PCL')
+
+              cy.wait('@budgetCodesRequest')
+
+              cy.get('[data-testid=budgetCode]').type(
+                'H2555 - 200031 - Lifts Breakdown'
+              )
+
+              cy.wait('@sorCodesRequestMultiTrade')
+
+              cy.get('[data-testid="rateScheduleItems[0][code]"]')
+                .parent()
+                .find('datalist option')
+                .should('have.length', 7)
+                .first()
+                .should(
+                  'have.attr',
+                  'value',
+                  '20060020 - BATHROOM PLUMBING REPAIRS'
+                )
+                .next()
+                .should(
+                  'have.attr',
+                  'value',
+                  '20060030 - KITCHEN PLUMBING REPAIRS'
+                )
+                .next()
+                .should('have.attr', 'value', 'DES5R003 - Immediate call outs')
+                .next()
+                .should('have.attr', 'value', 'DES5R004 - Emergency call out')
+                .next()
+                .should('have.attr', 'value', 'DES5R005 - Normal call outs')
+                .next()
+                .should('have.attr', 'value', 'DES5R006 - Urgent call outs')
+                .next()
+                .should(
+                  'have.attr',
+                  'value',
+                  'INP5R001 - Pre insp of wrks by Constructr'
+                )
+            })
+          })
+        }
+      )
+
+      context.only('when the toggle API request errors', () => {
         beforeEach(() => {
           cy.intercept(
             { method: 'GET', path: '/api/toggles' },
@@ -1119,7 +1122,7 @@ describe('Raise repair form', () => {
             {
               method: 'GET',
               path:
-                '/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
+                '/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=PCL&isRaisable=true&showAllTrades=true',
             },
             { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
           ).as('sorCodesRequestMultiTrade')

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -83,10 +83,12 @@ const TradeContractorRateScheduleItemView = ({
     }
   }
 
+  const showAllTrades = (contractorRef, tradeCode) =>
+    contractorRef === PURDY_CONTRACTOR_REFERENCE &&
+    tradeCode === MULTITRADE_TRADE_CODE
+
   const incrementalSORSearchRequired = async (contractorRef, tradeCode) => {
-    const orderApplicable =
-      contractorRef === PURDY_CONTRACTOR_REFERENCE &&
-      tradeCode === MULTITRADE_TRADE_CODE
+    const orderApplicable = showAllTrades(contractorRef, tradeCode)
 
     if (!orderApplicable) {
       setOrderRequiresIncrementalSearch(false)
@@ -117,7 +119,12 @@ const TradeContractorRateScheduleItemView = ({
     if (incrementalSearch) {
       resetSORs()
     } else {
-      getSorCodesData(tradeCode, propertyReference, contractorRef)
+      getSorCodesData(
+        tradeCode,
+        propertyReference,
+        contractorRef,
+        showAllTrades(contractorRef, tradeCode)
+      )
     }
   }
 
@@ -209,7 +216,12 @@ const TradeContractorRateScheduleItemView = ({
     }
   }
 
-  const getSorCodesData = async (tradeCode, propertyRef, contractorRef) => {
+  const getSorCodesData = async (
+    tradeCode,
+    propertyRef,
+    contractorRef,
+    showAllTrades = false
+  ) => {
     setLoadingSorCodes(true)
     setGetSorCodesError(null)
 
@@ -222,6 +234,7 @@ const TradeContractorRateScheduleItemView = ({
           propertyReference: propertyRef,
           contractorReference: contractorRef,
           isRaisable: true,
+          ...(showAllTrades && { showAllTrades: true }),
         },
       })
 


### PR DESCRIPTION
If the search SOR feature is disabled, we should still request an appropriate list of codes from the backend. This commit resolves this for the case when the contractor is Purdy and the trade is multitrade, which means all trade codes should be fetched.