### PR TITLE
MR-574 - SOR codes now sorted by displayPriority (Raise-Repair page)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "endOfLine":"auto",
+  "endOfLine": "auto",
   "useTabs": false
 }

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -233,7 +233,11 @@ const TradeContractorRateScheduleItemView = ({
         },
       })
 
-      setSorCodeArrays([sorCodes])
+      setSorCodeArrays([
+        sorCodes.sort((a, b) => {
+          return b.displayPriority - a.displayPriority
+        }),
+      ])
     } catch (e) {
       resetSORs()
       console.error('An error has occured:', e.response)


### PR DESCRIPTION
### Description of change

SOR codes now are sorted based on the newly added displayPriority

Before:
![image](https://user-images.githubusercontent.com/70756861/200078431-97bd85f1-c52c-4299-880e-9ac514b3d8f6.png)
(Shows top options, no 200xxxxx SOR codes)

After:
![image](https://user-images.githubusercontent.com/70756861/200078169-7558af60-b655-4bb6-bbef-2f00251ce068.png)
(Shows 200xxxxx codes, going from the top down, based on displayPriority: 200xxxxx SOR codes have a displayPriority of 1, while the others have default displayPriority of 0).


### Story Link

https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?modal=detail&selectedIssue=MR-574

### Automated test checklist

If a type of test isn't included, add note explaining why.

No functionality has been altered

### Decisions [OPTIONAL]

Not sure how scalable this displayPriority system is going to be going forward if more priorities need to be added. It's fine if we define a higher priority: priority "2" for example will end up being on top of priority "1" SOR codes (200xxxxx), but what if we introduce more priorities, and these are below priority "1", but higher than priority "0"?

### Known issues [OPTIONAL]

N/A