### PR TITLE
Fix start time summary bug

### DIFF
--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -169,7 +169,10 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     )
     setCompletionDate(formattedCompletionDate)
 
-    if (!formData.hasOwnProperty("startDate") || formData.startDate === '') {
+    if (
+      !Object.prototype.hasOwnProperty.call(formData, 'startDate') ||
+      formData.startDate === ''
+    ) {
       setStartDate('')
     } else {
       const formattedStartDate = convertToDateFormat(

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -169,13 +169,14 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     )
     setCompletionDate(formattedCompletionDate)
 
-    if (formData.startDate === '') {
+    if (!formData.hasOwnProperty("startDate") || formData.startDate === '') {
       setStartDate('')
     } else {
       const formattedStartDate = convertToDateFormat(
         formData.startDate,
         formData.startTime
       )
+
       setStartDate(formattedStartDate)
     }
 


### PR DESCRIPTION
## Summary of Changes

Add a check to prevent the Invalid Date bug when closing workOrder. The error occurs when the startTime has been set by an operative, and the startTime fields are removed from the form. 

![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/88662046/b53843df-93e2-4d6d-a727-c67817d2fa19)
