### PR TITLE
Display Contract area in budget code dropdown

### DIFF
--- a/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
+++ b/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
@@ -57,7 +57,7 @@ const BudgetCodeItemView = ({
                 ) || 'Budget code is not valid',
             })}
             error={errors && errors.budgetCode}
-            widthClass="govuk-!-width-one-half"
+            widthClass="govuk-!-width-full"
           />
           {apiError && <ErrorMessage label={apiError} />}
         </>

--- a/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
+++ b/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
@@ -57,7 +57,7 @@ const BudgetCodeItemView = ({
                 ) || 'Budget code is not valid',
             })}
             error={errors && errors.budgetCode}
-            widthClass="govuk-!-width-full"
+            widthClass="govuk-!-width-one-half"
           />
           {apiError && <ErrorMessage label={apiError} />}
         </>

--- a/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
+++ b/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
@@ -4,6 +4,8 @@ import Spinner from '../../Spinner'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import { formatBudgetCodeForOption } from '@/utils/helpers/budgetCodes'
 
+
+
 const BudgetCodeItemView = ({
   budgetCodeId,
   setBudgetCodeId,
@@ -14,9 +16,10 @@ const BudgetCodeItemView = ({
   loading,
   apiError,
   afterValidBudgetCodeSelected,
+  contractorIsPurdy
 }) => {
   const budgetCodeOptions = budgetCodes.map((code) =>
-    formatBudgetCodeForOption(code)
+    formatBudgetCodeForOption(code, contractorIsPurdy)
   )
 
   const budgetCodesWithOptions = budgetCodes.map((code, index) => ({
@@ -83,6 +86,7 @@ BudgetCodeItemView.propTypes = {
   loading: PropTypes.bool.isRequired,
   apiError: PropTypes.string,
   afterValidBudgetCodeSelected: PropTypes.func.isRequired,
+  contractorIsPurdy: PropTypes.bool.isRequired
 }
 
 export default BudgetCodeItemView

--- a/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
+++ b/src/components/Property/RaiseWorkOrder/BudgetCodeItemView.js
@@ -4,8 +4,6 @@ import Spinner from '../../Spinner'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import { formatBudgetCodeForOption } from '@/utils/helpers/budgetCodes'
 
-
-
 const BudgetCodeItemView = ({
   budgetCodeId,
   setBudgetCodeId,
@@ -16,7 +14,7 @@ const BudgetCodeItemView = ({
   loading,
   apiError,
   afterValidBudgetCodeSelected,
-  contractorIsPurdy
+  contractorIsPurdy,
 }) => {
   const budgetCodeOptions = budgetCodes.map((code) =>
     formatBudgetCodeForOption(code, contractorIsPurdy)
@@ -86,7 +84,7 @@ BudgetCodeItemView.propTypes = {
   loading: PropTypes.bool.isRequired,
   apiError: PropTypes.string,
   afterValidBudgetCodeSelected: PropTypes.func.isRequired,
-  contractorIsPurdy: PropTypes.bool.isRequired
+  contractorIsPurdy: PropTypes.bool.isRequired,
 }
 
 export default BudgetCodeItemView

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -308,7 +308,9 @@ const TradeContractorRateScheduleItemView = ({
             budgetCodeId={budgetCodeId}
             setBudgetCodeId={setBudgetCodeId}
             register={register}
-            contractorIsPurdy={contractorReference === PURDY_CONTRACTOR_REFERENCE}
+            contractorIsPurdy={
+              contractorReference === PURDY_CONTRACTOR_REFERENCE
+            }
             afterValidBudgetCodeSelected={async () => {
               await prepareSORData(contractorReference, tradeCode)
             }}

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -308,6 +308,7 @@ const TradeContractorRateScheduleItemView = ({
             budgetCodeId={budgetCodeId}
             setBudgetCodeId={setBudgetCodeId}
             register={register}
+            contractorIsPurdy={contractorReference === PURDY_CONTRACTOR_REFERENCE}
             afterValidBudgetCodeSelected={async () => {
               await prepareSORData(contractorReference, tradeCode)
             }}

--- a/src/utils/helpers/budgetCodes.js
+++ b/src/utils/helpers/budgetCodes.js
@@ -9,7 +9,7 @@ export const formatBudgetCodeForOption = (
     budgetCode?.descriptionOfWorks,
   ]
 
-  if (!contractorIsPurdy) displayFields.push(budgetCode?.contractorsList)
+  if (!contractorIsPurdy) displayFields.push(budgetCode?.contractorList)
 
   return displayFields.filter((x) => x).join(separator)
 }

--- a/src/utils/helpers/budgetCodes.js
+++ b/src/utils/helpers/budgetCodes.js
@@ -1,18 +1,26 @@
-export const formatBudgetCodeForOption = (budgetCode, separator = ' - ') =>
-  [
+export const formatBudgetCodeForOption = (
+  budgetCode,
+  contractorIsPurdy,
+  separator = ' - '
+) => {
+  const displayFields = [
     budgetCode?.externalCostCode,
     budgetCode?.corporateSubjectiveCode,
     budgetCode?.descriptionOfWorks,
   ]
-    .filter((x) => x)
-    .join(separator)
 
-export const formatBudgetCode = (budgetCode) =>
-  [
+  if (!contractorIsPurdy) displayFields.push(budgetCode?.contractorsList)
+
+  return displayFields.filter((x) => x).join(separator)
+}
+
+export const formatBudgetCode = (budgetCode) => {
+  const displayFields = [
     budgetCode?.externalCostCode,
     [budgetCode?.corporateSubjectiveCode, budgetCode?.descriptionOfWorks]
       .filter((x) => x)
       .join(' '),
   ]
-    .filter((x) => x)
-    .join(' - ')
+
+  return displayFields.filter((x) => x).join(' - ')
+}

--- a/src/utils/helpers/budgetCodes.test.js
+++ b/src/utils/helpers/budgetCodes.test.js
@@ -1,13 +1,22 @@
 import { formatBudgetCode, formatBudgetCodeForOption } from './budgetCodes'
 
 describe('formatBudgetCodeForOption', () => {
-  it('includes the externalCostCode, corporateSubjectiveCode and descriptionOfWorks', () => {
+  const budgetCode = {
+    externalCostCode: 'costCode',
+    corporateSubjectiveCode: 'subjectiveCode',
+    descriptionOfWorks: 'description',
+    contractorsList: 'H01, H02'
+  };
+
+  it('includes the externalCostCode, corporateSubjectiveCode, descriptionOfWorks, and contractorsList', () => {
     expect(
-      formatBudgetCodeForOption({
-        externalCostCode: 'costCode',
-        corporateSubjectiveCode: 'subjectiveCode',
-        descriptionOfWorks: 'description',
-      })
+      formatBudgetCodeForOption(budgetCode)
+    ).toEqual('costCode - subjectiveCode - description - H01, H02')
+  })
+
+  it('doesnt include contractorsList when contractor is Purdy', () => {
+    expect(
+      formatBudgetCodeForOption(budgetCode, true)
     ).toEqual('costCode - subjectiveCode - description')
   })
 })

--- a/src/utils/helpers/budgetCodes.test.js
+++ b/src/utils/helpers/budgetCodes.test.js
@@ -5,19 +5,19 @@ describe('formatBudgetCodeForOption', () => {
     externalCostCode: 'costCode',
     corporateSubjectiveCode: 'subjectiveCode',
     descriptionOfWorks: 'description',
-    contractorsList: 'H01, H02'
-  };
+    contractorsList: 'H01, H02',
+  }
 
   it('includes the externalCostCode, corporateSubjectiveCode, descriptionOfWorks, and contractorsList', () => {
-    expect(
-      formatBudgetCodeForOption(budgetCode)
-    ).toEqual('costCode - subjectiveCode - description - H01, H02')
+    expect(formatBudgetCodeForOption(budgetCode)).toEqual(
+      'costCode - subjectiveCode - description - H01, H02'
+    )
   })
 
   it('doesnt include contractorsList when contractor is Purdy', () => {
-    expect(
-      formatBudgetCodeForOption(budgetCode, true)
-    ).toEqual('costCode - subjectiveCode - description')
+    expect(formatBudgetCodeForOption(budgetCode, true)).toEqual(
+      'costCode - subjectiveCode - description'
+    )
   })
 })
 

--- a/src/utils/helpers/budgetCodes.test.js
+++ b/src/utils/helpers/budgetCodes.test.js
@@ -5,16 +5,16 @@ describe('formatBudgetCodeForOption', () => {
     externalCostCode: 'costCode',
     corporateSubjectiveCode: 'subjectiveCode',
     descriptionOfWorks: 'description',
-    contractorsList: 'H01, H02',
+    contractorList: 'H01, H02',
   }
 
-  it('includes the externalCostCode, corporateSubjectiveCode, descriptionOfWorks, and contractorsList', () => {
+  it('includes the externalCostCode, corporateSubjectiveCode, descriptionOfWorks, and contractorList', () => {
     expect(formatBudgetCodeForOption(budgetCode)).toEqual(
       'costCode - subjectiveCode - description - H01, H02'
     )
   })
 
-  it('doesnt include contractorsList when contractor is Purdy', () => {
+  it('doesnt include contractorList when contractor is Purdy', () => {
     expect(formatBudgetCodeForOption(budgetCode, true)).toEqual(
       'costCode - subjectiveCode - description'
     )


### PR DESCRIPTION
[Ticket
](https://hackney.atlassian.net/browse/MR-410?atlOrigin=eyJpIjoiYWFkODZkNDlhMDIwNDlmOThlYTUxYjQwYTkwYjNlOGYiLCJwIjoiaiJ9)

### Description of change

Display contract area in budgetCode dropdown, unless the contractor is purdy. For purdy, only purdy budgetCodes are returned, so the contract area is implicit.

### Spacing issues

Some of the budget code descriptions are being cut off in the datalist. This was already an issue with some descriptions, so Im not sure if its within the scope of this ticket. 

However, since some budget codes have been cut off, the user cannot see the contract area.