### PR TITLE
RH - Improvements to Backoffice testing (specific to form reset)

### DIFF
--- a/cypress/integration/backoffice/add-new-sor-codes.spec.js
+++ b/cypress/integration/backoffice/add-new-sor-codes.spec.js
@@ -205,6 +205,39 @@ describe('Add New SOR Codes page - when user has data admin permissions', () => 
       cy.contains('Add more SOR codes').should('be.visible')
     })
 
+    it('takes the user back to the form page with blank fields, when the user clicks on the "Add more SOR codes" link under the success message', () => {
+      cy.wait('@contractorsRequest')
+      cy.wait('@tradesRequest')
+
+      cy.intercept(
+        { method: 'POST', path: '/api/backoffice/sor-codes' },
+        { statusCode: 200 }
+      ).as('newSORCodeSubmitRequest')
+
+      populateForm()
+
+      // Submit new SOR codes
+      cy.get('[data-testid="submit-button"]').click()
+
+      // Press "Add SOR codes" in confirmation modal
+      cy.get('[data-test="confirm-button"]').click()
+
+      cy.wait('@newSORCodeSubmitRequest')
+
+      // Click on "Add more SOR codes
+      cy.contains('Add more SOR codes').click()
+
+      // Assert all the fields are empty
+      cy.get('[data-testid="contractor"]').should('be.empty')
+      cy.get('[data-testid="contract"]').should('be.empty')
+      cy.get('[data-testid="trade"]').should('be.empty')
+      cy.get('[data-testid="sor-code-input"]').should('be.empty')
+      cy.get('[data-testid="sor-code-cost-input"]').should('be.empty')
+      cy.get('[data-testid="sor-code-smv-input"]').should('be.empty')
+      cy.get('[data-testid="sor-code-short-desc-input"]').should('be.empty')
+      cy.get('[data-testid="sor-code-long-desc-input"]').should('be.empty')
+    })
+
     it('displays an error message if the network request fails, after all form fields are populated and the form is submitted', () => {
       cy.wait('@contractorsRequest')
       cy.wait('@tradesRequest')

--- a/cypress/integration/backoffice/close-workorders.spec.js
+++ b/cypress/integration/backoffice/close-workorders.spec.js
@@ -85,7 +85,7 @@ describe('Close-WorkOrders', () => {
 
     cy.wait('@cancelRequest').its('request.method').should('deep.equal', 'POST')
 
-    cy.contains('WorkOrders cancelled').should('be.visible')
+    cy.contains('Work Orders cancelled').should('be.visible')
     cy.contains('Bulk-close work orders').should('be.visible')
   })
 
@@ -117,7 +117,7 @@ describe('Close-WorkOrders', () => {
 
     cy.wait('@cancelRequest').its('request.method').should('deep.equal', 'POST')
 
-    cy.contains('WorkOrders cancelled').should('be.visible')
+    cy.contains('Work Orders cancelled').should('be.visible')
     cy.contains('Bulk-close work orders').should('be.visible')
   })
 

--- a/cypress/integration/backoffice/sor-contracts.spec.js
+++ b/cypress/integration/backoffice/sor-contracts.spec.js
@@ -3,7 +3,7 @@
 import 'cypress-audit/commands'
 
 describe('SOR-Contracts - when user unauthorized', () => {
-  it("Shows access denied when user doesn't have correct permissions", () => {
+  it("shows access denied when user doesn't have correct permissions", () => {
     cy.loginWithOperativeRole()
     cy.visit('/backoffice/sor-contracts')
     cy.contains('Access denied').should('be.visible')
@@ -28,7 +28,7 @@ describe('SOR-Contracts - When Copy selected', () => {
     cy.wait('@contractorsRequest')
   })
 
-  it('Shows error messages when form fields invalid', () => {
+  it('shows error messages when form fields invalid', () => {
     cy.get("[data-test='submit-button']").click()
 
     cy.get('.govuk-error-message.lbh-error-message')
@@ -100,8 +100,40 @@ describe('SOR-Contracts - When Copy selected', () => {
       .its('request.url')
       .should('contain', '/api/backOffice/sor-contracts')
 
-    cy.contains('SOR contract modification')
-    cy.contains('SOR Contracts Updated')
+    cy.contains('SOR contract modification').should('be.visible')
+    cy.contains('SOR Contracts Updated').should('be.visible')
+  })
+
+  it('resets the form after the user clicks on the "Update more SOR contracts" and the fields are empty', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        path: '/api/backOffice/sor-contracts',
+      },
+      {
+        body: '',
+      }
+    ).as('sorContractRequest')
+
+    const propertyReference1 = '12345678'
+    const propertyReference2 = '87654321'
+    cy.get('[data-test="sourcePropertyReference"]').type(propertyReference1)
+    cy.get('[data-test="destinationPropertyReference"]').type(
+      propertyReference2
+    )
+    cy.get("[data-test='submit-button']").click()
+
+    // Click 'Modify SOR contract' modal button
+    cy.get("[data-test='confirm-button']").click()
+
+    cy.wait('@sorContractRequest')
+
+    // Click on reset form button
+    cy.contains('Update more SOR contracts').click()
+
+    // Assert fields are empty
+    cy.get('[data-test="sourcePropertyReference"]').should('be.empty')
+    cy.get('[data-test="destinationPropertyReference"]').should('be.empty')
   })
 })
 
@@ -125,7 +157,7 @@ describe('SOR-Contracts - When Add selected', () => {
     cy.get('#selectedOption_Add').click()
   })
 
-  it('Shows error messages when form fields invalid', () => {
+  it('shows error messages when form fields invalid', () => {
     cy.get("[data-test='submit-button']").click()
 
     cy.get('.govuk-error-message.lbh-error-message')
@@ -198,7 +230,57 @@ describe('SOR-Contracts - When Add selected', () => {
       .its('request.url')
       .should('contain', '/api/backOffice/sor-contracts')
 
-    cy.contains('SOR contract modification')
-    cy.contains('SOR Contracts Updated')
+    cy.contains('SOR contract modification').should('be.visible')
+    cy.contains('SOR Contracts Updated').should('be.visible')
+  })
+
+  it('resets the form after the user clicks on the "Update more SOR contracts" and the fields are empty', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/api/backoffice/contracts',
+        query: {
+          contractorReference: '*',
+        },
+      },
+      {
+        fixture: 'contracts/contracts.json',
+      }
+    ).as('contractsRequest')
+
+    cy.intercept(
+      {
+        method: 'POST',
+        path: '/api/backOffice/sor-contracts',
+      },
+      {
+        body: '',
+      }
+    ).as('sorContractRequest')
+
+    const propertyReference = '12345678'
+    cy.get('[data-test="destinationPropertyReference"]').type(propertyReference)
+
+    const contractor = 'DECORATION ALLOWANCE'
+    cy.get('[data-testid="contractor"]').type(contractor)
+
+    const contract = 'F22-H04-GSC3'
+    cy.wait('@contractsRequest')
+    cy.get('[data-testid="contract"]').type(contract)
+
+    cy.get("[data-test='submit-button']").click()
+
+    // Click 'Modify SOR contract' modal button
+    cy.get("[data-test='confirm-button']").click()
+
+    cy.wait('@sorContractRequest')
+
+    // Click on reset form button
+    cy.contains('Update more SOR contracts').click()
+
+    // Assert fields are empty
+    cy.get('[data-test="destinationPropertyReference"]').should('be.empty')
+    cy.get('[data-testid="contractor"]').should('be.empty')
+    cy.get('[data-testid="contract"]').should('be.empty')
   })
 })

--- a/src/components/BackOffice/AddSORCodes/index.js
+++ b/src/components/BackOffice/AddSORCodes/index.js
@@ -63,6 +63,7 @@ const AddSORCodes = () => {
     loadingContracts,
     loadingContractors,
     handleSelectContract,
+    handleFormReset,
   } = useSelectContract()
 
   const { selectedTrade, handleSelectTrade } = useSelectTrade(trades)
@@ -74,7 +75,7 @@ const AddSORCodes = () => {
     setShowDialog(false)
     state.sorCodes = [new SorCode(1)]
 
-    handleSelectContractor(null)
+    handleFormReset()
     handleSelectTrade(null)
   }
 

--- a/src/components/BackOffice/CloseWorkOrders/index.js
+++ b/src/components/BackOffice/CloseWorkOrders/index.js
@@ -165,8 +165,8 @@ const CloseWorkOrders = () => {
         <>
           {formSuccess ? (
             <SuccessMessage
-              title="WorkOrders cancelled"
-              resetFormText="Cancel more WorkOrders"
+              title="Work Orders cancelled"
+              resetFormText="Cancel more work orders"
               resetFormCallback={() => setFormSuccess(null)}
             />
           ) : (

--- a/src/components/BackOffice/SORContracts/index.js
+++ b/src/components/BackOffice/SORContracts/index.js
@@ -53,6 +53,7 @@ const SORContracts = () => {
     loadingContracts,
     loadingContractors,
     handleSelectContract,
+    handleFormReset,
   } = useSelectContract()
 
   const [errors, setErrors] = useState({})
@@ -104,7 +105,7 @@ const SORContracts = () => {
   const resetForm = () => {
     setSourcePropertyReference('')
     setDestinationPropertyReference('')
-    handleSelectContractor(null)
+    handleFormReset()
     setFormSuccess(null)
     setErrors({})
     setRequestError(null)
@@ -181,7 +182,7 @@ const SORContracts = () => {
           {formSuccess ? (
             <SuccessMessage
               title="SOR Contracts Updated"
-              resetFormText="Update more SOR Contracts"
+              resetFormText="Update more SOR contracts"
               resetFormCallback={resetForm}
             />
           ) : (

--- a/src/components/BackOffice/hooks/useSelectContract.js
+++ b/src/components/BackOffice/hooks/useSelectContract.js
@@ -46,7 +46,7 @@ const useSelectContract = () => {
   }, [selectedContractor])
 
   const handleSelectContractor = (e) => {
-    const contractorName = e ? e.target?.value : undefined
+    const contractorName = e.target.value
     const selectedContractor = contractors.find(
       (contractor) => contractor.contractorName === contractorName
     )
@@ -58,6 +58,11 @@ const useSelectContract = () => {
     setSelectedContract(e.target.value)
   }
 
+  const handleFormReset = () => {
+    setSelectedContractor(null)
+    setSelectedContract(null)
+  }
+
   return {
     contractors,
     handleSelectContractor,
@@ -67,6 +72,7 @@ const useSelectContract = () => {
     loadingContracts,
     loadingContractors,
     handleSelectContract,
+    handleFormReset,
   }
 }
 


### PR DESCRIPTION
The contract was not being reset correctly after a successful "Modify SOR Contracts" workflow. There were no tests to test the state of the form after a successful submit, and a reset.

- Added handleFormReset method to useSelectContract hook to set Contractor and Contract values back to null after form reset. 
- Added "reset form" test for Add new SOR codes
- Added test for reset form for the Modify SOR contracts feature. Implemented use of handleFormReset in component.
- Spelling/casing minor corrections
- Added a few assertions where only the `cy.contains` was being used (as an assertion). Cy.contains is used to return an HTML element, assertions should be followed by a "should".


