### PR TITLE
Add support for linked notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "start": "next start -p 5001",
     "tests": "yarn test:unit && yarn test:e2e",
     "test:unit": "NODE_ENV=test node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage",
+    "test:unit-windows": "node ./node_modules/jest/bin/jest.js --runInBand",
+    "test:unit-win-upd": "node ./node_modules/jest/bin/jest.js --runInBand --updateSnapshot",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx && echo 'Lint complete.'",
     "lintfix": "eslint . --max-warnings 0 --ext .js,.jsx --fix",
     "test:e2e": "NODE_ENV=test start-test 5001 cy:run",

--- a/src/components/WorkOrder/Notes/NoteEntry.js
+++ b/src/components/WorkOrder/Notes/NoteEntry.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types'
 import { formatDateTime } from '@/utils/time'
 
+const IMAGE_DETECTION_STRING = 'Image from user: '
+
 const NoteInfo = ({ time, user, email }) => {
   return (
     <>
@@ -10,18 +12,30 @@ const NoteInfo = ({ time, user, email }) => {
   )
 }
 
+const DetectImageNote = (note) => {
+  return note.includes(IMAGE_DETECTION_STRING)
+}
+
+const ParseUriFromImageNote = (note) => {
+  return note.replace(IMAGE_DETECTION_STRING, '')
+}
+
 const NoteEntry = ({ note, time, user, userEmail }) => {
   return (
     <>
       <div className="note-info lbh-body-s">
         <NoteInfo time={time} user={user} email={userEmail} />
       </div>
-      {note.split('\n').map((el, i) => (
-        <span key={i}>
-          {el}
-          <br />
-        </span>
-      ))}
+      {DetectImageNote(note) ? (
+        <a href={ParseUriFromImageNote(note)}>{'Image from user'}</a>
+      ) : (
+        note.split('\n').map((el, i) => (
+          <span key={i}>
+            {el}
+            <br />
+          </span>
+        ))
+      )}
     </>
   )
 }

--- a/src/components/WorkOrder/Notes/NoteEntry.test.js
+++ b/src/components/WorkOrder/Notes/NoteEntry.test.js
@@ -4,7 +4,7 @@ import NoteEntry from './NoteEntry'
 describe('NoteEntry component', () => {
   const props = {
     note: 'Image from user: http://example-url/',
-    time: new Date(),
+    time: '',
     user: 'Test user',
     userEmail: 'sample@sample.com',
   }

--- a/src/components/WorkOrder/Notes/NoteEntry.test.js
+++ b/src/components/WorkOrder/Notes/NoteEntry.test.js
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react'
+import NoteEntry from './NoteEntry'
+
+describe('NoteEntry component', () => {
+  const props = {
+    note: 'Image from user: http://example-url/',
+    time: new Date(),
+    user: 'Test user',
+    userEmail: 'sample@sample.com',
+  }
+
+  it('should render properle', () => {
+    const { asFragment } = render(
+      <NoteEntry
+        note={props.note}
+        time={props.time}
+        user={props.user}
+        userEmail={props.userEmail}
+      />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/components/WorkOrder/Notes/__snapshots__/NoteEntry.test.js.snap
+++ b/src/components/WorkOrder/Notes/__snapshots__/NoteEntry.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoteEntry component should render properle 1`] = `
+<DocumentFragment>
+  <div
+    class="note-info lbh-body-s"
+  >
+    20 Dec 2022, 15:32 by Test user (sample@sample.com)
+  </div>
+  <a
+    href="http://example-url/"
+  >
+    Image from user
+  </a>
+</DocumentFragment>
+`;

--- a/src/components/WorkOrder/Notes/__snapshots__/NoteEntry.test.js.snap
+++ b/src/components/WorkOrder/Notes/__snapshots__/NoteEntry.test.js.snap
@@ -5,7 +5,7 @@ exports[`NoteEntry component should render properle 1`] = `
   <div
     class="note-info lbh-body-s"
   >
-    20 Dec 2022, 15:32 by Test user (sample@sample.com)
+    — by Test user (sample@sample.com)
   </div>
   <a
     href="http://example-url/"


### PR DESCRIPTION
- Previously, a note with a URL would be added from HROL with this format:

![image](https://user-images.githubusercontent.com/8542878/208705599-5f4d83b9-c96f-4d43-99a7-05022b107df8.png)

Obviously that's not mobile (or desktop) friendly, and doesn't contain an actual link. This change introduces a new type of note "linked note" using a magic phrase:

![image](https://user-images.githubusercontent.com/8542878/208705809-652db789-a2ac-42d5-b168-13a7ee33b2a6.png)
