### PR TITLE
User on Repairs Hub cannot change startTime if already set by operative

### DIFF
--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -249,6 +249,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
                   totalSMV={workOrder.totalSMVs}
                   jobIsSplitByOperative={workOrder.isSplit}
                   paymentType={paymentType}
+                  existingStartTime={workOrder.startTime !== null}
                 />
               )}
 

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -34,6 +34,7 @@ const CloseWorkOrderForm = ({
   totalSMV,
   jobIsSplitByOperative,
   paymentType,
+  existingStartTime,
 }) => {
   const {
     handleSubmit,
@@ -73,40 +74,45 @@ const CloseWorkOrderForm = ({
           error={errors && errors.reason}
         />
 
-        <DatePicker
-          name="startDate"
-          label="Select start date (optional)"
-          hint="For example, 15/05/2021"
-          onChange={onStartDateChange}
-          register={register({
-            validate: {
-              isInThePast: (value) => {
-                if (value === '') return
+        {/* Start time cannot be changed once set by an operative */}
+        {!existingStartTime && (
+          <>
+            <DatePicker
+              name="startDate"
+              label="Select start date (optional)"
+              hint="For example, 15/05/2021"
+              onChange={onStartDateChange}
+              register={register({
+                validate: {
+                  isInThePast: (value) => {
+                    if (value === '') return
 
-                return (
-                  isPast(new Date(value)) ||
-                  'Please select a date that is in the past'
-                )
-              },
-            },
-          })}
-          error={errors && errors.startDate}
-          defaultValue={
-            startDate ? startDate.toISOString().split('T')[0] : null
-          }
-        />
+                    return (
+                      isPast(new Date(value)) ||
+                      'Please select a date that is in the past'
+                    )
+                  },
+                },
+              })}
+              error={errors && errors.startDate}
+              defaultValue={
+                startDate ? startDate.toISOString().split('T')[0] : null
+              }
+            />
 
-        <TimeInput
-          name="startTime"
-          label="Start time"
-          showAsOptional={true}
-          hint="Use 24h format. For example, 14:30"
-          control={control}
-          required={startTimeIsRequired}
-          register={register()}
-          defaultValue={startTime}
-          error={errors && errors['startTime']}
-        />
+            <TimeInput
+              name="startTime"
+              label="Start time"
+              showAsOptional={true}
+              hint="Use 24h format. For example, 14:30"
+              control={control}
+              required={startTimeIsRequired}
+              register={register()}
+              defaultValue={startTime}
+              error={errors && errors['startTime']}
+            />
+          </>
+        )}
 
         <DatePicker
           name="completionDate"
@@ -203,6 +209,7 @@ CloseWorkOrderForm.propTypes = {
   totalSMV: PropTypes.number.isRequired,
   jobIsSplitByOperative: PropTypes.bool.isRequired,
   paymentType: PropTypes.string,
+  existingStartTime: PropTypes.bool.isRequired,
 }
 
 export default CloseWorkOrderForm

--- a/src/components/WorkOrders/CloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.test.js
@@ -55,6 +55,39 @@ describe('CloseWorkOrderForm component', () => {
           totalSMV={props.totalSMVs}
           jobIsSplitByOperative={false}
           paymentType={'Overtime'}
+          existingStartTime={false}
+        />
+      </UserContext.Provider>
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should not render startDate or startTime', () => {
+    const { asFragment } = render(
+      <UserContext.Provider
+        value={{
+          user: agent,
+        }}
+      >
+        <CloseWorkOrderForm
+          reference={props.reference}
+          onSubmit={props.onSubmit}
+          notes={props.notes}
+          completionTime={props.completionTime}
+          completionDate={props.completionDate}
+          startTime={props.startTime}
+          startDate={props.startDate}
+          reason={props.reason}
+          operativeAssignmentMandatory={true}
+          assignedOperativesToWorkOrder={props.operatives}
+          availableOperatives={props.availableOperatives}
+          selectedPercentagesToShowOnEdit={
+            props.selectedPercentagesToShowOnEdit
+          }
+          totalSMV={props.totalSMVs}
+          jobIsSplitByOperative={false}
+          paymentType={'Overtime'}
+          existingStartTime={true}
         />
       </UserContext.Provider>
     )

--- a/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
@@ -67,6 +67,1132 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
             </label>
           </div>
         </div>
+      </div>    
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label lbh-label govuk-label--m"
+          for="completionDate"
+        >
+          Select completion date 
+        </label>
+        <span
+          class="govuk-hint lbh-hint"
+          id="completionDate-hint"
+        >
+          For example, 15/05/2021
+        </span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          data-testid="completionDate"
+          id="completionDate"
+          name="completionDate"
+          type="date"
+          value="2021-01-12"
+        />
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <fieldset
+          aria-describedby="completionTime-hint"
+          class="govuk-fieldset lbh-fieldset"
+          role="group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Completion time 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="completionTime-hint"
+          >
+            Use 24h format. For example, 14:30
+          </span>
+          <div
+            class="govuk-date-input lbh-date-input"
+            id="completionTime"
+          >
+            <div
+              class="govuk-date-input__item"
+            >
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label govuk-date-input__label"
+                  for="completionTime-hour"
+                >
+                  Hour
+                </label>
+                <input
+                  class="govuk-input lbh-input govuk-date-input__input govuk-input--width-2"
+                  data-testid="completionTime-hour"
+                  id="completionTime-hour"
+                  inputmode="numeric"
+                  name="completionTime-hour"
+                  pattern="^\\\\d{1,2}$"
+                  type="text"
+                  value="14"
+                />
+              </div>
+            </div>
+            <div
+              class="govuk-date-input__item"
+            >
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label govuk-date-input__label"
+                  for="completionTime-minutes"
+                >
+                  Minutes
+                </label>
+                <input
+                  class="govuk-input govuk-date-input__input govuk-input--width-2"
+                  data-testid="completionTime-minutes"
+                  id="completionTime-minutes"
+                  inputmode="numeric"
+                  name="completionTime-minutes"
+                  pattern="^\\\\d{1,2}$"
+                  type="text"
+                  value="30"
+                />
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        class="operatives"
+      >
+        <p
+          class="govuk-heading-m"
+        >
+          Search by operative name and select from the list
+        </p>
+        <div>
+          <div
+            class="govuk-form-group lbh-form-group operative-datalist"
+            id="operative-0-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="operative-0"
+            >
+              Operative name 1 *  
+            </label>
+            <input
+              autocomplete="off"
+              class="govuk-select lbh-select govuk-!-width-full"
+              data-testid="operative-0"
+              id="operative-0"
+              list="autocomplete-list-operative-0"
+              name="operative-0"
+              value="Operative A [1]"
+            />
+            <datalist
+              id="autocomplete-list-operative-0"
+            >
+              <option
+                value="Operative A [1]"
+              />
+              <option
+                value="Operative B [2]"
+              />
+            </datalist>
+          </div>
+          <div
+            class="select-percentage"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-0-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-0"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-0"
+                id="percentage-0"
+                name="percentage-0"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="smv-read-only"
+          >
+            <p
+              class="lbh-body smv-read-only--label"
+            >
+              SMV
+            </p>
+            <p
+              class="lbh-body smv-read-only--value"
+            >
+              38
+            </p>
+          </div>
+        </div>
+        <div>
+          <div
+            class="govuk-form-group lbh-form-group operative-datalist"
+            id="operative-1-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="operative-1"
+            >
+              Operative name 2 *  
+            </label>
+            <input
+              autocomplete="off"
+              class="govuk-select lbh-select govuk-!-width-full"
+              data-testid="operative-1"
+              id="operative-1"
+              list="autocomplete-list-operative-1"
+              name="operative-1"
+              value="Operative B [2]"
+            />
+            <datalist
+              id="autocomplete-list-operative-1"
+            >
+              <option
+                value="Operative A [1]"
+              />
+              <option
+                value="Operative B [2]"
+              />
+            </datalist>
+          </div>
+          <div
+            class="select-percentage"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-1-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-1"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-1"
+                id="percentage-1"
+                name="percentage-1"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="smv-read-only"
+          >
+            <p
+              class="lbh-body smv-read-only--label"
+            >
+              SMV
+            </p>
+            <p
+              class="lbh-body smv-read-only--value"
+            >
+              38
+            </p>
+          </div>
+        </div>
+        <div>
+          <a
+            class="lbh-link"
+            href="#"
+          >
+            + Add operative from list
+          </a>
+        </div>
+        <div>
+          <a
+            class="lbh-link"
+            href="#"
+          >
+            - Remove operative from list
+          </a>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label govuk-label--m"
+          for="paymentType"
+        >
+          Payment type 
+        </label>
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Bonus"
+              name="paymentType"
+              type="radio"
+              value="Bonus"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Bonus"
+            >
+              Bonus calculation
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-overtime-hint"
+              checked=""
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Overtime"
+              name="paymentType"
+              type="radio"
+              value="Overtime"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Overtime"
+            >
+              Overtime work order
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-overtime-hint"
+            >
+              SMVs not included in Bonus
+            </span>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-closetobase-hint"
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_CloseToBase"
+              name="paymentType"
+              type="radio"
+              value="CloseToBase"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_CloseToBase"
+            >
+              Close to base
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-closetobase-hint"
+            >
+              Operative payment made
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+        id="notes-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="notes"
+        >
+          Add notes 
+        </label>
+        <textarea
+          aria-describedby="notes-hint notes-error"
+          class="govuk-textarea lbh-textarea"
+          data-testid="notes"
+          id="notes"
+          name="notes"
+          rows="4"
+        >
+          this is a note
+        </textarea>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <button
+          class="govuk-button lbh-button"
+          data-module="govuk-button"
+          type="submit"
+        >
+          Close work order
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`CloseWorkOrderForm component should should not render startDate or startTime 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link lbh-back-link govuk-!-display-none-print"
+      role="button"
+    >
+      Back
+    </a>
+    <h1
+      class="lbh-heading-h2"
+    >
+      Close work order: 10000012
+    </h1>
+    <form
+      role="form"
+    >
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label govuk-label--m"
+          for="reason"
+        >
+          Select reason for closing 
+        </label>
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_Work Order Completed"
+              name="reason"
+              type="radio"
+              value="Work Order Completed"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_Work Order Completed"
+            >
+              Completed
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              checked=""
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_No Access"
+              name="reason"
+              type="radio"
+              value="No Access"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_No Access"
+            >
+              No access
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label lbh-label govuk-label--m"
+          for="completionDate"
+        >
+          Select completion date 
+        </label>
+        <span
+          class="govuk-hint lbh-hint"
+          id="completionDate-hint"
+        >
+          For example, 15/05/2021
+        </span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          data-testid="completionDate"
+          id="completionDate"
+          name="completionDate"
+          type="date"
+          value="2021-01-12"
+        />
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <fieldset
+          aria-describedby="completionTime-hint"
+          class="govuk-fieldset lbh-fieldset"
+          role="group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Completion time 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="completionTime-hint"
+          >
+            Use 24h format. For example, 14:30
+          </span>
+          <div
+            class="govuk-date-input lbh-date-input"
+            id="completionTime"
+          >
+            <div
+              class="govuk-date-input__item"
+            >
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label govuk-date-input__label"
+                  for="completionTime-hour"
+                >
+                  Hour
+                </label>
+                <input
+                  class="govuk-input lbh-input govuk-date-input__input govuk-input--width-2"
+                  data-testid="completionTime-hour"
+                  id="completionTime-hour"
+                  inputmode="numeric"
+                  name="completionTime-hour"
+                  pattern="^\\\\d{1,2}$"
+                  type="text"
+                  value="14"
+                />
+              </div>
+            </div>
+            <div
+              class="govuk-date-input__item"
+            >
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label govuk-date-input__label"
+                  for="completionTime-minutes"
+                >
+                  Minutes
+                </label>
+                <input
+                  class="govuk-input govuk-date-input__input govuk-input--width-2"
+                  data-testid="completionTime-minutes"
+                  id="completionTime-minutes"
+                  inputmode="numeric"
+                  name="completionTime-minutes"
+                  pattern="^\\\\d{1,2}$"
+                  type="text"
+                  value="30"
+                />
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        class="operatives"
+      >
+        <p
+          class="govuk-heading-m"
+        >
+          Search by operative name and select from the list
+        </p>
+        <div>
+          <div
+            class="govuk-form-group lbh-form-group operative-datalist"
+            id="operative-0-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="operative-0"
+            >
+              Operative name 1 *  
+            </label>
+            <input
+              autocomplete="off"
+              class="govuk-select lbh-select govuk-!-width-full"
+              data-testid="operative-0"
+              id="operative-0"
+              list="autocomplete-list-operative-0"
+              name="operative-0"
+              value="Operative A [1]"
+            />
+            <datalist
+              id="autocomplete-list-operative-0"
+            >
+              <option
+                value="Operative A [1]"
+              />
+              <option
+                value="Operative B [2]"
+              />
+            </datalist>
+          </div>
+          <div
+            class="select-percentage"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-0-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-0"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-0"
+                id="percentage-0"
+                name="percentage-0"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="smv-read-only"
+          >
+            <p
+              class="lbh-body smv-read-only--label"
+            >
+              SMV
+            </p>
+            <p
+              class="lbh-body smv-read-only--value"
+            >
+              38
+            </p>
+          </div>
+        </div>
+        <div>
+          <div
+            class="govuk-form-group lbh-form-group operative-datalist"
+            id="operative-1-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="operative-1"
+            >
+              Operative name 2 *  
+            </label>
+            <input
+              autocomplete="off"
+              class="govuk-select lbh-select govuk-!-width-full"
+              data-testid="operative-1"
+              id="operative-1"
+              list="autocomplete-list-operative-1"
+              name="operative-1"
+              value="Operative B [2]"
+            />
+            <datalist
+              id="autocomplete-list-operative-1"
+            >
+              <option
+                value="Operative A [1]"
+              />
+              <option
+                value="Operative B [2]"
+              />
+            </datalist>
+          </div>
+          <div
+            class="select-percentage"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-1-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-1"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-1"
+                id="percentage-1"
+                name="percentage-1"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="smv-read-only"
+          >
+            <p
+              class="lbh-body smv-read-only--label"
+            >
+              SMV
+            </p>
+            <p
+              class="lbh-body smv-read-only--value"
+            >
+              38
+            </p>
+          </div>
+        </div>
+        <div>
+          <a
+            class="lbh-link"
+            href="#"
+          >
+            + Add operative from list
+          </a>
+        </div>
+        <div>
+          <a
+            class="lbh-link"
+            href="#"
+          >
+            - Remove operative from list
+          </a>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label govuk-label--m"
+          for="paymentType"
+        >
+          Payment type 
+        </label>
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Bonus"
+              name="paymentType"
+              type="radio"
+              value="Bonus"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Bonus"
+            >
+              Bonus calculation
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-overtime-hint"
+              checked=""
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Overtime"
+              name="paymentType"
+              type="radio"
+              value="Overtime"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Overtime"
+            >
+              Overtime work order
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-overtime-hint"
+            >
+              SMVs not included in Bonus
+            </span>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-closetobase-hint"
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_CloseToBase"
+              name="paymentType"
+              type="radio"
+              value="CloseToBase"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_CloseToBase"
+            >
+              Close to base
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-closetobase-hint"
+            >
+              Operative payment made
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+        id="notes-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="notes"
+        >
+          Add notes 
+        </label>
+        <textarea
+          aria-describedby="notes-hint notes-error"
+          class="govuk-textarea lbh-textarea"
+          data-testid="notes"
+          id="notes"
+          name="notes"
+          rows="4"
+        >
+          this is a note
+        </textarea>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <button
+          class="govuk-button lbh-button"
+          data-module="govuk-button"
+          type="submit"
+        >
+          Close work order
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`CloseWorkOrderForm component should render properly 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link lbh-back-link govuk-!-display-none-print"
+      role="button"
+    >
+      Back
+    </a>
+    <h1
+      class="lbh-heading-h2"
+    >
+      Close work order: 10000012
+    </h1>
+    <form
+      role="form"
+    >
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label govuk-label--m"
+          for="reason"
+        >
+          Select reason for closing 
+        </label>
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_Work Order Completed"
+              name="reason"
+              type="radio"
+              value="Work Order Completed"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_Work Order Completed"
+            >
+              Completed
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              checked=""
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_No Access"
+              name="reason"
+              type="radio"
+              value="No Access"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_No Access"
+            >
+              No access
+            </label>
+          </div>
+        </div>
       </div>
       <div
         class="govuk-form-group lbh-form-group"
@@ -165,6 +1291,569 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
             </div>
           </div>
         </fieldset>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label lbh-label govuk-label--m"
+          for="completionDate"
+        >
+          Select completion date 
+        </label>
+        <span
+          class="govuk-hint lbh-hint"
+          id="completionDate-hint"
+        >
+          For example, 15/05/2021
+        </span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          data-testid="completionDate"
+          id="completionDate"
+          name="completionDate"
+          type="date"
+          value="2021-01-12"
+        />
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <fieldset
+          aria-describedby="completionTime-hint"
+          class="govuk-fieldset lbh-fieldset"
+          role="group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Completion time 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="completionTime-hint"
+          >
+            Use 24h format. For example, 14:30
+          </span>
+          <div
+            class="govuk-date-input lbh-date-input"
+            id="completionTime"
+          >
+            <div
+              class="govuk-date-input__item"
+            >
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label govuk-date-input__label"
+                  for="completionTime-hour"
+                >
+                  Hour
+                </label>
+                <input
+                  class="govuk-input lbh-input govuk-date-input__input govuk-input--width-2"
+                  data-testid="completionTime-hour"
+                  id="completionTime-hour"
+                  inputmode="numeric"
+                  name="completionTime-hour"
+                  pattern="^\\\\d{1,2}$"
+                  type="text"
+                  value="14"
+                />
+              </div>
+            </div>
+            <div
+              class="govuk-date-input__item"
+            >
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label govuk-date-input__label"
+                  for="completionTime-minutes"
+                >
+                  Minutes
+                </label>
+                <input
+                  class="govuk-input govuk-date-input__input govuk-input--width-2"
+                  data-testid="completionTime-minutes"
+                  id="completionTime-minutes"
+                  inputmode="numeric"
+                  name="completionTime-minutes"
+                  pattern="^\\\\d{1,2}$"
+                  type="text"
+                  value="30"
+                />
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        class="operatives"
+      >
+        <p
+          class="govuk-heading-m"
+        >
+          Search by operative name and select from the list
+        </p>
+        <div>
+          <div
+            class="govuk-form-group lbh-form-group operative-datalist"
+            id="operative-0-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="operative-0"
+            >
+              Operative name 1 *  
+            </label>
+            <input
+              autocomplete="off"
+              class="govuk-select lbh-select govuk-!-width-full"
+              data-testid="operative-0"
+              id="operative-0"
+              list="autocomplete-list-operative-0"
+              name="operative-0"
+              value="Operative A [1]"
+            />
+            <datalist
+              id="autocomplete-list-operative-0"
+            >
+              <option
+                value="Operative A [1]"
+              />
+              <option
+                value="Operative B [2]"
+              />
+            </datalist>
+          </div>
+          <div
+            class="select-percentage"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-0-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-0"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-0"
+                id="percentage-0"
+                name="percentage-0"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="smv-read-only"
+          >
+            <p
+              class="lbh-body smv-read-only--label"
+            >
+              SMV
+            </p>
+            <p
+              class="lbh-body smv-read-only--value"
+            >
+              38
+            </p>
+          </div>
+        </div>
+        <div>
+          <div
+            class="govuk-form-group lbh-form-group operative-datalist"
+            id="operative-1-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="operative-1"
+            >
+              Operative name 2 *  
+            </label>
+            <input
+              autocomplete="off"
+              class="govuk-select lbh-select govuk-!-width-full"
+              data-testid="operative-1"
+              id="operative-1"
+              list="autocomplete-list-operative-1"
+              name="operative-1"
+              value="Operative B [2]"
+            />
+            <datalist
+              id="autocomplete-list-operative-1"
+            >
+              <option
+                value="Operative A [1]"
+              />
+              <option
+                value="Operative B [2]"
+              />
+            </datalist>
+          </div>
+          <div
+            class="select-percentage"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+              id="percentage-1-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="percentage-1"
+              >
+                Work done 
+              </label>
+              <select
+                class="govuk-select lbh-select undefined"
+                data-testid="percentage-1"
+                id="percentage-1"
+                name="percentage-1"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  value="100%"
+                >
+                  100%
+                </option>
+                <option
+                  value="90%"
+                >
+                  90%
+                </option>
+                <option
+                  value="80%"
+                >
+                  80%
+                </option>
+                <option
+                  value="70%"
+                >
+                  70%
+                </option>
+                <option
+                  value="60%"
+                >
+                  60%
+                </option>
+                <option
+                  value="50%"
+                >
+                  50%
+                </option>
+                <option
+                  value="40%"
+                >
+                  40%
+                </option>
+                <option
+                  value="30%"
+                >
+                  30%
+                </option>
+                <option
+                  value="20%"
+                >
+                  20%
+                </option>
+                <option
+                  value="10%"
+                >
+                  10%
+                </option>
+                <option
+                  value="-"
+                >
+                  -
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="smv-read-only"
+          >
+            <p
+              class="lbh-body smv-read-only--label"
+            >
+              SMV
+            </p>
+            <p
+              class="lbh-body smv-read-only--value"
+            >
+              38
+            </p>
+          </div>
+        </div>
+        <div>
+          <a
+            class="lbh-link"
+            href="#"
+          >
+            + Add operative from list
+          </a>
+        </div>
+        <div>
+          <a
+            class="lbh-link"
+            href="#"
+          >
+            - Remove operative from list
+          </a>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label govuk-label--m"
+          for="paymentType"
+        >
+          Payment type 
+        </label>
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Bonus"
+              name="paymentType"
+              type="radio"
+              value="Bonus"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Bonus"
+            >
+              Bonus calculation
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-overtime-hint"
+              checked=""
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Overtime"
+              name="paymentType"
+              type="radio"
+              value="Overtime"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Overtime"
+            >
+              Overtime work order
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-overtime-hint"
+            >
+              SMVs not included in Bonus
+            </span>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-closetobase-hint"
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_CloseToBase"
+              name="paymentType"
+              type="radio"
+              value="CloseToBase"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_CloseToBase"
+            >
+              Close to base
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-closetobase-hint"
+            >
+              Operative payment made
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+        id="notes-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="notes"
+        >
+          Add notes 
+        </label>
+        <textarea
+          aria-describedby="notes-hint notes-error"
+          class="govuk-textarea lbh-textarea"
+          data-testid="notes"
+          id="notes"
+          name="notes"
+          rows="4"
+        >
+          this is a note
+        </textarea>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <button
+          class="govuk-button lbh-button"
+          data-module="govuk-button"
+          type="submit"
+        >
+          Close work order
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`should not render startDate or startTime 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="govuk-back-link lbh-back-link govuk-!-display-none-print"
+      role="button"
+    >
+      Back
+    </a>
+    <h1
+      class="lbh-heading-h2"
+    >
+      Close work order: 10000012
+    </h1>
+    <form
+      role="form"
+    >
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label govuk-label--m"
+          for="reason"
+        >
+          Select reason for closing 
+        </label>
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_Work Order Completed"
+              name="reason"
+              type="radio"
+              value="Work Order Completed"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_Work Order Completed"
+            >
+              Completed
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              checked=""
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_No Access"
+              name="reason"
+              type="radio"
+              value="No Access"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_No Access"
+            >
+              No access
+            </label>
+          </div>
+        </div>
       </div>
       <div
         class="govuk-form-group lbh-form-group"


### PR DESCRIPTION
## Summary of Changes

- Hide startTime and startTime fields if `workOrder.startTime`  is not null.