### PR TITLE
MR-688 - Modify SOR contracts confirmation modal

### DIFF
--- a/cypress/integration/backoffice/sor-contracts.spec.js
+++ b/cypress/integration/backoffice/sor-contracts.spec.js
@@ -6,7 +6,7 @@ describe('SOR-Contracts - when user unauthorized', () => {
   it("Shows access denied when user doesn't have correct permissions", () => {
     cy.loginWithOperativeRole()
     cy.visit('/backoffice/sor-contracts')
-    cy.contains('Access denied')
+    cy.contains('Access denied').should('be.visible')
   })
 })
 
@@ -31,12 +31,12 @@ describe('SOR-Contracts - When Copy selected', () => {
   it('Shows error messages when form fields invalid', () => {
     cy.get("[data-test='submit-button']").click()
 
-    cy.get('.govuk-error-message.lbh-error-message').contains(
-      'You must enter a source property reference'
-    )
-    cy.get('.govuk-error-message.lbh-error-message').contains(
-      'You must enter a destination property reference'
-    )
+    cy.get('.govuk-error-message.lbh-error-message')
+      .contains('You must enter a source property reference')
+      .should('be.visible')
+    cy.get('.govuk-error-message.lbh-error-message')
+      .contains('You must enter a destination property reference')
+      .should('be.visible')
   })
 
   it('shows error messages when property references invalid', () => {
@@ -64,12 +64,14 @@ describe('SOR-Contracts - When Copy selected', () => {
 
     cy.get("[data-test='submit-button']").click()
 
-    cy.get('.govuk-error-message.lbh-error-message').contains(
-      'The destination property reference cannot match source property reference'
-    )
+    cy.get('.govuk-error-message.lbh-error-message')
+      .contains(
+        'The destination property reference cannot match source property reference'
+      )
+      .should('be.visible')
   })
 
-  it('sends request to /sor-contracts', () => {
+  it('sends request to /sor-contracts after displaying the confirmation modal', () => {
     cy.intercept(
       {
         method: 'POST',
@@ -88,10 +90,18 @@ describe('SOR-Contracts - When Copy selected', () => {
     )
     cy.get("[data-test='submit-button']").click()
 
-    cy.wait('@sorContractRequest')
+    // Assert confirmation modal is visible
+    cy.get("[data-test='confirmation-modal']").should('be.visible')
 
-    cy.contains('SOR Contract Modification')
-    cy.contains('SOR contracts modified successfully!')
+    // Click 'Modify SOR contract' modal button
+    cy.get("[data-test='confirm-button']").click()
+
+    cy.wait('@sorContractRequest')
+      .its('request.url')
+      .should('contain', '/api/backOffice/sor-contracts')
+
+    cy.contains('SOR contract modification').should('be.visible')
+    cy.contains('SOR contracts modified successfully!').should('be.visible')
   })
 })
 
@@ -118,15 +128,15 @@ describe('SOR-Contracts - When Add selected', () => {
   it('Shows error messages when form fields invalid', () => {
     cy.get("[data-test='submit-button']").click()
 
-    cy.get('.govuk-error-message.lbh-error-message').contains(
-      'You must enter a destination property reference'
-    )
-    cy.get('.govuk-error-message.lbh-error-message').contains(
-      'You must select a contractor'
-    )
-    cy.get('.govuk-error-message.lbh-error-message').contains(
-      'You must select a contract'
-    )
+    cy.get('.govuk-error-message.lbh-error-message')
+      .contains('You must enter a destination property reference')
+      .should('be.visible')
+    cy.get('.govuk-error-message.lbh-error-message')
+      .contains('You must select a contractor')
+      .should('be.visible')
+    cy.get('.govuk-error-message.lbh-error-message')
+      .contains('You must select a contract')
+      .should('be.visible')
   })
 
   it('shows error message when property references invalid', () => {
@@ -137,12 +147,12 @@ describe('SOR-Contracts - When Add selected', () => {
 
     cy.get("[data-test='submit-button']").click()
 
-    cy.get('.govuk-error-message.lbh-error-message').contains(
-      'PropertyReference is invalid'
-    )
+    cy.get('.govuk-error-message.lbh-error-message')
+      .contains('PropertyReference is invalid')
+      .should('be.visible')
   })
 
-  it('sends request to /sor-contracts', () => {
+  it('sends request to /sor-contracts after displaying the confirmation modal', () => {
     cy.intercept(
       {
         method: 'GET',
@@ -178,9 +188,17 @@ describe('SOR-Contracts - When Add selected', () => {
 
     cy.get("[data-test='submit-button']").click()
 
-    cy.wait('@sorContractRequest')
+    // Assert confirmation modal is visible
+    cy.get("[data-test='confirmation-modal']").should('be.visible')
 
-    cy.contains('SOR Contract Modification')
-    cy.contains('SOR contracts modified successfully!')
+    // Click 'Modify SOR contract' modal button
+    cy.get("[data-test='confirm-button']").click()
+
+    cy.wait('@sorContractRequest')
+      .its('request.url')
+      .should('contain', '/api/backOffice/sor-contracts')
+
+    cy.contains('SOR contract modification').should('be.visible')
+    cy.contains('SOR contracts modified successfully!').should('be.visible')
   })
 })

--- a/src/components/BackOffice/SORContracts/__snapshots__/index.test.js.snap
+++ b/src/components/BackOffice/SORContracts/__snapshots__/index.test.js.snap
@@ -11,7 +11,7 @@ exports[`SORContracts component should render the component 1`] = `
   <h1
     class="lbh-heading-h1"
   >
-    SOR Contract Modification
+    SOR contract modification
   </h1>
   <svg
     data-testid="spinner-undefined"

--- a/src/components/BackOffice/SORContracts/index.js
+++ b/src/components/BackOffice/SORContracts/index.js
@@ -1,6 +1,7 @@
 import Layout from '../Layout'
 import { useState } from 'react'
 import { TextInput, Button } from '../../Form'
+import ConfirmationModal from '../Components/ConfirmationModal'
 import ControlledRadio from '../Components/ControlledRadio'
 import Spinner from '../../Spinner'
 import ErrorMessage from '../../Errors/ErrorMessage'
@@ -41,6 +42,7 @@ const SORContracts = () => {
     destinationPropertyReference,
     setDestinationPropertyReference,
   ] = useState('')
+  const [showDialog, setShowDialog] = useState(false)
 
   const {
     contractors,
@@ -106,6 +108,24 @@ const SORContracts = () => {
     setFormSuccess(null)
     setErrors({})
     setRequestError(null)
+    setShowDialog(false)
+  }
+
+  const renderConfirmationModal = () => {
+    if (showDialog) {
+      return (
+        <ConfirmationModal
+          title={'Modify SOR contracts?'}
+          showDialog
+          setShowDialog={setShowDialog}
+          modalText={
+            'The operation cannot be undone, please make sure the details entered are correct before proceeding.'
+          }
+          onSubmit={modifySORContracts}
+          yesButtonText={'Modify contracts'}
+        />
+      )
+    }
   }
 
   const handleSubmit = (e) => {
@@ -119,14 +139,18 @@ const SORContracts = () => {
 
     if (Object.keys(newErrors).length > 0) return
 
+    setShowDialog(true)
+  }
+
+  const modifySORContracts = () => {
+    setLoading(true)
+
     const body = dataToRequestObject(
       sourcePropertyReference,
       destinationPropertyReference,
       selectedContract,
       selectedOption
     )
-
-    setLoading(true)
 
     saveContractChangesToDatabase(body)
       .then(() => {
@@ -144,11 +168,12 @@ const SORContracts = () => {
       })
       .finally(() => {
         setLoading(false)
+        setShowDialog(false)
       })
   }
 
   return (
-    <Layout title="SOR Contract Modification">
+    <Layout title="SOR contract modification">
       {loading || loadingContractors ? (
         <Spinner />
       ) : (
@@ -165,6 +190,8 @@ const SORContracts = () => {
           ) : (
             <form onSubmit={handleSubmit}>
               {requestError && <ErrorMessage label={requestError} />}
+
+              {renderConfirmationModal()}
 
               <div>
                 <ControlledRadio
@@ -253,7 +280,7 @@ const SORContracts = () => {
               <div>
                 <Button
                   data-test="submit-button"
-                  label="Save Changes"
+                  label="Save changes"
                   type="submit"
                 />
               </div>

--- a/src/components/BackOffice/hooks/useSelectContract.js
+++ b/src/components/BackOffice/hooks/useSelectContract.js
@@ -46,7 +46,6 @@ const useSelectContract = () => {
   }, [selectedContractor])
 
   const handleSelectContractor = (e) => {
-    // Ternary operator prevents the line below from erroring when "resetForm() calls handleSelectContractor(null)"
     const contractorName = e ? e.target?.value : undefined
     const selectedContractor = contractors.find(
       (contractor) => contractor.contractorName === contractorName

--- a/src/components/BackOffice/hooks/useSelectContract.js
+++ b/src/components/BackOffice/hooks/useSelectContract.js
@@ -46,7 +46,8 @@ const useSelectContract = () => {
   }, [selectedContractor])
 
   const handleSelectContractor = (e) => {
-    const contractorName = e.target.value
+    // Ternary operator prevents the line below from erroring when "resetForm() calls handleSelectContractor(null)"
+    const contractorName = e ? e.target?.value : undefined
     const selectedContractor = contractors.find(
       (contractor) => contractor.contractorName === contractorName
     )


### PR DESCRIPTION
- Added confirmation modal prior to sending POST request to modify SOR contracts
- Added tests to assert the modal is shown and other test assertions mentioned in PR comments #743 
- Corrected issue with useSelectContract hook to prevent error when resetForm() would call handleSelectContractor and pass null instead of a valid browser event.

![image](https://user-images.githubusercontent.com/70756861/219462572-68567621-c89d-4e2d-94c5-c20e8c93a0ed.png)