### PR TITLE
Prepare raise form for Multiple SORs workflow

### DIFF
--- a/reporter-rules.json
+++ b/reporter-rules.json
@@ -14,5 +14,13 @@
   {
     "match": "Component undefined has no permittedRoles defined",
     "group": null
+  },
+  {
+    "match": "Error fetching toggles from configuration API: {\"response\":{\"status\":500}}",
+    "group": null
+  },
+  {
+    "match": "Service API response {\"status\":500,\"data\":\"Unable to connect to DRS Web Services to allow scheduling of this order (DRSWebServicesError: DRS Web Services returned non-200 response: DRS error message)\"}",
+    "group": null
   }
 ]

--- a/src/components/Operatives/SelectOperatives.test.js
+++ b/src/components/Operatives/SelectOperatives.test.js
@@ -27,6 +27,8 @@ describe('SelectOperatives component', () => {
         availableOperatives={operatives}
         register={() => {}}
         selectedPercentagesToShowOnEdit={[]}
+        totalSMV={1}
+        jobIsSplitByOperative={false}
       />
     )
     expect(asFragment()).toMatchSnapshot()
@@ -40,6 +42,8 @@ describe('SelectOperatives component', () => {
         register={() => {}}
         selectedPercentagesToShowOnEdit={[]}
         currentUserPayrollNumber="PN1"
+        totalSMV={1}
+        jobIsSplitByOperative={false}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
+++ b/src/components/Operatives/__snapshots__/SelectOperatives.test.js.snap
@@ -147,7 +147,7 @@ exports[`SelectOperatives component should disable the current operative when a 
         <p
           class="lbh-body smv-read-only--value"
         >
-          NaN
+          0.33
         </p>
       </div>
     </div>
@@ -281,7 +281,7 @@ exports[`SelectOperatives component should disable the current operative when a 
         <p
           class="lbh-body smv-read-only--value"
         >
-          NaN
+          0.33
         </p>
       </div>
     </div>
@@ -415,7 +415,7 @@ exports[`SelectOperatives component should disable the current operative when a 
         <p
           class="lbh-body smv-read-only--value"
         >
-          NaN
+          0.33
         </p>
       </div>
     </div>
@@ -564,7 +564,9 @@ exports[`SelectOperatives component should render properly 1`] = `
         </p>
         <p
           class="lbh-body smv-read-only--value"
-        />
+        >
+          1
+        </p>
       </div>
     </div>
     <div>

--- a/src/components/Property/Contacts/ContactsRow.js
+++ b/src/components/Property/Contacts/ContactsRow.js
@@ -16,7 +16,7 @@ Row.propTypes = {
   contact: PropTypes.shape({
     firstName: PropTypes.string,
     lastName: PropTypes.string,
-    phoneNumbers: PropTypes.arrayOf(PropTypes.string),
+    phoneNumbers: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,
 }
 

--- a/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
+++ b/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
@@ -3,9 +3,10 @@ import { DataList } from '../../Form'
 import Spinner from '../../Spinner'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import { formatBudgetCodeForOption } from '@/utils/helpers/budgetCodes'
-import { useState } from 'react'
 
 const BudgetCodeItemView = ({
+  budgetCodeId,
+  setBudgetCodeId,
   register,
   errors,
   disabled,
@@ -13,9 +14,7 @@ const BudgetCodeItemView = ({
   loading,
   apiError,
   afterValidBudgetCodeSelected,
-  afterInvalidBudgetCodeSelected,
 }) => {
-  const [budgetCodeSelected, setBudgetCodeSelected] = useState()
   const budgetCodeOptions = budgetCodes.map((code) =>
     formatBudgetCodeForOption(code)
   )
@@ -45,10 +44,8 @@ const BudgetCodeItemView = ({
               )
 
               if (budgetCode) {
-                setBudgetCodeSelected(budgetCode)
+                setBudgetCodeId(budgetCode.id)
                 afterValidBudgetCodeSelected()
-              } else {
-                afterInvalidBudgetCodeSelected()
               }
             }}
             register={register({
@@ -70,13 +67,15 @@ const BudgetCodeItemView = ({
         name="budgetCodeId"
         type="hidden"
         ref={register}
-        value={budgetCodeSelected?.id}
+        value={budgetCodeId}
       />
     </div>
   )
 }
 
 BudgetCodeItemView.propTypes = {
+  budgetCodeId: PropTypes.string.isRequired,
+  setBudgetCodeId: PropTypes.func.isRequired,
   register: PropTypes.func.isRequired,
   errors: PropTypes.object.isRequired,
   disabled: PropTypes.bool.isRequired,
@@ -84,7 +83,6 @@ BudgetCodeItemView.propTypes = {
   loading: PropTypes.bool.isRequired,
   apiError: PropTypes.string,
   afterValidBudgetCodeSelected: PropTypes.func.isRequired,
-  afterInvalidBudgetCodeSelected: PropTypes.func.isRequired,
 }
 
 export default BudgetCodeItemView

--- a/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.test.js
+++ b/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.test.js
@@ -5,6 +5,8 @@ describe('BudgetCodeItemView component', () => {
   it('should render a datalist with formatted budget codes as options', () => {
     const { asFragment } = render(
       <BudgetCodeItemView
+        budgetCode={{}}
+        setBudgetCode={jest.fn()}
         budgetCodes={[
           {
             id: 1,
@@ -25,7 +27,6 @@ describe('BudgetCodeItemView component', () => {
         disabled={false}
         loading={false}
         errors={{}}
-        afterInvalidBudgetCodeSelected={jest.fn()}
         afterValidBudgetCodeSelected={jest.fn()}
       />
     )

--- a/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.test.js
+++ b/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.test.js
@@ -5,8 +5,8 @@ describe('BudgetCodeItemView component', () => {
   it('should render a datalist with formatted budget codes as options', () => {
     const { asFragment } = render(
       <BudgetCodeItemView
-        budgetCode={{}}
-        setBudgetCode={jest.fn()}
+        budgetCodeId={''}
+        setBudgetCodeId={jest.fn()}
         budgetCodes={[
           {
             id: 1,

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
@@ -29,8 +29,14 @@ const RaiseWorkOrderForm = ({
   tenure,
   priorities,
   trades,
+  tradeCode,
+  setTradeCode,
   contractors,
+  contractorReference,
+  setContractorReference,
   setContractors,
+  budgetCodeId,
+  setBudgetCodeId,
   budgetCodes,
   setBudgetCodes,
   sorCodeArrays,
@@ -191,10 +197,16 @@ const RaiseWorkOrderForm = ({
               register={register}
               errors={errors}
               trades={trades}
+              tradeCode={tradeCode}
+              setTradeCode={setTradeCode}
               contractors={contractors}
               setContractors={setContractors}
+              contractorReference={contractorReference}
+              setContractorReference={setContractorReference}
               budgetCodes={budgetCodes}
               setBudgetCodes={setBudgetCodes}
+              budgetCodeId={budgetCodeId}
+              setBudgetCodeId={setBudgetCodeId}
               sorCodeArrays={sorCodeArrays}
               setSorCodeArrays={setSorCodeArrays}
               propertyReference={propertyReference}
@@ -297,6 +309,12 @@ RaiseWorkOrderForm.propTypes = {
   setSorCodeArrays: PropTypes.func.isRequired,
   priorities: PropTypes.array.isRequired,
   onFormSubmit: PropTypes.func.isRequired,
+  tradeCode: PropTypes.string.isRequired,
+  setTradeCode: PropTypes.func.isRequired,
+  contractorReference: PropTypes.string.isRequired,
+  setContractorReference: PropTypes.func.isRequired,
+  budgetCodeId: PropTypes.string.isRequired,
+  setBudgetCodeId: PropTypes.func.isRequired,
 }
 
 export default RaiseWorkOrderForm

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
@@ -29,6 +29,12 @@ const RaiseWorkOrderForm = ({
   tenure,
   priorities,
   trades,
+  contractors,
+  setContractors,
+  budgetCodes,
+  setBudgetCodes,
+  sorCodeArrays,
+  setSorCodeArrays,
   contacts,
   onFormSubmit,
   raiseLimit,
@@ -182,6 +188,12 @@ const RaiseWorkOrderForm = ({
               register={register}
               errors={errors}
               trades={trades}
+              contractors={contractors}
+              setContractors={setContractors}
+              budgetCodes={budgetCodes}
+              setBudgetCodes={setBudgetCodes}
+              sorCodeArrays={sorCodeArrays}
+              setSorCodeArrays={setSorCodeArrays}
               propertyReference={propertyReference}
               isContractorUpdatePage={false}
               updatePriority={updatePriority}
@@ -293,6 +305,12 @@ RaiseWorkOrderForm.propTypes = {
   canRaiseRepair: PropTypes.bool.isRequired,
   tenure: PropTypes.object,
   trades: PropTypes.array.isRequired,
+  contractors: PropTypes.array.isRequired,
+  setContractors: PropTypes.func.isRequired,
+  budgetCodes: PropTypes.array.isRequired,
+  setBudgetCodes: PropTypes.func.isRequired,
+  sorCodeArrays: PropTypes.array.isRequired,
+  setSorCodeArrays: PropTypes.func.isRequired,
   priorities: PropTypes.array.isRequired,
   onFormSubmit: PropTypes.func.isRequired,
 }

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.js
@@ -53,6 +53,9 @@ const RaiseWorkOrderForm = ({
 
     const scheduleWorkOrderFormData = buildScheduleWorkOrderFormData({
       ...formData,
+      propertyReference,
+      shortAddress: address.shortAddress,
+      postalCode: address.postalCode,
       priorityDescription: priority.description,
       daysToComplete: priority.daysToComplete,
       hoursToComplete:
@@ -210,6 +213,7 @@ const RaiseWorkOrderForm = ({
               priorityCode={priorityCode}
               priorityCodesWithoutDrs={PRIORITY_CODES_WITHOUT_DRS}
             />
+
             <CharacterCountLimitedTextArea
               name="descriptionOfWork"
               label="Repair description"
@@ -219,36 +223,15 @@ const RaiseWorkOrderForm = ({
               register={register}
               error={errors && errors.descriptionOfWork}
             />
-            <input
-              id="propertyReference"
-              name="propertyReference"
-              label="propertyReference"
-              type="hidden"
-              value={propertyReference}
-              ref={register}
-            />
-            <input
-              id="shortAddress"
-              name="shortAddress"
-              label="shortAddress"
-              type="hidden"
-              value={address.shortAddress}
-              ref={register}
-            />
-            <input
-              id="postalCode"
-              name="postalCode"
-              label="postalCode"
-              type="hidden"
-              value={address.postalCode}
-              ref={register}
-            />
+
             <Contacts contacts={contacts} />
+
             <WarningInfoBox
               name="contact-number-warning"
               header="Need to add an additional contact number?"
               text="Any additional contact numbers can be added into the Repair description field"
             />
+
             <TextInput
               name="callerName"
               label="Caller name"
@@ -263,6 +246,7 @@ const RaiseWorkOrderForm = ({
               })}
               error={errors && errors.callerName}
             />
+
             <TextInput
               name="contactNumber"
               label="Telephone number"

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
@@ -75,6 +75,9 @@ describe('RaiseWorkOrderForm component', () => {
     ],
     contactDetails: [],
     onFormSubmit: jest.fn(),
+    setContractors: jest.fn(),
+    setBudgetCodes: jest.fn(),
+    setSorCodeArrays: jest.fn(),
   }
 
   it('should render properly', async () => {
@@ -88,6 +91,12 @@ describe('RaiseWorkOrderForm component', () => {
           tenure={props.tenure}
           priorities={props.priorities}
           trades={props.trades}
+          contractors={[]}
+          setContractors={props.setContractors}
+          budgetCodes={[]}
+          setBudgetCodes={props.setBudgetCodes}
+          sorCodeArrays={[[]]}
+          setSorCodeArrays={props.setSorCodeArrays}
           contacts={props.contactDetails}
           onFormSubmit={props.onFormSubmit}
         />
@@ -115,6 +124,12 @@ describe('RaiseWorkOrderForm component', () => {
           tenure={props.tenure}
           priorities={props.priorities}
           trades={props.trades}
+          contractors={[]}
+          setContractors={props.setContractors}
+          budgetCodes={[]}
+          setBudgetCodes={props.setBudgetCodes}
+          sorCodeArrays={[[]]}
+          setSorCodeArrays={props.setSorCodeArrays}
           contacts={props.contactDetails}
           onFormSubmit={props.onFormSubmit}
         />

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
@@ -78,6 +78,9 @@ describe('RaiseWorkOrderForm component', () => {
     setContractors: jest.fn(),
     setBudgetCodes: jest.fn(),
     setSorCodeArrays: jest.fn(),
+    setTradeCode: jest.fn(),
+    setContractorReference: jest.fn(),
+    setBudgetCodeId: jest.fn(),
   }
 
   it('should render properly', async () => {
@@ -99,6 +102,12 @@ describe('RaiseWorkOrderForm component', () => {
           setSorCodeArrays={props.setSorCodeArrays}
           contacts={props.contactDetails}
           onFormSubmit={props.onFormSubmit}
+          tradeCode={''}
+          setTradeCode={props.setTradeCode}
+          contractorReference={''}
+          setContractorReference={props.setContractorReference}
+          budgetCodeId={''}
+          setBudgetCodeId={props.setBudgetCodeId}
         />
       </UserContext.Provider>
     )
@@ -132,6 +141,12 @@ describe('RaiseWorkOrderForm component', () => {
           setSorCodeArrays={props.setSorCodeArrays}
           contacts={props.contactDetails}
           onFormSubmit={props.onFormSubmit}
+          tradeCode={''}
+          setTradeCode={props.setTradeCode}
+          contractorReference={''}
+          setContractorReference={props.setContractorReference}
+          budgetCodeId={''}
+          setBudgetCodeId={props.setBudgetCodeId}
         />
       </UserContext.Provider>
     )

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -19,8 +19,14 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
   const [tenure, setTenure] = useState({})
 
   const [trades, setTrades] = useState([])
+  const [tradeCode, setTradeCode] = useState('')
+
   const [contractors, setContractors] = useState([])
+  const [contractorReference, setContractorReference] = useState('')
+
   const [budgetCodes, setBudgetCodes] = useState([])
+  const [budgetCodeId, setBudgetCodeId] = useState('')
+
   const [sorCodeArrays, setSorCodeArrays] = useState([[]])
   const [priorities, setPriorities] = useState([])
   const [contacts, setContacts] = useState([])
@@ -194,8 +200,14 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
                 tenure={tenure}
                 priorities={priorities}
                 trades={trades}
+                tradeCode={tradeCode}
+                setTradeCode={setTradeCode}
                 contractors={contractors}
+                contractorReference={contractorReference}
+                setContractorReference={setContractorReference}
                 setContractors={setContractors}
+                budgetCodeId={budgetCodeId}
+                setBudgetCodeId={setBudgetCodeId}
                 budgetCodes={budgetCodes}
                 setBudgetCodes={setBudgetCodes}
                 sorCodeArrays={sorCodeArrays}

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -17,9 +17,14 @@ import router from 'next/router'
 const RaiseWorkOrderFormView = ({ propertyReference }) => {
   const [property, setProperty] = useState({})
   const [tenure, setTenure] = useState({})
+
   const [trades, setTrades] = useState([])
+  const [contractors, setContractors] = useState([])
+  const [budgetCodes, setBudgetCodes] = useState([])
+  const [sorCodeArrays, setSorCodeArrays] = useState([[]])
   const [priorities, setPriorities] = useState([])
   const [contacts, setContacts] = useState([])
+
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
   const [formSuccess, setFormSuccess] = useState(false)
@@ -189,6 +194,12 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
                 tenure={tenure}
                 priorities={priorities}
                 trades={trades}
+                contractors={contractors}
+                setContractors={setContractors}
+                budgetCodes={budgetCodes}
+                setBudgetCodes={setBudgetCodes}
+                sorCodeArrays={sorCodeArrays}
+                setSorCodeArrays={setSorCodeArrays}
                 contacts={contacts}
                 onFormSubmit={onFormSubmit}
                 raiseLimit={currentUser?.raiseLimit}

--- a/src/components/Property/RaiseWorkOrder/SelectPriority.test.js
+++ b/src/components/Property/RaiseWorkOrder/SelectPriority.test.js
@@ -56,6 +56,7 @@ describe('SelectPriority component', () => {
         priorityCode={props.priorityCode}
         priorityCodesWithoutDrs={props.priorityCodesWithoutDrs}
         register={props.register}
+        errors={{}}
       />
     )
     fireEvent.change(getByTestId('priorityCode'), { target: { value: 9 } })
@@ -73,6 +74,7 @@ describe('SelectPriority component', () => {
         priorityCode={props.priorityCode}
         priorityCodesWithoutDrs={props.priorityCodesWithoutDrs}
         register={props.register}
+        errors={{}}
       />
     )
     expect(asFragment()).toMatchSnapshot()
@@ -85,6 +87,7 @@ describe('SelectPriority component', () => {
         priorityCode={9}
         priorityCodesWithoutDrs={props.priorityCodesWithoutDrs}
         register={props.register}
+        errors={{}}
       />
     )
 

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -18,8 +18,14 @@ import {
 
 const TradeContractorRateScheduleItemView = ({
   trades,
+  tradeCode,
+  setTradeCode,
   contractors,
+  contractorReference,
+  setContractorReference,
   setContractors,
+  budgetCodeId,
+  setBudgetCodeId,
   budgetCodes,
   setBudgetCodes,
   sorCodeArrays,
@@ -38,9 +44,6 @@ const TradeContractorRateScheduleItemView = ({
   const [loadingContractors, setLoadingContractors] = useState(false)
   const [loadingSorCodes, setLoadingSorCodes] = useState(false)
   const [loadingBudgetCodes, setLoadingBudgetCodes] = useState(false)
-  const [tradeCode, setTradeCode] = useState('')
-  const [contractorReference, setContractorReference] = useState('')
-  const [budgetCodeId, setBudgetCodeId] = useState('')
 
   const [
     orderRequiresIncrementalSearch,
@@ -337,6 +340,12 @@ TradeContractorRateScheduleItemView.propTypes = {
   errors: PropTypes.object.isRequired,
   updatePriority: PropTypes.func.isRequired,
   getPriorityObjectByCode: PropTypes.func.isRequired,
+  tradeCode: PropTypes.string.isRequired,
+  setTradeCode: PropTypes.func.isRequired,
+  contractorReference: PropTypes.string.isRequired,
+  setContractorReference: PropTypes.func.isRequired,
+  budgetCodeId: PropTypes.string.isRequired,
+  setBudgetCodeId: PropTypes.func.isRequired,
 }
 
 export default TradeContractorRateScheduleItemView

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -18,6 +18,12 @@ import {
 
 const TradeContractorRateScheduleItemView = ({
   trades,
+  contractors,
+  setContractors,
+  budgetCodes,
+  setBudgetCodes,
+  sorCodeArrays,
+  setSorCodeArrays,
   propertyReference,
   register,
   errors,
@@ -33,13 +39,10 @@ const TradeContractorRateScheduleItemView = ({
   const [loadingSorCodes, setLoadingSorCodes] = useState(false)
   const [loadingBudgetCodes, setLoadingBudgetCodes] = useState(false)
   const [tradeCode, setTradeCode] = useState('')
-  const [contractors, setContractors] = useState([])
-  const [budgetCodes, setBudgetCodes] = useState([])
   const [contractorReference, setContractorReference] = useState('')
   const [contractorSelectDisabled, setContractorSelectDisabled] = useState(true)
   const [rateScheduleItemDisabled, setRateScheduleItemDisabled] = useState(true)
   const [budgetCodeItemDisabled, setBudgetCodeItemDisabled] = useState(true)
-  const [sorCodeArrays, setSorCodeArrays] = useState([[]])
 
   const [
     orderRequiresIncrementalSearch,
@@ -328,6 +331,8 @@ const TradeContractorRateScheduleItemView = ({
 
 TradeContractorRateScheduleItemView.propTypes = {
   trades: PropTypes.array.isRequired,
+  sorCodeArrays: PropTypes.array.isRequired,
+  setSorCodeArrays: PropTypes.func.isRequired,
   propertyReference: PropTypes.string.isRequired,
   register: PropTypes.func.isRequired,
   errors: PropTypes.object.isRequired,

--- a/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
+++ b/src/components/Property/RaiseWorkOrder/__snapshots__/RaiseWorkOrderForm.test.js.snap
@@ -343,27 +343,6 @@ exports[`RaiseWorkOrderForm component should render properly 1`] = `
         >
           You have 230 characters remaining.
         </span>
-        <input
-          id="propertyReference"
-          label="propertyReference"
-          name="propertyReference"
-          type="hidden"
-          value="00012345"
-        />
-        <input
-          id="shortAddress"
-          label="shortAddress"
-          name="shortAddress"
-          type="hidden"
-          value="16 Pitcairn House  St Thomass Square"
-        />
-        <input
-          id="postalCode"
-          label="postalCode"
-          name="postalCode"
-          type="hidden"
-          value="E9 6PT"
-        />
         <div
           class="govuk-warning-text lbh-warning-text"
         >
@@ -782,27 +761,6 @@ exports[`RaiseWorkOrderForm component should render without possibility to choos
         >
           You have 230 characters remaining.
         </span>
-        <input
-          id="propertyReference"
-          label="propertyReference"
-          name="propertyReference"
-          type="hidden"
-          value="00012345"
-        />
-        <input
-          id="shortAddress"
-          label="shortAddress"
-          name="shortAddress"
-          type="hidden"
-          value="16 Pitcairn House  St Thomass Square"
-        />
-        <input
-          id="postalCode"
-          label="postalCode"
-          name="postalCode"
-          type="hidden"
-          value="E9 6PT"
-        />
         <div
           class="govuk-warning-text lbh-warning-text"
         >

--- a/src/components/WorkOrder/TasksAndSors/MobileWorkingTasksAndSorsTable.test.js
+++ b/src/components/WorkOrder/TasksAndSors/MobileWorkingTasksAndSorsTable.test.js
@@ -50,6 +50,19 @@ describe('MobileWorkingTasksAndSorsTable component', () => {
         tasksAndSors={props.tasksAndSors}
         tabName={props.tabName}
         workOrderReference="10000000"
+        readOnly={false}
+      />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders tasks and SORs without links when readOnly is true', () => {
+    const { asFragment } = render(
+      <MobileWorkingTasksAndSorsTable
+        tasksAndSors={props.tasksAndSors}
+        tabName={props.tabName}
+        workOrderReference="10000000"
+        readOnly={true}
       />
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/WorkOrder/TasksAndSors/__snapshots__/MobileWorkingTasksAndSorsTable.test.js.snap
+++ b/src/components/WorkOrder/TasksAndSors/__snapshots__/MobileWorkingTasksAndSorsTable.test.js.snap
@@ -164,3 +164,138 @@ exports[`MobileWorkingTasksAndSorsTable component renders tasks and SORs table p
   </div>
 </DocumentFragment>
 `;
+
+exports[`MobileWorkingTasksAndSorsTable component renders tasks and SORs without links when readOnly is true 1`] = `
+<DocumentFragment>
+  <div
+    class="operative-work-order-task-and-sors-table"
+  >
+    <h2
+      class="lbh-heading-h2"
+    >
+      Tasks and SORs
+    </h2>
+    <table
+      class="govuk-table lbh-table latest-tasks-and-sors-table govuk-!-margin-top-0"
+    >
+      <thead
+        class="govuk-table__head"
+      >
+        <tr
+          class="govuk-table__row lbh-body"
+        >
+          <th
+            class="govuk-table__header"
+            scope="col"
+          >
+            Qty
+          </th>
+          <th
+            class="govuk-table__header"
+            scope="col"
+          >
+            SOR
+          </th>
+          <th
+            class="govuk-table__header"
+            scope="col"
+          >
+            Description
+          </th>
+          <th
+            class="govuk-table__header govuk-table__header--numeric"
+            scope="col"
+          >
+            SMV
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row lbh-body"
+          data-row-id="0"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            2
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            DES5R006
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            Urgent call outs
+          </td>
+          <td
+            class="govuk-table__cell govuk-table__cell--numeric"
+          >
+            50
+          </td>
+        </tr>
+        <tr
+          class="govuk-table__row lbh-body"
+          data-row-id="1"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            4
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            DES5R005
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            Normal call outs
+          </td>
+          <td
+            class="govuk-table__cell govuk-table__cell--numeric"
+          >
+            120
+          </td>
+        </tr>
+        <tr
+          class="govuk-table__row lbh-body zero-quantity-row"
+          data-row-id="2"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            0
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            DES5R013
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            Inspect additional sec entrance
+          </td>
+          <td
+            class="govuk-table__cell govuk-table__cell--numeric"
+          >
+            0
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h3
+      class="lbh-heading-h3 background-wrap-color"
+    >
+      SMV total 170
+    </h3>
+    <br />
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/WorkOrders/CloseWorkOrderSuccessPage.test.js
+++ b/src/components/WorkOrders/CloseWorkOrderSuccessPage.test.js
@@ -3,7 +3,7 @@ import CloseWorkOrderSuccessPage from './CloseWorkOrderSuccessPage'
 
 describe('CloseWorkOrderSuccessPage component', () => {
   const props = {
-    workOrderReference: '10000012',
+    workOrderReference: 10000012,
   }
 
   describe('should render properly', () => {

--- a/src/pages/api/[...path].test.js
+++ b/src/pages/api/[...path].test.js
@@ -290,7 +290,7 @@ describe('/api/[...path]', () => {
             axios.create = jest.fn(() => axios)
 
             // Mock the 'GET' return value from the service API
-            axios.mockImplementationOnce(() =>
+            axios.mockImplementation(() =>
               Promise.resolve({
                 status: 200,
                 data: { key: 'hackney' },


### PR DESCRIPTION
We need this form to retain state when the user navigates away to another form step and comes back, as they will for the upcoming multiple SOR workflow.

This PR prepares for that by pushing state up into the parent "view" component.

It also removes some unnecessary hidden fields, simplifies the way we control input disabled states, and fixes lots of error output in Jest test runs.