### PR TITLE
Work Order Update page link spacing

### DIFF
--- a/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
+++ b/src/components/WorkOrder/RateScheduleItems/AddedRateScheduleItems.js
@@ -167,9 +167,8 @@ const AddedRateScheduleItems = ({
 
   return (
     <>
+      <div>{showRateScheduleItems(rateScheduleItems)}</div>
       <div>
-        {showRateScheduleItems(rateScheduleItems)}
-
         <a className="lbh-link" href="#" onClick={addRateScheduleItem}>
           + Add another SOR code
         </a>

--- a/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
+++ b/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
@@ -204,6 +204,7 @@ exports[`WorkOrderUpdateForm component should render properly when there are no 
         />
       </section>
     </div>
+    <div />
     <div>
       <a
         class="lbh-link"
@@ -570,6 +571,8 @@ exports[`WorkOrderUpdateForm component should render properly with 250 character
           </button>
         </div>
       </div>
+    </div>
+    <div>
       <a
         class="lbh-link"
         href="#"
@@ -928,6 +931,8 @@ exports[`WorkOrderUpdateForm component should render properly with unlimited cha
           </button>
         </div>
       </div>
+    </div>
+    <div>
       <a
         class="lbh-link"
         href="#"


### PR DESCRIPTION
### Description of change

Fixed issue with spacing between the last SOR field and link below, in Work Order Update page

BEFORE
![image](https://user-images.githubusercontent.com/70756861/188168499-90715789-2f45-4e37-9233-98601809d72f.png)

AFTER
![image](https://user-images.githubusercontent.com/70756861/188168550-47ef0083-1dd6-4e21-bb05-2e62eda28797.png)

and updated snapshot.

### Story Link

https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?modal=detail&selectedIssue=MR-398
