### PR TITLE
MR-697 - Add StartTime to CloseWorkOrder form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hackney Repairs Hub frontend
 
-Allows agents and managers to raise, review, approve and close work orders..
+Allows agents and managers to raise, review, approve and close work orders.
 
 Allows operatives to sign in to a "mobile working" view, see upcoming jobs and complete them.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hackney Repairs Hub frontend
 
-Allows agents and managers to raise, review, approve and close work orders.
+Allows agents and managers to raise, review, approve and close work orders..
 
 Allows operatives to sign in to a "mobile working" view, see upcoming jobs and complete them.
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "axios": "^0.21.1",
     "cookie": "^0.4.1",
     "date-fns": "^2.16.1",
+    "dayjs": "^1.11.7",
     "dotenv": "^8.2.0",
     "easy-soap-request": "^4.1.3",
     "http-status-codes": "^2.1.4",

--- a/src/components/Form/TimeInput/index.js
+++ b/src/components/Form/TimeInput/index.js
@@ -23,6 +23,7 @@ const TimeInput = forwardRef(
       register,
       onChange,
       required,
+      showAsOptional = false,
       ...otherProps
     },
     ref
@@ -53,7 +54,8 @@ const TimeInput = forwardRef(
           <legend
             className={`govuk-fieldset__legend govuk-fieldset__legend--${labelSize}`}
           >
-            {label} {required && <span className="govuk-required">*</span>}
+            {label} {showAsOptional && '(optional)'}{' '}
+            {required && <span className="govuk-required">*</span>}
           </legend>
           <span id={`${name}-hint`} className="govuk-hint lbh-hint">
             {hint}
@@ -133,25 +135,33 @@ TimeInput.propTypes = {
   labelSize: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
   hint: PropTypes.string,
   rules: PropTypes.shape({}),
+  showAsOptional: PropTypes.bool,
 }
 
 const ControlledTimeInput = ({
   control,
   name,
   label,
-  emptyErrorMessage,
   required,
+  showAsOptional = false,
   ...otherProps
 }) => {
   return (
     <Controller
-      as={<TimeInput label={label} {...otherProps} />}
+      as={
+        <TimeInput
+          label={label}
+          showAsOptional={showAsOptional}
+          {...otherProps}
+        />
+      }
       onChange={([value]) => value}
       rules={{
         validate: {
           valid: (value) => {
             // required - validate being empty
-            if (required && !value) return emptyErrorMessage
+            if (required && !value)
+              return `Please enter a value for ${label.toLowerCase()}`
 
             // not required - valid if empty
             if (!required && !value) return true
@@ -189,10 +199,10 @@ const ControlledTimeInput = ({
 ControlledTimeInput.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  emptyErrorMessage: PropTypes.string.isRequired,
   rules: PropTypes.shape({}),
   control: PropTypes.object.isRequired,
   required: PropTypes.bool.isRequired,
+  showAsOptional: PropTypes.bool,
 }
 
 export default ControlledTimeInput

--- a/src/components/Form/TimeInput/index.js
+++ b/src/components/Form/TimeInput/index.js
@@ -139,25 +139,33 @@ const ControlledTimeInput = ({
   control,
   name,
   rules,
-  optional,
+  label,
+  emptyErrorMessage,
+  required,
   ...otherProps
-}) => (
-  <Controller
-    as={<TimeInput {...otherProps} />}
-    onChange={([value]) => value}
-    name={name}
-    rules={{
-      ...rules,
-      validate: {
-        valid: (value) => {
-          // if optional, only validate when not empty
-          if (optional && !value) return true
+}) => {
+  return (
+    <Controller
+      as={<TimeInput label={label} {...otherProps} />}
+      onChange={([value]) => value}
+      rules={{
+        validate: {
+          valid: (value) => {
+            // required - validate being empty
+            if (required && !value) return emptyErrorMessage
 
-          if (value) {
-            let hourStr = value.split(':')[0]
-            let minuteStr = value.split(':')[1]
-            let hour = parseInt(hourStr)
-            let minute = parseInt(minuteStr)
+            // not required - valid if empty
+            if (!required && !value) return true
+
+            const hourStr = value.split(':')[0] || ''
+            const minuteStr = value.split(':')[1] || ''
+
+            const hour = parseInt(hourStr)
+            const minute = parseInt(minuteStr)
+
+            if (!Number(hour) || !Number(minute))
+              return 'Please enter a valid time'
+
             if (
               hourStr.length == 2 &&
               minuteStr.length == 2 &&
@@ -168,21 +176,25 @@ const ControlledTimeInput = ({
             ) {
               return true
             }
-          }
-          return 'Please enter a valid time'
+
+            return 'Please enter a valid time'
+          },
         },
-        ...rules?.validate,
-      },
-    }}
-    control={control}
-    defaultValue={control.defaultValuesRef.current[name] || null}
-  />
-)
+      }}
+      name={name}
+      control={control}
+      defaultValue={control.defaultValuesRef.current[name] || null}
+    />
+  )
+}
 
 ControlledTimeInput.propTypes = {
   name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  emptyErrorMessage: PropTypes.string.isRequired,
   rules: PropTypes.shape({}),
   control: PropTypes.object.isRequired,
+  required: PropTypes.bool.isRequired,
 }
 
 export default ControlledTimeInput

--- a/src/components/Form/TimeInput/index.js
+++ b/src/components/Form/TimeInput/index.js
@@ -138,7 +138,6 @@ TimeInput.propTypes = {
 const ControlledTimeInput = ({
   control,
   name,
-  rules,
   label,
   emptyErrorMessage,
   required,

--- a/src/components/Form/TimeInput/index.js
+++ b/src/components/Form/TimeInput/index.js
@@ -162,8 +162,7 @@ const ControlledTimeInput = ({
             const hour = parseInt(hourStr)
             const minute = parseInt(minuteStr)
 
-            if (!Number(hour) || !Number(minute))
-              return 'Please enter a valid time'
+            if (isNaN(hour) || isNaN(minute)) return 'Please enter a valid time'
 
             if (
               hourStr.length == 2 &&

--- a/src/components/Form/TimeInput/index.js
+++ b/src/components/Form/TimeInput/index.js
@@ -54,7 +54,7 @@ const TimeInput = forwardRef(
           <legend
             className={`govuk-fieldset__legend govuk-fieldset__legend--${labelSize}`}
           >
-            {label} {showAsOptional && '(optional)'}{' '}
+            {label} {showAsOptional && '(optional) '}
             {required && <span className="govuk-required">*</span>}
           </legend>
           <span id={`${name}-hint`} className="govuk-hint lbh-hint">

--- a/src/components/Form/TimeInput/index.js
+++ b/src/components/Form/TimeInput/index.js
@@ -135,7 +135,7 @@ TimeInput.propTypes = {
   rules: PropTypes.shape({}),
 }
 
-const ControlledTimeInput = ({ control, name, rules, ...otherProps }) => (
+const ControlledTimeInput = ({ control, name, rules, optional, ...otherProps }) => (
   <Controller
     as={<TimeInput {...otherProps} />}
     onChange={([value]) => value}
@@ -144,6 +144,10 @@ const ControlledTimeInput = ({ control, name, rules, ...otherProps }) => (
       ...rules,
       validate: {
         valid: (value) => {
+
+          // if optional, only validate when not empty
+          if (optional && !value) return true
+
           if (value) {
             let hourStr = value.split(':')[0]
             let minuteStr = value.split(':')[1]

--- a/src/components/Form/TimeInput/index.js
+++ b/src/components/Form/TimeInput/index.js
@@ -135,7 +135,13 @@ TimeInput.propTypes = {
   rules: PropTypes.shape({}),
 }
 
-const ControlledTimeInput = ({ control, name, rules, optional, ...otherProps }) => (
+const ControlledTimeInput = ({
+  control,
+  name,
+  rules,
+  optional,
+  ...otherProps
+}) => (
   <Controller
     as={<TimeInput {...otherProps} />}
     onChange={([value]) => value}
@@ -144,7 +150,6 @@ const ControlledTimeInput = ({ control, name, rules, optional, ...otherProps }) 
       ...rules,
       validate: {
         valid: (value) => {
-
           // if optional, only validate when not empty
           if (optional && !value) return true
 

--- a/src/components/WorkOrder/AppointmentDetails.js
+++ b/src/components/WorkOrder/AppointmentDetails.js
@@ -12,6 +12,7 @@ import { buildDataFromScheduleAppointment } from '@/utils/hact/jobStatusUpdate/n
 import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
 import ScheduleDRSAppointmentLink from './ScheduleDRSAppointmentLink'
 import ScheduleInternalAppointmentLink from './ScheduleInternalAppointmentLink'
+import { formatDateTime } from '../../utils/time'
 
 const AppointmentDetails = ({ workOrder, schedulerSessionId }) => {
   const { user } = useContext(UserContext)
@@ -65,10 +66,21 @@ const AppointmentDetails = ({ workOrder, schedulerSessionId }) => {
   }
 
   return (
-    (canScheduleAppointment(user) || canSeeAppointmentDetailsInfo(user)) && (
+    <>
+       {!!workOrder?.startTime && (
+        <div className="lbh-body-xs govuk-!-margin-bottom-2">
+          <span>Started at</span>
+          <br></br>
+          <span>{formatDateTime(workOrder.startTime)}</span>
+        </div>
+      )}
+   {
+     (canScheduleAppointment(user) || canSeeAppointmentDetailsInfo(user)) && (
       <div className="appointment-details">
         <p className="govuk-!-font-size-14">Appointment details</p>
         <div className="lbh-body-s govuk-!-margin-0">
+     
+
           {user && (
             <>
               {canSeeAppointmentDetailsInfo(user) &&
@@ -90,7 +102,10 @@ const AppointmentDetails = ({ workOrder, schedulerSessionId }) => {
         </div>
       </div>
     )
+   }
+  </>
   )
+
 }
 
 AppointmentDetails.propTypes = {

--- a/src/components/WorkOrder/AppointmentDetails.js
+++ b/src/components/WorkOrder/AppointmentDetails.js
@@ -67,45 +67,40 @@ const AppointmentDetails = ({ workOrder, schedulerSessionId }) => {
 
   return (
     <>
-       {!!workOrder?.startTime && (
+      {!!workOrder?.startTime && (
         <div className="lbh-body-xs govuk-!-margin-bottom-2">
           <span>Started at</span>
           <br></br>
           <span>{formatDateTime(workOrder.startTime)}</span>
         </div>
       )}
-   {
-     (canScheduleAppointment(user) || canSeeAppointmentDetailsInfo(user)) && (
-      <div className="appointment-details">
-        <p className="govuk-!-font-size-14">Appointment details</p>
-        <div className="lbh-body-s govuk-!-margin-0">
-     
+      {(canScheduleAppointment(user) || canSeeAppointmentDetailsInfo(user)) && (
+        <div className="appointment-details">
+          <p className="govuk-!-font-size-14">Appointment details</p>
+          <div className="lbh-body-s govuk-!-margin-0">
+            {user && (
+              <>
+                {canSeeAppointmentDetailsInfo(user) &&
+                  workOrder.appointment &&
+                  workOrder.status !== STATUS_CANCELLED &&
+                  appointmentDetailsInfoHtml()}
 
-          {user && (
-            <>
-              {canSeeAppointmentDetailsInfo(user) &&
-                workOrder.appointment &&
-                workOrder.status !== STATUS_CANCELLED &&
-                appointmentDetailsInfoHtml()}
+                {canScheduleAppointment(user) &&
+                  workOrder.canBeScheduled() &&
+                  scheduleAppointmentHtml(workOrder.appointment)}
 
-              {canScheduleAppointment(user) &&
-                workOrder.canBeScheduled() &&
-                scheduleAppointmentHtml(workOrder.appointment)}
-
-              {canSeeAppointmentDetailsInfo(user) &&
-                !workOrder.appointment &&
-                !workOrder.canBeScheduled() && (
-                  <p className="lbh-!-font-weight-bold">Not applicable</p>
-                )}
-            </>
-          )}
+                {canSeeAppointmentDetailsInfo(user) &&
+                  !workOrder.appointment &&
+                  !workOrder.canBeScheduled() && (
+                    <p className="lbh-!-font-weight-bold">Not applicable</p>
+                  )}
+              </>
+            )}
+          </div>
         </div>
-      </div>
-    )
-   }
-  </>
+      )}
+    </>
   )
-
 }
 
 AppointmentDetails.propTypes = {

--- a/src/components/WorkOrder/WorkOrderInfo.js
+++ b/src/components/WorkOrder/WorkOrderInfo.js
@@ -55,14 +55,6 @@ const WorkOrderInfo = ({ workOrder }) => {
           )}
         </div>
       )}
-
-      {!!workOrder?.startTime && (
-        <div className="lbh-body-xs govuk-!-margin-bottom-2">
-          <span>Started at</span>
-          <br></br>
-          <span>{formatDateTime(workOrder.startTime)}</span>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/WorkOrder/WorkOrderInfo.js
+++ b/src/components/WorkOrder/WorkOrderInfo.js
@@ -55,6 +55,18 @@ const WorkOrderInfo = ({ workOrder }) => {
           )}
         </div>
       )}
+
+{!!workOrder?.startTime && (
+  <div className="lbh-body-xs govuk-!-margin-bottom-2">
+  <span>Started at</span>
+  <br></br>
+  <span>{formatDateTime(workOrder.startTime)}</span>
+</div>
+
+
+
+          
+        )}
     </div>
   )
 }

--- a/src/components/WorkOrder/WorkOrderInfo.js
+++ b/src/components/WorkOrder/WorkOrderInfo.js
@@ -56,17 +56,13 @@ const WorkOrderInfo = ({ workOrder }) => {
         </div>
       )}
 
-{!!workOrder?.startTime && (
-  <div className="lbh-body-xs govuk-!-margin-bottom-2">
-  <span>Started at</span>
-  <br></br>
-  <span>{formatDateTime(workOrder.startTime)}</span>
-</div>
-
-
-
-          
-        )}
+      {!!workOrder?.startTime && (
+        <div className="lbh-body-xs govuk-!-margin-bottom-2">
+          <span>Started at</span>
+          <br></br>
+          <span>{formatDateTime(workOrder.startTime)}</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -260,6 +260,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
                   changeStep={changeCurrentPage}
                   reference={workOrder.reference}
                   paymentType={paymentType}
+                  startTime={startTime}
                 />
               )}
               {currentPage === CONFIRMATION_PAGE && (

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -25,6 +25,7 @@ import { generalLinks } from '@/utils/successPageLinks'
 const CloseWorkOrderByProxy = ({ reference }) => {
   const [completionDate, setCompletionDate] = useState('')
   const [completionTime, setCompletionTime] = useState('')
+  const [startTime, setStartTime] = useState('')
   const [dateToShow, setDateToShow] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
@@ -60,6 +61,19 @@ const CloseWorkOrderByProxy = ({ reference }) => {
           method: 'post',
           path: `/api/jobStatusUpdate`,
           requestData: operativeAssignmentFormData,
+        })
+      }
+
+      console.log({ reference, startTime })
+
+      if (startTime !== null) {
+        await frontEndApiRequest({
+          method: 'put',
+          path: `/api/workOrders/starttime`,
+          requestData: {
+            startTime: startTime,
+            workOrderId: reference,
+          },
         })
       }
 
@@ -191,6 +205,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     formData.paymentType && setPaymentType(formData.paymentType)
     setCurrentPage(SUMMARY_PAGE)
     setCompletionTime(formData.completionTime)
+    setStartTime(formData.startTime)
   }
 
   return (

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -25,8 +25,10 @@ import { generalLinks } from '@/utils/successPageLinks'
 const CloseWorkOrderByProxy = ({ reference }) => {
   const [completionDate, setCompletionDate] = useState('')
   const [completionTime, setCompletionTime] = useState('')
+
+  const [startDate, setStartDate] = useState('')
   const [startTime, setStartTime] = useState('')
-  const [dateToShow, setDateToShow] = useState('')
+
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
   const [notes, setNotes] = useState('')
@@ -64,14 +66,12 @@ const CloseWorkOrderByProxy = ({ reference }) => {
         })
       }
 
-      console.log({ reference, startTime })
-
-      if (startTime !== null) {
+      if (startDate !== '') {
         await frontEndApiRequest({
           method: 'put',
           path: `/api/workOrders/starttime`,
           requestData: {
-            startTime: startTime,
+            startTime: startDate,
             workOrderId: reference,
           },
         })
@@ -163,11 +163,21 @@ const CloseWorkOrderByProxy = ({ reference }) => {
   }
 
   const onGetToSummary = (formData) => {
-    const properDate = convertToDateFormat(
-      formData.date,
+    const formattedCompletionDate = convertToDateFormat(
+      formData.completionDate,
       formData.completionTime
     )
-    setCompletionDate(properDate)
+    setCompletionDate(formattedCompletionDate)
+
+    if (formData.startDate === '') {
+      setStartDate('')
+    } else {
+      const formattedStartDate = convertToDateFormat(
+        formData.startDate,
+        formData.startTime
+      )
+      setStartDate(formattedStartDate)
+    }
 
     const operativeIds = Object.keys(formData)
       .filter((k) => k.match(/operative-\d+/))
@@ -201,7 +211,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     )
     setReason(formData.reason)
     setNotes(formData.notes)
-    setDateToShow(formData.date)
+    // setDateToShow(formData.completionDate)
     formData.paymentType && setPaymentType(formData.paymentType)
     setCurrentPage(SUMMARY_PAGE)
     setCompletionTime(formData.completionTime)
@@ -223,8 +233,10 @@ const CloseWorkOrderByProxy = ({ reference }) => {
                   reference={workOrder.reference}
                   onSubmit={onGetToSummary}
                   notes={notes}
-                  time={completionTime}
-                  date={completionDate}
+                  completionTime={completionTime}
+                  completionDate={completionDate}
+                  startTime={startTime}
+                  startDate={startDate}
                   reason={reason}
                   operativeAssignmentMandatory={workOrder.canAssignOperative}
                   assignedOperativesToWorkOrder={selectedOperatives}
@@ -244,8 +256,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
                 <SummaryCloseWorkOrder
                   onJobSubmit={onJobSubmit}
                   notes={notes}
-                  time={completionTime}
-                  date={dateToShow}
+                  completionDate={completionDate}
                   reason={reason}
                   operativeNames={
                     workOrder.canAssignOperative &&
@@ -260,7 +271,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
                   changeStep={changeCurrentPage}
                   reference={workOrder.reference}
                   paymentType={paymentType}
-                  startTime={startTime}
+                  startDate={startDate}
                 />
               )}
               {currentPage === CONFIRMATION_PAGE && (

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -98,11 +98,11 @@ const CloseWorkOrderForm = ({
 
         <TimeInput
           name="startTime"
-          label="Start time (optional)"
+          label="Start time"
+          showAsOptional={true}
           hint="Use 24h format. For example, 14:30"
           control={control}
           required={startTimeIsRequired}
-          emptyErrorMessage="Please enter a start time"
           register={register()}
           defaultValue={startTime}
           error={errors && errors['startTime']}
@@ -138,7 +138,6 @@ const CloseWorkOrderForm = ({
           hint="Use 24h format. For example, 14:30"
           control={control}
           required={true}
-          emptyErrorMessage="Please enter a completion time"
           register={register()}
           defaultValue={completionTime}
           error={errors && errors['completionTime']}

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -15,6 +15,7 @@ import {
   optionsForPaymentType,
 } from '../../utils/paymentTypes'
 import { CLOSURE_STATUS_OPTIONS } from '@/utils/statusCodes'
+import { useState } from 'react'
 
 const CloseWorkOrderForm = ({
   reference,
@@ -23,8 +24,10 @@ const CloseWorkOrderForm = ({
   assignedOperativesToWorkOrder,
   operativeAssignmentMandatory,
   notes,
-  time,
-  date,
+  completionTime,
+  completionDate,
+  startTime,
+  startDate,
   reason,
   dateRaised,
   selectedPercentagesToShowOnEdit,
@@ -41,121 +44,150 @@ const CloseWorkOrderForm = ({
     getValues,
   } = useForm({})
 
+  const [startTimeIsRequired, setStartTimeIsRequired] = useState(false)
+
+  // startTime is required when startDate is set
+  const onStartDateChange = (e) => {
+    setStartTimeIsRequired(e.target.value !== '')
+  }
+
   return (
-    <>
-      <div>
-        <BackButton />
+    <div>
+      <BackButton />
+      <h1 className="lbh-heading-h2">{`Close work order: ${reference}`}</h1>
 
-        <h1 className="lbh-heading-h2">{`Close work order: ${reference}`}</h1>
+      <form role="form" onSubmit={handleSubmit(onSubmit)}>
+        <Radios
+          label="Select reason for closing"
+          name="reason"
+          options={CLOSURE_STATUS_OPTIONS.map((r) => {
+            return {
+              text: r.text,
+              value: r.value,
+              defaultChecked: r.value === reason,
+            }
+          })}
+          register={register({
+            required: 'Please select a reason for closing the work order',
+          })}
+          error={errors && errors.reason}
+        />
 
-        <form role="form" onSubmit={handleSubmit(onSubmit)}>
-          <Radios
-            label="Select reason for closing"
-            name="reason"
-            options={CLOSURE_STATUS_OPTIONS.map((r) => {
-              return {
-                text: r.text,
-                value: r.value,
-                defaultChecked: r.value === reason,
-              }
-            })}
-            register={register({
-              required: 'Please select a reason for closing the work order',
-            })}
-            error={errors && errors.reason}
-          />
+        <DatePicker
+          name="startDate"
+          label="Select start date (optional)"
+          hint="For example, 15/05/2021"
+          onChange={onStartDateChange}
+          register={register({
+            validate: {
+              isInThePast: (value) => {
+                if (value === '') return
 
-          <DatePicker
-            name="date"
-            label="Select completion date"
-            hint="For example, 15/05/2021"
-            register={register({
-              required: 'Please pick completion date',
-              validate: {
-                isInThePast: (value) =>
+                return (
                   isPast(new Date(value)) ||
-                  'Please select a date that is in the past',
-                isEqualOrLaterThanRaisedDate: (value) =>
-                  new Date(value) >=
-                    new Date(new Date(dateRaised).toDateString()) ||
-                  `Completion date must be on or after ${new Date(
-                    dateRaised
-                  ).toLocaleDateString('en-GB')}`,
+                  'Please select a date that is in the past'
+                )
               },
-            })}
-            error={errors && errors.date}
-            defaultValue={date ? date.toISOString().split('T')[0] : null}
-          />
+            },
+          })}
+          error={errors && errors.startDate}
+          defaultValue={
+            startDate ? startDate.toISOString().split('T')[0] : null
+          }
+        />
 
-          <TimeInput
-            name="startTime"
-            label="Start time (optional)"
-            hint="Use 24h format. For example, 14:30"
-            control={control}
-            register={register}
-            optional={true}
-            defaultValue={time}
-            error={errors && errors.startTime}
-          />
+        <TimeInput
+          name="startTime"
+          label="Start time (optional)"
+          hint="Use 24h format. For example, 14:30"
+          control={control}
+          required={startTimeIsRequired}
+          emptyErrorMessage="Please enter a start time"
+          register={register()}
+          defaultValue={startTime}
+          error={errors && errors['startTime']}
+        />
 
-          <TimeInput
-            name="completionTime"
-            label="Completion time"
-            hint="Use 24h format. For example, 14:30"
-            control={control}
-            register={register}
-            defaultValue={time}
-            error={errors && errors.completionTime}
-          />
+        <DatePicker
+          name="completionDate"
+          label="Select completion date"
+          hint="For example, 15/05/2021"
+          register={register({
+            required: 'Please pick completion date',
+            validate: {
+              isInThePast: (value) =>
+                isPast(new Date(value)) ||
+                'Please select a date that is in the past',
+              isEqualOrLaterThanRaisedDate: (value) =>
+                new Date(value) >=
+                  new Date(new Date(dateRaised).toDateString()) ||
+                `Completion date must be on or after ${new Date(
+                  dateRaised
+                ).toLocaleDateString('en-GB')}`,
+            },
+          })}
+          error={errors && errors.completionDate}
+          defaultValue={
+            completionDate ? completionDate.toISOString().split('T')[0] : null
+          }
+        />
 
-          {operativeAssignmentMandatory && (
-            <>
-              <SelectOperatives
-                assignedOperativesToWorkOrder={assignedOperativesToWorkOrder}
-                availableOperatives={availableOperatives}
-                register={register}
-                errors={errors}
-                selectedPercentagesToShowOnEdit={
-                  selectedPercentagesToShowOnEdit
-                }
-                trigger={trigger}
-                getValues={getValues}
-                totalSMV={totalSMV}
-                jobIsSplitByOperative={jobIsSplitByOperative}
-              />
+        <TimeInput
+          name="completionTime"
+          label="Completion time"
+          hint="Use 24h format. For example, 14:30"
+          control={control}
+          required={true}
+          emptyErrorMessage="Please enter a completion time"
+          register={register()}
+          defaultValue={completionTime}
+          error={errors && errors['completionTime']}
+        />
 
-              <Radios
-                label="Payment type"
-                name="paymentType"
-                options={optionsForPaymentType({
-                  paymentTypes: [
-                    BONUS_PAYMENT_TYPE,
-                    OVERTIME_PAYMENT_TYPE,
-                    CLOSE_TO_BASE_PAYMENT_TYPE,
-                  ],
-                  currentPaymentType: paymentType,
-                })}
-                register={register({
-                  required: 'Provide payment type',
-                })}
-                error={errors && errors.paymentType}
-              />
-            </>
-          )}
+        {operativeAssignmentMandatory && (
+          <>
+            <SelectOperatives
+              assignedOperativesToWorkOrder={assignedOperativesToWorkOrder}
+              availableOperatives={availableOperatives}
+              register={register}
+              errors={errors}
+              selectedPercentagesToShowOnEdit={selectedPercentagesToShowOnEdit}
+              trigger={trigger}
+              getValues={getValues}
+              totalSMV={totalSMV}
+              jobIsSplitByOperative={jobIsSplitByOperative}
+            />
 
-          <TextArea
-            name="notes"
-            label="Add notes"
-            label={'Add notes'}
-            register={register}
-            error={errors && errors.notes}
-            defaultValue={notes}
-          />
+            <Radios
+              label="Payment type"
+              name="paymentType"
+              options={optionsForPaymentType({
+                paymentTypes: [
+                  BONUS_PAYMENT_TYPE,
+                  OVERTIME_PAYMENT_TYPE,
+                  CLOSE_TO_BASE_PAYMENT_TYPE,
+                ],
+                currentPaymentType: paymentType,
+              })}
+              register={register({
+                required: 'Provide payment type',
+              })}
+              error={errors && errors.paymentType}
+            />
+          </>
+        )}
 
-          <PrimarySubmitButton label="Close work order" />
-        </form>
-      </div>
-    </>
+        <TextArea
+          name="notes"
+          label="Add notes"
+          register={register}
+          error={errors && errors.notes}
+          defaultValue={notes}
+        />
+
+        <PrimarySubmitButton label="Close work order" />
+      </form>
+    </div>
   )
 }
 
@@ -163,8 +195,10 @@ CloseWorkOrderForm.propTypes = {
   reference: PropTypes.number.isRequired,
   onSubmit: PropTypes.func.isRequired,
   notes: PropTypes.string.isRequired,
-  time: PropTypes.string.isRequired,
-  date: PropTypes.instanceOf(Date),
+  completionTime: PropTypes.string.isRequired,
+  completionDate: PropTypes.instanceOf(Date),
+  startTime: PropTypes.string,
+  startDate: PropTypes.instanceOf(Date),
   reason: PropTypes.string,
   dateRaised: PropTypes.string,
   totalSMV: PropTypes.number.isRequired,

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -87,7 +87,7 @@ const CloseWorkOrderForm = ({
             defaultValue={date ? date.toISOString().split('T')[0] : null}
           />
 
-<TimeInput
+          <TimeInput
             name="startTime"
             label="Start time (optional)"
             hint="Use 24h format. For example, 14:30"

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -87,6 +87,17 @@ const CloseWorkOrderForm = ({
             defaultValue={date ? date.toISOString().split('T')[0] : null}
           />
 
+<TimeInput
+            name="startTime"
+            label="Start time (optional)"
+            hint="Use 24h format. For example, 14:30"
+            control={control}
+            register={register}
+            optional={true}
+            defaultValue={time}
+            error={errors && errors.startTime}
+          />
+
           <TimeInput
             name="completionTime"
             label="Completion time"

--- a/src/components/WorkOrders/CloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.test.js
@@ -21,6 +21,8 @@ describe('CloseWorkOrderForm component', () => {
     notes: 'this is a note',
     completionTime: '14:30',
     completionDate: new Date('2021-01-12T16:24:26.632Z'),
+    startTime: '14:30',
+    startDate: new Date('2021-01-12T16:24:26.632Z'),
     operatives: operatives,
     availableOperatives: operatives,
     reason: 'No Access',
@@ -41,6 +43,8 @@ describe('CloseWorkOrderForm component', () => {
           notes={props.notes}
           completionTime={props.completionTime}
           completionDate={props.completionDate}
+          startTime={props.startTime}
+          startDate={props.startDate}
           reason={props.reason}
           operativeAssignmentMandatory={true}
           assignedOperativesToWorkOrder={props.operatives}

--- a/src/components/WorkOrders/CloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.test.js
@@ -19,8 +19,8 @@ describe('CloseWorkOrderForm component', () => {
     reference: 10000012,
     onSubmit: jest.fn(),
     notes: 'this is a note',
-    time: '14:30',
-    date: new Date('2021-01-12T16:24:26.632Z'),
+    completionTime: '14:30',
+    completionDate: new Date('2021-01-12T16:24:26.632Z'),
     operatives: operatives,
     availableOperatives: operatives,
     reason: 'No Access',
@@ -39,8 +39,8 @@ describe('CloseWorkOrderForm component', () => {
           reference={props.reference}
           onSubmit={props.onSubmit}
           notes={props.notes}
-          time={props.time}
-          date={props.date}
+          completionTime={props.completionTime}
+          completionDate={props.completionDate}
           reason={props.reason}
           operativeAssignmentMandatory={true}
           assignedOperativesToWorkOrder={props.operatives}

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.js
@@ -14,6 +14,7 @@ const SummaryCloseWorkOrder = ({
   reason,
   operativeNames,
   paymentType,
+  startTime,
 }) => {
   const { handleSubmit } = useForm({})
 
@@ -36,7 +37,19 @@ const SummaryCloseWorkOrder = ({
               </TD>
             </TR>
 
-            {paymentType && (
+            {startTime!== null && (
+              <TR>
+                <TH scope="row">Start Time</TH>
+                <TD>edit me</TD>
+                <TD>
+                  <a className="lbh-link" onClick={changeStep} href="#">
+                    Edit
+                  </a>
+                </TD>
+              </TR>
+            )}
+
+            {paymentType  && (
               <TR>
                 <TH scope="row">Payment type</TH>
                 <TD>{PAYMENT_TYPE_FORM_DESCRIPTIONS[paymentType].text}</TD>

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.js
@@ -3,18 +3,18 @@ import { useForm } from 'react-hook-form'
 import { PAYMENT_TYPE_FORM_DESCRIPTIONS } from '@/utils/paymentTypes'
 import { PrimarySubmitButton } from '../Form'
 import { Table, TBody, TR, TH, TD } from '../Layout/Table'
+import dayjs from 'dayjs'
 
 const SummaryCloseWorkOrder = ({
   reference,
   onJobSubmit,
   notes,
-  time,
-  date,
+  completionDate,
   changeStep,
   reason,
   operativeNames,
   paymentType,
-  startTime,
+  startDate,
 }) => {
   const { handleSubmit } = useForm({})
 
@@ -25,22 +25,10 @@ const SummaryCloseWorkOrder = ({
         <h4 className="lbh-heading-h4">Summary of updates to work order</h4>
         <Table>
           <TBody>
-            <TR>
-              <TH scope="row">Completion time</TH>
-              <TD>
-                {date.split('-').join('/')} {time}
-              </TD>
-              <TD>
-                <a className="lbh-link" onClick={changeStep} href="#">
-                  Edit
-                </a>
-              </TD>
-            </TR>
-
-            {startTime!== null && (
+            {startDate !== '' && (
               <TR>
-                <TH scope="row">Start Time</TH>
-                <TD>edit me</TD>
+                <TH scope="row">Start time</TH>
+                <TD>{dayjs(startDate).format('YYYY/MM/DD HH:mm:ss')}</TD>
                 <TD>
                   <a className="lbh-link" onClick={changeStep} href="#">
                     Edit
@@ -49,7 +37,17 @@ const SummaryCloseWorkOrder = ({
               </TR>
             )}
 
-            {paymentType  && (
+            <TR>
+              <TH scope="row">Completion time</TH>
+              <TD>{dayjs(completionDate).format('YYYY/MM/DD HH:mm:ss')}</TD>
+              <TD>
+                <a className="lbh-link" onClick={changeStep} href="#">
+                  Edit
+                </a>
+              </TD>
+            </TR>
+
+            {paymentType && (
               <TR>
                 <TH scope="row">Payment type</TH>
                 <TD>{PAYMENT_TYPE_FORM_DESCRIPTIONS[paymentType].text}</TD>
@@ -104,8 +102,8 @@ SummaryCloseWorkOrder.propTypes = {
   reference: PropTypes.number.isRequired,
   onJobSubmit: PropTypes.func.isRequired,
   notes: PropTypes.string.isRequired,
-  time: PropTypes.string,
-  date: PropTypes.string,
+  completionDate: PropTypes.string,
+  startDate: PropTypes.string,
   changeStep: PropTypes.func.isRequired,
   reason: PropTypes.string.isRequired,
   paymentType: PropTypes.string,

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
@@ -5,8 +5,8 @@ describe('SummaryCloseWorkOrder component', () => {
   const props = {
     reference: 10000012,
     notes: 'this is a note',
-    time: '14:30',
-    date: '2021-02-03T11:33:35.757339',
+    completionDate: '2021-02-03T11:33:35.757339',
+    startDate: '2021-02-03T11:33:35.757339',
     reason: 'No Access',
     operatives: ['Operative A', 'Operative B'],
     onJobSubmit: jest.fn(),
@@ -18,8 +18,8 @@ describe('SummaryCloseWorkOrder component', () => {
       <SummaryCloseWorkOrder
         reference={props.reference}
         notes={props.notes}
-        startTime={props.time}
-        startDate={props.date}
+        completionDate={props.completionDate}
+        startDate={props.startDate}
         reason={props.reason}
         onJobSubmit={props.onJobSubmit}
         changeStep={props.changeStep}
@@ -35,8 +35,8 @@ describe('SummaryCloseWorkOrder component', () => {
       <SummaryCloseWorkOrder
         reference={props.reference}
         notes={props.notes}
-        startTime={props.time}
-        startDate={props.date}
+        completionDate={props.completionDate}
+        startDate={props.startDate}
         reason={props.reason}
         onJobSubmit={props.onJobSubmit}
         changeStep={props.changeStep}

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
@@ -18,8 +18,8 @@ describe('SummaryCloseWorkOrder component', () => {
       <SummaryCloseWorkOrder
         reference={props.reference}
         notes={props.notes}
-        time={props.time}
-        date={props.date}
+        startTime={props.time}
+        startDate={props.date}
         reason={props.reason}
         onJobSubmit={props.onJobSubmit}
         changeStep={props.changeStep}
@@ -35,8 +35,8 @@ describe('SummaryCloseWorkOrder component', () => {
       <SummaryCloseWorkOrder
         reference={props.reference}
         notes={props.notes}
-        time={props.time}
-        date={props.date}
+        startTime={props.time}
+        startDate={props.date}
         reason={props.reason}
         onJobSubmit={props.onJobSubmit}
         changeStep={props.changeStep}

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -15,14 +15,21 @@ export const formatDateTime = (datetime) => {
   if (typeof datetime === 'string') {
     datetime = new Date(datetime)
   }
-  return datetime.toLocaleString('en-GB', {
+
+  const options = {
     hourCycle: 'h23',
     day: 'numeric',
     month: 'short',
     year: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
-  })
+  }
+
+  if (process.env.NODE_ENV === 'test') {
+    options.timeZone = 'UTC'
+  }
+
+  return datetime.toLocaleString('en-GB', options)
 }
 
 export const beginningOfDay = (date) => {


### PR DESCRIPTION
## Summary of Changes

- Fix snapshot date issue (sets the timezone to UTC when `NODE_ENV=test`
- Add StartTime to the main workOrder view (above appointments)
- Add StartDate and StartTime fields to CloseWorkOrderComponent (StartDate optional, StartTime required when StartDate not null)
- Update SummaryCloseWorkOrder component to include StartTime
- Sends a request to `/api/workOrders/starttime` when a workOrder is closed
- Refactored `ControlledTimeInput` component
- Added dayjs library (better alternative to moments), for use in the Summary page
- Update Cypress tests

## Views

### WorkOrder page
![image](https://user-images.githubusercontent.com/88662046/234276068-6064fe8c-2606-4c33-b2aa-6795553ee404.png)

### Close workOrder form
![image](https://user-images.githubusercontent.com/88662046/234275881-6db36fe8-6557-42b8-ba63-7a6351c54614.png)

## Summary page
![image](https://user-images.githubusercontent.com/88662046/234275989-b0c276e6-13de-4a22-9364-9a2102c09a56.png)
