### PR TITLE
MR-730 Enable multitrade for more contractors

### DIFF
--- a/cypress/fixtures/contractors/multiTradeContractors.json
+++ b/cypress/fixtures/contractors/multiTradeContractors.json
@@ -1,5 +1,11 @@
 [
   {
+    "contractorReference": "AEP",
+    "contractorName": "Axis Europe (X) PLC",
+    "contractReference": null,
+    "contractCost": 0
+  },
+  {
     "contractorReference": "DEX",
     "contractorName": "DECORATION ALLOWANCE",
     "contractReference": null,

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -88,7 +88,7 @@ describe('Raise repair form', () => {
     cy.intercept(
       {
         method: 'GET',
-        path: '/api/workOrders/budget-codes?contractorReference=*',
+        path: '/api/workOrders/budget-codes?contractorReference=PCL',
       },
       { fixture: 'scheduleOfRates/budgetCodes.json' }
     ).as('budgetCodesRequest')
@@ -97,7 +97,7 @@ describe('Raise repair form', () => {
       {
         method: 'GET',
         path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=*&isRaisable=true',
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
       },
       { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     ).as('sorCodesRequest')
@@ -830,6 +830,23 @@ describe('Raise repair form', () => {
             },
             { fixture: 'contractors/multiTradeContractors.json' }
           ).as('multiTradeContractorsRequest')
+
+          cy.intercept(
+            {
+              method: 'GET',
+              path: `/api/workOrders/budget-codes?contractorReference=${ctr.code}`,
+            },
+            { fixture: 'scheduleOfRates/budgetCodes.json' }
+          ).as('budgetCodesRequest')
+      
+          cy.intercept(
+            {
+              method: 'GET',
+              path:
+                `/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=${ctr.code}&isRaisable=true`,
+            },
+            { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
+          ).as('sorCodesRequest')
         })
 
         context(

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -838,12 +838,11 @@ describe('Raise repair form', () => {
             },
             { fixture: 'scheduleOfRates/budgetCodes.json' }
           ).as('budgetCodesRequest')
-      
+
           cy.intercept(
             {
               method: 'GET',
-              path:
-                `/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=${ctr.code}&isRaisable=true`,
+              path: `/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=${ctr.code}&isRaisable=true`,
             },
             { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
           ).as('sorCodesRequest')

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -816,242 +816,248 @@ describe('Raise repair form', () => {
       cy.audit()
     })
 
-    describe("when the order is for the 'multi trade' trade and the contractor is Purdy", () => {
-      beforeEach(() => {
-        cy.intercept(
-          {
-            method: 'GET',
-            path: '/api/contractors?propertyReference=00012345&tradeCode=MU',
-          },
-          { fixture: 'contractors/multiTradeContractors.json' }
-        ).as('multiTradeContractorsRequest')
-      })
-
-      context('and the incremental multitrade SOR search toggle is on', () => {
+    describe("when the order is for the 'multi trade' trade and the contractor is Purdy, Axis, or HHL", () => {
+      [
+        {code: 'PCL', name: 'Purdy Contracts (P) Ltd'},
+        {code: 'AEP', name: 'Axis Europe (X) PLC'},
+        {code: 'HHL', name: 'Herts Heritage Ltd'},
+      ].forEach((ctr) => {
         beforeEach(() => {
           cy.intercept(
-            { method: 'GET', path: '/api/toggles' },
             {
-              body: [
-                {
-                  featureToggles: {
-                    [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: true,
-                  },
-                },
-              ],
-            }
-          ).as('toggleRequest')
+              method: 'GET',
+              path: '/api/contractors?propertyReference=00012345&tradeCode=MU',
+            },
+            { fixture: 'contractors/multiTradeContractors.json' }
+          ).as('multiTradeContractorsRequest')
         })
-
-        it('Searches SOR codes after entering three characters with a debounced API request', () => {
-          cy.visit('/properties/00012345/raise-repair/new')
-
-          cy.wait([
-            '@propertyRequest',
-            '@sorPrioritiesRequest',
-            '@tradesRequest',
-          ])
-
-          cy.get('#repair-request-form').within(() => {
-            cy.get('#trade').type('Multi Trade - MU')
-
-            cy.wait('@multiTradeContractorsRequest')
-
-            cy.get('#contractor').type('Purdy Contracts (P) Ltd - PCL')
-
-            cy.wait('@budgetCodesRequest')
-
-            cy.get('[data-testid=budgetCode]').type(
-              'H2555 - 200031 - Lifts Breakdown'
-            )
-
-            cy.wait('@toggleRequest')
-
-            cy.get('input[id="rateScheduleItems[0][code]"]').clear().type('D')
-
-            cy.get('input[id="rateScheduleItems[0][code]"]').type('E')
-            cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
-              'eq',
-              0
-            )
-
+  
+        context('and the incremental multitrade SOR search toggle is on', () => {
+          beforeEach(() => {
             cy.intercept(
-              {
-                method: 'GET',
-                path:
-                  '/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=PCL&isRaisable=true?filter=DES?showAllTrades=true',
-              },
+              { method: 'GET', path: '/api/toggles' },
               {
                 body: [
                   {
-                    code: 'DES5R003',
-                    shortDescription: 'Immediate call outs',
-                    priority: {
-                      priorityCode: 1,
-                      description: '1 [I] IMMEDIATE',
+                    featureToggles: {
+                      [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: true,
                     },
-                    cost: 0,
-                  },
-                  {
-                    code: 'DES5R004',
-                    shortDescription: 'Emergency call out',
-                    priority: {
-                      priorityCode: 2,
-                      description: '2 [E] EMERGENCY',
-                    },
-                    cost: 1,
                   },
                 ],
               }
-            ).as('sorCodesRequestDES')
-
-            // Enter three characters, then clear and immediately re-enter them
-            cy.get('input[id="rateScheduleItems[0][code]"]')
-              .type('S')
-              .clear()
-              .type('DES')
-
-            cy.wait('@sorCodesRequestDES')
-
-            // The three-character input triggering an API request should have been debounced from 2 requests to just 1
-            cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
-              'eq',
-              1
-            )
-
-            cy.get('[data-testid="rateScheduleItems[0][code]"]')
-              .parent()
-              .find('datalist option')
-              .should('have.length', 2)
-              .first()
-              .should(
-                'have.attr',
-                'value',
-                'DES5R003 - Immediate call outs - £0'
-              )
-              .next()
-              .should(
-                'have.attr',
-                'value',
-                'DES5R004 - Emergency call out - £1'
-              )
-
-            // type the remainder of the code
-            cy.get('input[id="rateScheduleItems[0][code]"]').type(
-              '5R003 - Immediate call outs - £0'
-            )
-
-            // Entering more than three characters does not trigger more API requests
-            cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
-              'eq',
-              1
-            )
-
-            cy.get('#priorityCode')
-              .find('option:selected')
-              .should('have.text', '1 [I] IMMEDIATE')
-
-            cy.contains('+ Add another SOR code').click()
-
-            cy.get('input[id="rateScheduleItems[1][code]"]').type('DES')
-
-            cy.wait('@sorCodesRequestDES')
-
-            cy.get('input[id="rateScheduleItems[1][code]"]').type(
-              '5R004 - Emergency call out - £1'
-            )
-
-            cy.get('input[id="rateScheduleItems[0][quantity]"]')
-              .clear()
-              .type('1')
-
-            cy.get('input[id="rateScheduleItems[1][quantity]"]')
-              .clear()
-              .type('1')
-
-            cy.get('#descriptionOfWork')
-              .get('.govuk-textarea')
-              .type('A problem')
-
-            cy.get('[data-testid=callerName]').type('Test Caller')
-            cy.get('[data-testid=contactNumber]').type('12345678910')
-
-            cy.get('[type="submit"]').contains('Create work order').click()
+            ).as('toggleRequest')
           })
-
-          cy.wait('@apiCheck', { requestTimeout: 9000 }).then(({ request }) => {
-            const referenceIdUuid = request.body.reference[0].id
-
-            cy.wrap(request.body).should('deep.include', {
-              reference: [{ id: referenceIdUuid }],
-              descriptionOfWork: 'A problem',
-              priority: {
-                priorityCode: IMMEDIATE_PRIORITY_CODE,
-                priorityDescription: '1 [I] IMMEDIATE',
-                numberOfDays: 0,
-              },
-              workElement: [
+  
+          it('Searches SOR codes after entering three characters with a debounced API request', () => {
+            cy.visit('/properties/00012345/raise-repair/new')
+  
+            cy.wait([
+              '@propertyRequest',
+              '@sorPrioritiesRequest',
+              '@tradesRequest',
+            ])
+  
+            cy.get('#repair-request-form').within(() => {
+              cy.get('#trade').type('Multi Trade - MU')
+  
+              cy.wait('@multiTradeContractorsRequest')
+  
+              cy.get('#contractor').type(`${ctr.name} - ${ctr.code}`)
+  
+              cy.wait('@budgetCodesRequest')
+  
+              cy.get('[data-testid=budgetCode]').type(
+                'H2555 - 200031 - Lifts Breakdown'
+              )
+  
+              cy.wait('@toggleRequest')
+  
+              cy.get('input[id="rateScheduleItems[0][code]"]').clear().type('D')
+  
+              cy.get('input[id="rateScheduleItems[0][code]"]').type('E')
+              cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
+                'eq',
+                0
+              )
+  
+              cy.intercept(
                 {
-                  rateScheduleItem: [
-                    {
-                      customCode: 'DES5R003',
-                      customName: 'Immediate call outs',
-                      quantity: { amount: [1] },
-                    },
-                  ],
-                  trade: [
-                    {
-                      code: 'SP',
-                      customCode: 'MU',
-                      customName: 'Multi Trade - MU',
-                    },
-                  ],
+                  method: 'GET',
+                  path:
+                    `/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=${ctr.code}&isRaisable=true?filter=DES?showAllTrades=true`,
                 },
                 {
-                  rateScheduleItem: [
+                  body: [
                     {
-                      customCode: 'DES5R004',
-                      customName: 'Emergency call out',
-                      quantity: { amount: [1] },
+                      code: 'DES5R003',
+                      shortDescription: 'Immediate call outs',
+                      priority: {
+                        priorityCode: 1,
+                        description: '1 [I] IMMEDIATE',
+                      },
+                      cost: 0,
+                    },
+                    {
+                      code: 'DES5R004',
+                      shortDescription: 'Emergency call out',
+                      priority: {
+                        priorityCode: 2,
+                        description: '2 [E] EMERGENCY',
+                      },
+                      cost: 1,
                     },
                   ],
-                  trade: [
-                    {
-                      code: 'SP',
-                      customCode: 'MU',
-                      customName: 'Multi Trade - MU',
-                    },
-                  ],
+                }
+              ).as('sorCodesRequestDES')
+  
+              // Enter three characters, then clear and immediately re-enter them
+              cy.get('input[id="rateScheduleItems[0][code]"]')
+                .type('S')
+                .clear()
+                .type('DES')
+  
+              cy.wait('@sorCodesRequestDES')
+  
+              // The three-character input triggering an API request should have been debounced from 2 requests to just 1
+              cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
+                'eq',
+                1
+              )
+  
+              cy.get('[data-testid="rateScheduleItems[0][code]"]')
+                .parent()
+                .find('datalist option')
+                .should('have.length', 2)
+                .first()
+                .should(
+                  'have.attr',
+                  'value',
+                  'DES5R003 - Immediate call outs - £0'
+                )
+                .next()
+                .should(
+                  'have.attr',
+                  'value',
+                  'DES5R004 - Emergency call out - £1'
+                )
+  
+              // type the remainder of the code
+              cy.get('input[id="rateScheduleItems[0][code]"]').type(
+                '5R003 - Immediate call outs - £0'
+              )
+  
+              // Entering more than three characters does not trigger more API requests
+              cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
+                'eq',
+                1
+              )
+  
+              cy.get('#priorityCode')
+                .find('option:selected')
+                .should('have.text', '1 [I] IMMEDIATE')
+  
+              cy.contains('+ Add another SOR code').click()
+  
+              cy.get('input[id="rateScheduleItems[1][code]"]').type('DES')
+  
+              cy.wait('@sorCodesRequestDES')
+  
+              cy.get('input[id="rateScheduleItems[1][code]"]').type(
+                '5R004 - Emergency call out - £1'
+              )
+  
+              cy.get('input[id="rateScheduleItems[0][quantity]"]')
+                .clear()
+                .type('1')
+  
+              cy.get('input[id="rateScheduleItems[1][quantity]"]')
+                .clear()
+                .type('1')
+  
+              cy.get('#descriptionOfWork')
+                .get('.govuk-textarea')
+                .type('A problem')
+  
+              cy.get('[data-testid=callerName]').type('Test Caller')
+              cy.get('[data-testid=contactNumber]').type('12345678910')
+  
+              cy.get('[type="submit"]').contains('Create work order').click()
+            })
+  
+            cy.wait('@apiCheck', { requestTimeout: 9000 }).then(({ request }) => {
+              const referenceIdUuid = request.body.reference[0].id
+  
+              cy.wrap(request.body).should('deep.include', {
+                reference: [{ id: referenceIdUuid }],
+                descriptionOfWork: 'A problem',
+                priority: {
+                  priorityCode: IMMEDIATE_PRIORITY_CODE,
+                  priorityDescription: '1 [I] IMMEDIATE',
+                  numberOfDays: 0,
                 },
-              ],
-              site: {
-                property: [
+                workElement: [
                   {
-                    propertyReference: '00012345',
-                    address: {
-                      addressLine: ['16 Pitcairn House  St Thomass Square'],
-                      postalCode: 'E9 6PT',
-                    },
-                    reference: [
+                    rateScheduleItem: [
                       {
-                        id: '00012345',
+                        customCode: 'DES5R003',
+                        customName: 'Immediate call outs',
+                        quantity: { amount: [1] },
+                      },
+                    ],
+                    trade: [
+                      {
+                        code: 'SP',
+                        customCode: 'MU',
+                        customName: 'Multi Trade - MU',
+                      },
+                    ],
+                  },
+                  {
+                    rateScheduleItem: [
+                      {
+                        customCode: 'DES5R004',
+                        customName: 'Emergency call out',
+                        quantity: { amount: [1] },
+                      },
+                    ],
+                    trade: [
+                      {
+                        code: 'SP',
+                        customCode: 'MU',
+                        customName: 'Multi Trade - MU',
                       },
                     ],
                   },
                 ],
-              },
-              assignedToPrimary: {
-                name: 'Purdy Contracts (P) Ltd',
-                organization: {
-                  reference: [
+                site: {
+                  property: [
                     {
-                      id: 'PCL',
+                      propertyReference: '00012345',
+                      address: {
+                        addressLine: ['16 Pitcairn House  St Thomass Square'],
+                        postalCode: 'E9 6PT',
+                      },
+                      reference: [
+                        {
+                          id: '00012345',
+                        },
+                      ],
                     },
                   ],
                 },
-              },
-              budgetCode: { id: '1' },
-              multiTradeWorkOrder: true,
+                assignedToPrimary: {
+                  name: ctr.name,
+                  organization: {
+                    reference: [
+                      {
+                        id: ctr.code,
+                      },
+                    ],
+                  },
+                },
+                budgetCode: { id: '1' },
+                multiTradeWorkOrder: true,
+              })
             })
           })
         })

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -96,8 +96,42 @@ describe('Raise repair form', () => {
     cy.intercept(
       {
         method: 'GET',
+        path: '/api/workOrders/budget-codes?contractorReference=HHL',
+      },
+      { fixture: 'scheduleOfRates/budgetCodes.json' }
+    ).as('budgetCodesRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/workOrders/budget-codes?contractorReference=AEP',
+      },
+      { fixture: 'scheduleOfRates/budgetCodes.json' }
+    ).as('budgetCodesRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
         path:
           '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
+      },
+      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
+    ).as('sorCodesRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
+        path:
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=HHL&isRaisable=true',
+      },
+      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
+    ).as('sorCodesRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
+        path:
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=AEP&isRaisable=true',
       },
       { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     ).as('sorCodesRequest')

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -96,42 +96,8 @@ describe('Raise repair form', () => {
     cy.intercept(
       {
         method: 'GET',
-        path: '/api/workOrders/budget-codes?contractorReference=HHL',
-      },
-      { fixture: 'scheduleOfRates/budgetCodes.json' }
-    ).as('budgetCodesRequest')
-
-    cy.intercept(
-      {
-        method: 'GET',
-        path: '/api/workOrders/budget-codes?contractorReference=AEP',
-      },
-      { fixture: 'scheduleOfRates/budgetCodes.json' }
-    ).as('budgetCodesRequest')
-
-    cy.intercept(
-      {
-        method: 'GET',
         path:
           '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
-      },
-      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
-    ).as('sorCodesRequest')
-
-    cy.intercept(
-      {
-        method: 'GET',
-        path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=HHL&isRaisable=true',
-      },
-      { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
-    ).as('sorCodesRequest')
-
-    cy.intercept(
-      {
-        method: 'GET',
-        path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=AEP&isRaisable=true',
       },
       { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     ).as('sorCodesRequest')

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -88,7 +88,7 @@ describe('Raise repair form', () => {
     cy.intercept(
       {
         method: 'GET',
-        path: '/api/workOrders/budget-codes?contractorReference=PCL',
+        path: '/api/workOrders/budget-codes?contractorReference=*',
       },
       { fixture: 'scheduleOfRates/budgetCodes.json' }
     ).as('budgetCodesRequest')
@@ -97,7 +97,7 @@ describe('Raise repair form', () => {
       {
         method: 'GET',
         path:
-          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=PCL&isRaisable=true',
+          '/api/schedule-of-rates/codes?tradeCode=PL&propertyReference=00012345&contractorReference=*&isRaisable=true',
       },
       { fixture: 'scheduleOfRates/codesWithIsRaisableTrue.json' }
     ).as('sorCodesRequest')

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -817,10 +817,10 @@ describe('Raise repair form', () => {
     })
 
     describe("when the order is for the 'multi trade' trade and the contractor is Purdy, Axis, or HHL", () => {
-      [
-        {code: 'PCL', name: 'Purdy Contracts (P) Ltd'},
-        {code: 'AEP', name: 'Axis Europe (X) PLC'},
-        {code: 'HHL', name: 'Herts Heritage Ltd'},
+      ;[
+        { code: 'PCL', name: 'Purdy Contracts (P) Ltd' },
+        { code: 'AEP', name: 'Axis Europe (X) PLC' },
+        { code: 'HHL', name: 'Herts Heritage Ltd' },
       ].forEach((ctr) => {
         beforeEach(() => {
           cy.intercept(
@@ -831,236 +831,244 @@ describe('Raise repair form', () => {
             { fixture: 'contractors/multiTradeContractors.json' }
           ).as('multiTradeContractorsRequest')
         })
-  
-        context('and the incremental multitrade SOR search toggle is on', () => {
-          beforeEach(() => {
-            cy.intercept(
-              { method: 'GET', path: '/api/toggles' },
-              {
-                body: [
-                  {
-                    featureToggles: {
-                      [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: true,
-                    },
-                  },
-                ],
-              }
-            ).as('toggleRequest')
-          })
-  
-          it('Searches SOR codes after entering three characters with a debounced API request', () => {
-            cy.visit('/properties/00012345/raise-repair/new')
-  
-            cy.wait([
-              '@propertyRequest',
-              '@sorPrioritiesRequest',
-              '@tradesRequest',
-            ])
-  
-            cy.get('#repair-request-form').within(() => {
-              cy.get('#trade').type('Multi Trade - MU')
-  
-              cy.wait('@multiTradeContractorsRequest')
-  
-              cy.get('#contractor').type(`${ctr.name} - ${ctr.code}`)
-  
-              cy.wait('@budgetCodesRequest')
-  
-              cy.get('[data-testid=budgetCode]').type(
-                'H2555 - 200031 - Lifts Breakdown'
-              )
-  
-              cy.wait('@toggleRequest')
-  
-              cy.get('input[id="rateScheduleItems[0][code]"]').clear().type('D')
-  
-              cy.get('input[id="rateScheduleItems[0][code]"]').type('E')
-              cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
-                'eq',
-                0
-              )
-  
+
+        context(
+          'and the incremental multitrade SOR search toggle is on',
+          () => {
+            beforeEach(() => {
               cy.intercept(
-                {
-                  method: 'GET',
-                  path:
-                    `/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=${ctr.code}&isRaisable=true?filter=DES?showAllTrades=true`,
-                },
+                { method: 'GET', path: '/api/toggles' },
                 {
                   body: [
                     {
-                      code: 'DES5R003',
-                      shortDescription: 'Immediate call outs',
-                      priority: {
-                        priorityCode: 1,
-                        description: '1 [I] IMMEDIATE',
+                      featureToggles: {
+                        [MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY]: true,
                       },
-                      cost: 0,
-                    },
-                    {
-                      code: 'DES5R004',
-                      shortDescription: 'Emergency call out',
-                      priority: {
-                        priorityCode: 2,
-                        description: '2 [E] EMERGENCY',
-                      },
-                      cost: 1,
                     },
                   ],
                 }
-              ).as('sorCodesRequestDES')
-  
-              // Enter three characters, then clear and immediately re-enter them
-              cy.get('input[id="rateScheduleItems[0][code]"]')
-                .type('S')
-                .clear()
-                .type('DES')
-  
-              cy.wait('@sorCodesRequestDES')
-  
-              // The three-character input triggering an API request should have been debounced from 2 requests to just 1
-              cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
-                'eq',
-                1
-              )
-  
-              cy.get('[data-testid="rateScheduleItems[0][code]"]')
-                .parent()
-                .find('datalist option')
-                .should('have.length', 2)
-                .first()
-                .should(
-                  'have.attr',
-                  'value',
-                  'DES5R003 - Immediate call outs - £0'
-                )
-                .next()
-                .should(
-                  'have.attr',
-                  'value',
-                  'DES5R004 - Emergency call out - £1'
-                )
-  
-              // type the remainder of the code
-              cy.get('input[id="rateScheduleItems[0][code]"]').type(
-                '5R003 - Immediate call outs - £0'
-              )
-  
-              // Entering more than three characters does not trigger more API requests
-              cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
-                'eq',
-                1
-              )
-  
-              cy.get('#priorityCode')
-                .find('option:selected')
-                .should('have.text', '1 [I] IMMEDIATE')
-  
-              cy.contains('+ Add another SOR code').click()
-  
-              cy.get('input[id="rateScheduleItems[1][code]"]').type('DES')
-  
-              cy.wait('@sorCodesRequestDES')
-  
-              cy.get('input[id="rateScheduleItems[1][code]"]').type(
-                '5R004 - Emergency call out - £1'
-              )
-  
-              cy.get('input[id="rateScheduleItems[0][quantity]"]')
-                .clear()
-                .type('1')
-  
-              cy.get('input[id="rateScheduleItems[1][quantity]"]')
-                .clear()
-                .type('1')
-  
-              cy.get('#descriptionOfWork')
-                .get('.govuk-textarea')
-                .type('A problem')
-  
-              cy.get('[data-testid=callerName]').type('Test Caller')
-              cy.get('[data-testid=contactNumber]').type('12345678910')
-  
-              cy.get('[type="submit"]').contains('Create work order').click()
+              ).as('toggleRequest')
             })
-  
-            cy.wait('@apiCheck', { requestTimeout: 9000 }).then(({ request }) => {
-              const referenceIdUuid = request.body.reference[0].id
-  
-              cy.wrap(request.body).should('deep.include', {
-                reference: [{ id: referenceIdUuid }],
-                descriptionOfWork: 'A problem',
-                priority: {
-                  priorityCode: IMMEDIATE_PRIORITY_CODE,
-                  priorityDescription: '1 [I] IMMEDIATE',
-                  numberOfDays: 0,
-                },
-                workElement: [
+
+            it('Searches SOR codes after entering three characters with a debounced API request', () => {
+              cy.visit('/properties/00012345/raise-repair/new')
+
+              cy.wait([
+                '@propertyRequest',
+                '@sorPrioritiesRequest',
+                '@tradesRequest',
+              ])
+
+              cy.get('#repair-request-form').within(() => {
+                cy.get('#trade').type('Multi Trade - MU')
+
+                cy.wait('@multiTradeContractorsRequest')
+
+                cy.get('#contractor').type(`${ctr.name} - ${ctr.code}`)
+
+                cy.wait('@budgetCodesRequest')
+
+                cy.get('[data-testid=budgetCode]').type(
+                  'H2555 - 200031 - Lifts Breakdown'
+                )
+
+                cy.wait('@toggleRequest')
+
+                cy.get('input[id="rateScheduleItems[0][code]"]')
+                  .clear()
+                  .type('D')
+
+                cy.get('input[id="rateScheduleItems[0][code]"]').type('E')
+                cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
+                  'eq',
+                  0
+                )
+
+                cy.intercept(
                   {
-                    rateScheduleItem: [
-                      {
-                        customCode: 'DES5R003',
-                        customName: 'Immediate call outs',
-                        quantity: { amount: [1] },
-                      },
-                    ],
-                    trade: [
-                      {
-                        code: 'SP',
-                        customCode: 'MU',
-                        customName: 'Multi Trade - MU',
-                      },
-                    ],
+                    method: 'GET',
+                    path: `/api/schedule-of-rates/codes?tradeCode=MU&propertyReference=00012345&contractorReference=${ctr.code}&isRaisable=true?filter=DES?showAllTrades=true`,
                   },
                   {
-                    rateScheduleItem: [
+                    body: [
                       {
-                        customCode: 'DES5R004',
-                        customName: 'Emergency call out',
-                        quantity: { amount: [1] },
+                        code: 'DES5R003',
+                        shortDescription: 'Immediate call outs',
+                        priority: {
+                          priorityCode: 1,
+                          description: '1 [I] IMMEDIATE',
+                        },
+                        cost: 0,
+                      },
+                      {
+                        code: 'DES5R004',
+                        shortDescription: 'Emergency call out',
+                        priority: {
+                          priorityCode: 2,
+                          description: '2 [E] EMERGENCY',
+                        },
+                        cost: 1,
                       },
                     ],
-                    trade: [
+                  }
+                ).as('sorCodesRequestDES')
+
+                // Enter three characters, then clear and immediately re-enter them
+                cy.get('input[id="rateScheduleItems[0][code]"]')
+                  .type('S')
+                  .clear()
+                  .type('DES')
+
+                cy.wait('@sorCodesRequestDES')
+
+                // The three-character input triggering an API request should have been debounced from 2 requests to just 1
+                cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
+                  'eq',
+                  1
+                )
+
+                cy.get('[data-testid="rateScheduleItems[0][code]"]')
+                  .parent()
+                  .find('datalist option')
+                  .should('have.length', 2)
+                  .first()
+                  .should(
+                    'have.attr',
+                    'value',
+                    'DES5R003 - Immediate call outs - £0'
+                  )
+                  .next()
+                  .should(
+                    'have.attr',
+                    'value',
+                    'DES5R004 - Emergency call out - £1'
+                  )
+
+                // type the remainder of the code
+                cy.get('input[id="rateScheduleItems[0][code]"]').type(
+                  '5R003 - Immediate call outs - £0'
+                )
+
+                // Entering more than three characters does not trigger more API requests
+                cy.requestsCountByUrl('/api/schedule-of-rates/codes*').should(
+                  'eq',
+                  1
+                )
+
+                cy.get('#priorityCode')
+                  .find('option:selected')
+                  .should('have.text', '1 [I] IMMEDIATE')
+
+                cy.contains('+ Add another SOR code').click()
+
+                cy.get('input[id="rateScheduleItems[1][code]"]').type('DES')
+
+                cy.wait('@sorCodesRequestDES')
+
+                cy.get('input[id="rateScheduleItems[1][code]"]').type(
+                  '5R004 - Emergency call out - £1'
+                )
+
+                cy.get('input[id="rateScheduleItems[0][quantity]"]')
+                  .clear()
+                  .type('1')
+
+                cy.get('input[id="rateScheduleItems[1][quantity]"]')
+                  .clear()
+                  .type('1')
+
+                cy.get('#descriptionOfWork')
+                  .get('.govuk-textarea')
+                  .type('A problem')
+
+                cy.get('[data-testid=callerName]').type('Test Caller')
+                cy.get('[data-testid=contactNumber]').type('12345678910')
+
+                cy.get('[type="submit"]').contains('Create work order').click()
+              })
+
+              cy.wait('@apiCheck', { requestTimeout: 9000 }).then(
+                ({ request }) => {
+                  const referenceIdUuid = request.body.reference[0].id
+
+                  cy.wrap(request.body).should('deep.include', {
+                    reference: [{ id: referenceIdUuid }],
+                    descriptionOfWork: 'A problem',
+                    priority: {
+                      priorityCode: IMMEDIATE_PRIORITY_CODE,
+                      priorityDescription: '1 [I] IMMEDIATE',
+                      numberOfDays: 0,
+                    },
+                    workElement: [
                       {
-                        code: 'SP',
-                        customCode: 'MU',
-                        customName: 'Multi Trade - MU',
+                        rateScheduleItem: [
+                          {
+                            customCode: 'DES5R003',
+                            customName: 'Immediate call outs',
+                            quantity: { amount: [1] },
+                          },
+                        ],
+                        trade: [
+                          {
+                            code: 'SP',
+                            customCode: 'MU',
+                            customName: 'Multi Trade - MU',
+                          },
+                        ],
+                      },
+                      {
+                        rateScheduleItem: [
+                          {
+                            customCode: 'DES5R004',
+                            customName: 'Emergency call out',
+                            quantity: { amount: [1] },
+                          },
+                        ],
+                        trade: [
+                          {
+                            code: 'SP',
+                            customCode: 'MU',
+                            customName: 'Multi Trade - MU',
+                          },
+                        ],
                       },
                     ],
-                  },
-                ],
-                site: {
-                  property: [
-                    {
-                      propertyReference: '00012345',
-                      address: {
-                        addressLine: ['16 Pitcairn House  St Thomass Square'],
-                        postalCode: 'E9 6PT',
-                      },
-                      reference: [
+                    site: {
+                      property: [
                         {
-                          id: '00012345',
+                          propertyReference: '00012345',
+                          address: {
+                            addressLine: [
+                              '16 Pitcairn House  St Thomass Square',
+                            ],
+                            postalCode: 'E9 6PT',
+                          },
+                          reference: [
+                            {
+                              id: '00012345',
+                            },
+                          ],
                         },
                       ],
                     },
-                  ],
-                },
-                assignedToPrimary: {
-                  name: ctr.name,
-                  organization: {
-                    reference: [
-                      {
-                        id: ctr.code,
+                    assignedToPrimary: {
+                      name: ctr.name,
+                      organization: {
+                        reference: [
+                          {
+                            id: ctr.code,
+                          },
+                        ],
                       },
-                    ],
-                  },
-                },
-                budgetCode: { id: '1' },
-                multiTradeWorkOrder: true,
-              })
+                    },
+                    budgetCode: { id: '1' },
+                    multiTradeWorkOrder: true,
+                  })
+                }
+              )
             })
-          })
-        })
+          }
+        )
       })
 
       context('and the incremental multitrade SOR search toggle is off', () => {

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -89,7 +89,7 @@ const TradeContractorRateScheduleItemView = ({
 
   const incrementalSORSearchRequired = async (contractorRef, tradeCode) => {
     const orderApplicable =
-      contractorRef === PURDY_CONTRACTOR_REFERENCE &&
+      MULTITRADE_ENABLED_CONTRACTORS.includes(contractorRef) &&
       tradeCode === MULTITRADE_TRADE_CODE
 
     if (!orderApplicable) {
@@ -199,7 +199,7 @@ const TradeContractorRateScheduleItemView = ({
         method: 'get',
         path: '/api/workOrders/budget-codes',
         params: {
-          ...(contractorReference === PURDY_CONTRACTOR_REFERENCE
+          ...(MULTITRADE_ENABLED_CONTRACTORS.includes(contractorReference)
             ? { contractorReference: contractorReference }
             : ''),
         },

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -167,8 +167,8 @@ const TradeContractorRateScheduleItemView = ({
         },
       })
 
-      // Purdy have no SORs for multitrade so this is done
-      // to permit selection of Purdy
+      // Add multitrade contractors who don't have any MT SORs
+      // (only Purdy, Axis and HHL already have some)
       tradeCode === MULTITRADE_TRADE_CODE
         ? setContractors([
             ...contractors,

--- a/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
+++ b/src/components/Property/RaiseWorkOrder/TradeContractorRateScheduleItemView.js
@@ -13,7 +13,7 @@ import { canAssignBudgetCode } from '@/utils/userPermissions'
 import {
   MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY,
   MULTITRADE_TRADE_CODE,
-  PURDY_CONTRACTOR_REFERENCE,
+  MULTITRADE_ENABLED_CONTRACTORS,
 } from '@/utils/constants'
 
 const TradeContractorRateScheduleItemView = ({

--- a/src/components/WorkOrder/Update/Form.js
+++ b/src/components/WorkOrder/Update/Form.js
@@ -8,7 +8,7 @@ import { useForm } from 'react-hook-form'
 import OriginalRateScheduleItems from '../RateScheduleItems/OriginalRateScheduleItems'
 import LatestRateScheduleItems from '../RateScheduleItems/LatestRateScheduleItems'
 import AddedRateScheduleItems from '../RateScheduleItems/AddedRateScheduleItems'
-import { PURDY_CONTRACTOR_REFERENCE } from '@/utils/constants'
+import { MULTITRADE_ENABLED_CONTRACTORS } from '@/utils/constants'
 
 const WorkOrderUpdateForm = ({
   latestTasks,

--- a/src/components/WorkOrder/Update/Form.js
+++ b/src/components/WorkOrder/Update/Form.js
@@ -56,7 +56,7 @@ const WorkOrderUpdateForm = ({
             setPageToMultipleSORs(getValues())
           }}
         />
-        {contractorReference === PURDY_CONTRACTOR_REFERENCE ? (
+        {MULTITRADE_ENABLED_CONTRACTORS.includes(contractorReference) ? (
           <TextArea
             name="variationReason"
             value={variationReason}

--- a/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
+++ b/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
@@ -975,12 +975,6 @@ exports[`WorkOrderUpdateForm component should render properly with unlimited cha
         More work is necessary
       </textarea>
     </div>
-    <span
-      aria-live="polite"
-      class="govuk-hint govuk-character-count__message"
-    >
-      You have 250 characters remaining.
-    </span>
     <div
       class="govuk-form-group lbh-form-group"
     >

--- a/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
+++ b/src/components/WorkOrder/Update/__snapshots__/Form.test.js.snap
@@ -975,6 +975,12 @@ exports[`WorkOrderUpdateForm component should render properly with unlimited cha
         More work is necessary
       </textarea>
     </div>
+    <span
+      aria-live="polite"
+      class="govuk-hint govuk-character-count__message"
+    >
+      You have 250 characters remaining.
+    </span>
     <div
       class="govuk-form-group lbh-form-group"
     >

--- a/src/components/WorkOrder/Update/index.js
+++ b/src/components/WorkOrder/Update/index.js
@@ -14,7 +14,7 @@ import WorkOrderUpdateForm from './Form'
 import WorkOrderUpdateSummary from './Summary'
 import {
   MULTITRADE_SOR_INCREMENTAL_SEARCH_ENABLED_KEY,
-  PURDY_CONTRACTOR_REFERENCE,
+  MULTITRADE_ENABLED_CONTRACTORS,
 } from '@/utils/constants'
 import SuccessPage from '../../SuccessPage/index'
 import { updateWorkOrderLinks, generalLinks } from '@/utils/successPageLinks'
@@ -119,7 +119,9 @@ const WorkOrderUpdateView = ({ reference }) => {
     })
 
   const incrementalSORSearchRequired = async (contractorRef) => {
-    const orderApplicable = MULTITRADE_ENABLED_CONTRACTORS.includes(contractorRef)
+    const orderApplicable = MULTITRADE_ENABLED_CONTRACTORS.includes(
+      contractorRef
+    )
 
     if (!orderApplicable) {
       setOrderRequiresIncrementalSearch(false)

--- a/src/components/WorkOrder/Update/index.js
+++ b/src/components/WorkOrder/Update/index.js
@@ -119,7 +119,7 @@ const WorkOrderUpdateView = ({ reference }) => {
     })
 
   const incrementalSORSearchRequired = async (contractorRef) => {
-    const orderApplicable = contractorRef === PURDY_CONTRACTOR_REFERENCE
+    const orderApplicable = MULTITRADE_ENABLED_CONTRACTORS.includes(contractorRef)
 
     if (!orderApplicable) {
       setOrderRequiresIncrementalSearch(false)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
-export const PURDY_CONTRACTOR_REFERENCE = 'PCL'
+export const MULTITRADE_ENABLED_CONTRACTORS = ['PCL','AEP','HHL']
 export const MULTITRADE_TRADE_CODE = 'MU'
 
 // Feature toggle keys

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,5 @@
 export const MULTITRADE_ENABLED_CONTRACTORS = ['PCL', 'AEP', 'HHL']
+export const PURDY_CONTRACTOR_REFERENCE = 'PCL'
 export const MULTITRADE_TRADE_CODE = 'MU'
 
 // Feature toggle keys

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
-export const MULTITRADE_ENABLED_CONTRACTORS = ['PCL','AEP','HHL']
+export const MULTITRADE_ENABLED_CONTRACTORS = ['PCL', 'AEP', 'HHL']
 export const MULTITRADE_TRADE_CODE = 'MU'
 
 // Feature toggle keys


### PR DESCRIPTION
- Decided against using an environment variable just because this is the type of thing we will forget to update in staging and dev - having a const in code will make it easier to keep the behaviour consistent. If anyone disagrees I'm happy to change it to in env var
- I don't feel the need to copy every test for Purdy for these other two contractors. Ultimately it's testing the same thing. Rather, the strategy is:
"Test that a multi-trade contractor (e.g Purdy) works the way we want it to, and, test that all the multitrade contractors behave like Purdy" 