### PR TITLE
removed conditional rendering of work order history

### DIFF
--- a/cypress/integration/property/show.spec.js
+++ b/cypress/integration/property/show.spec.js
@@ -292,6 +292,22 @@ describe('Show property', () => {
         cy.contains('button', 'Load more').should('not.exist')
       })
     })
+
+    context('when a repair cannot be raised on the property', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/properties/00012345' },
+          { fixture: 'properties/propertyRepairNotRaisable.json' }
+        ).as('propertyNotRaisable')
+      })
+
+      it('Work order history is still visible', () => {
+        cy.visit('/properties/00012345')
+        cy.get('.govuk-tabs__list-item--selected a').contains(
+          'Work orders history'
+        )
+      })
+    })
   })
 
   describe('Raise work order', () => {

--- a/src/components/Property/PropertyView.js
+++ b/src/components/Property/PropertyView.js
@@ -63,12 +63,7 @@ const PropertyView = ({ propertyReference }) => {
                 tenure={tenure}
                 tmoName={property.tmoName}
               />
-              {property.canRaiseRepair && (
-                <Tabs
-                  tabsList={tabsList}
-                  propertyReference={propertyReference}
-                />
-              )}
+              <Tabs tabsList={tabsList} propertyReference={propertyReference} />
             </>
           )}
           {error && <ErrorMessage label={error} />}


### PR DESCRIPTION
### Description of change

- removed conditional rendering that displayed work order history only when canRaiseRepair = true
- added a test to confirm history tabs are visible

### Story Link

https://www.pivotaltracker.com/story/show/182075110