### PR TITLE
[RH FrontEnd] Tech Debt - Corrected permittedRoles in RH pages

### DIFF
--- a/src/pages/backoffice/close-workorders.js
+++ b/src/pages/backoffice/close-workorders.js
@@ -1,4 +1,4 @@
-import { DATA_ADMIN } from '@/utils/user'
+import { DATA_ADMIN_ROLE } from '@/utils/user'
 
 import Meta from '../../components/Meta'
 
@@ -16,6 +16,6 @@ const CloseWorkOrdersPage = () => {
 
 export const getServerSideProps = getQueryProps
 
-CloseWorkOrdersPage.permittedRoles = [DATA_ADMIN]
+CloseWorkOrdersPage.permittedRoles = [DATA_ADMIN_ROLE]
 
 export default CloseWorkOrdersPage

--- a/src/pages/backoffice/index.js
+++ b/src/pages/backoffice/index.js
@@ -1,4 +1,4 @@
-import { DATA_ADMIN } from '@/utils/user'
+import { DATA_ADMIN_ROLE } from '@/utils/user'
 
 import Meta from '../../components/Meta'
 import { getQueryProps } from '../../utils/helpers/serverSideProps'
@@ -16,6 +16,6 @@ const BackOfficePage = () => {
 
 export const getServerSideProps = getQueryProps
 
-BackOfficePage.permittedRoles = [DATA_ADMIN]
+BackOfficePage.permittedRoles = [DATA_ADMIN_ROLE]
 
 export default BackOfficePage

--- a/src/pages/backoffice/manage-sor-codes.js
+++ b/src/pages/backoffice/manage-sor-codes.js
@@ -1,4 +1,4 @@
-import { DATA_ADMIN } from '@/utils/user'
+import { DATA_ADMIN_ROLE } from '@/utils/user'
 
 import Meta from '../../components/Meta'
 
@@ -16,6 +16,6 @@ const ManageSORCodesPage = () => {
 
 export const getServerSideProps = getQueryProps
 
-ManageSORCodesPage.permittedRoles = [DATA_ADMIN]
+ManageSORCodesPage.permittedRoles = [DATA_ADMIN_ROLE]
 
 export default ManageSORCodesPage

--- a/src/pages/backoffice/sor-contracts.js
+++ b/src/pages/backoffice/sor-contracts.js
@@ -1,4 +1,4 @@
-import { DATA_ADMIN } from '@/utils/user'
+import { DATA_ADMIN_ROLE } from '@/utils/user'
 
 import Meta from '../../components/Meta'
 
@@ -16,6 +16,6 @@ const SORContractsPage = () => {
 
 export const getServerSideProps = getQueryProps
 
-SORContractsPage.permittedRoles = [DATA_ADMIN]
+SORContractsPage.permittedRoles = [DATA_ADMIN_ROLE]
 
 export default SORContractsPage


### PR DESCRIPTION
The js files under pages`/backoffice` had `DATA_ADMIN` as a permitted role, imported from user.js however the correct name for the role in `user.js` is `DATA_ADMIN_ROLE`.

The `/backoffice` can now be accessed without routing to the Access Denied (assuming the user is part of the `repairs-hub-data-admin` Google group.