### PR TITLE
Changes to gitignore (env files wildcard and version lock files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,9 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-# CAUTION: do not remove .env unless you are certain all team members have
+# CAUTION: do not remove .env* unless you are certain all team members have
 # migrated to the local equivalents (the dotenv-flow approach).
-.env
-.env.*
+.env*
 
 # vercel
 .vercel


### PR DESCRIPTION
### Description of change

Modified gitignore file to include all env file variants using a wildcard, this means any files beginning with 

`".env" `

should be not be included in future commits and they won't be pushed to Github.

Version lock files (package-lock.json and yarn.lock) have also been added as at the moment there seems to be no need for these files to be committed/pushed to the repository.

### Story Link

N/A

### Automated test checklist

N/A

### Decisions [OPTIONAL]

N/A

### Known issues [OPTIONAL]

N/A
