### PR TITLE
Pass `withContactDetails` query on the raise workOrder page

### DIFF
--- a/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
+++ b/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
@@ -9,7 +9,7 @@ describe('Raise repair form', () => {
         method: 'GET',
         path: '/api/properties/00012345',
         query: {
-          withContactDetails: '*',
+          withContactDetails: true,
         },
       },
       { fixture: 'properties/property.json' }

--- a/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
+++ b/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
@@ -9,7 +9,7 @@ describe('Raise repair form', () => {
         method: 'GET',
         path: '/api/properties/00012345',
         query: {
-          withContactDetails: true,
+          withContactDetails: 'true',
         },
       },
       { fixture: 'properties/property.json' }

--- a/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
+++ b/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
@@ -5,7 +5,13 @@ const now = new Date('2022-02-11T12:00:00')
 describe('Raise repair form', () => {
   beforeEach(() => {
     cy.intercept(
-      { method: 'GET', path: '/api/properties/00012345' },
+      {
+        method: 'GET',
+        path: '/api/properties/00012345',
+        query: {
+          withContactDetails: '*',
+        },
+      },
       { fixture: 'properties/property.json' }
     ).as('propertyRequest')
 

--- a/cypress/integration/work-order/create/create-with-appointment.spec.js
+++ b/cypress/integration/work-order/create/create-with-appointment.spec.js
@@ -13,7 +13,13 @@ describe('Schedule appointment form', () => {
     cy.loginWithAgentRole()
 
     cy.intercept(
-      { method: 'GET', path: '/api/properties/00012345' },
+      {
+        method: 'GET',
+        path: '/api/properties/00012345',
+        query: {
+          withContactDetails: 'true',
+        },
+      },
       { fixture: 'properties/property.json' }
     ).as('property')
 

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -13,7 +13,13 @@ const now = new Date('2022-02-11T12:00:00')
 describe('Raise repair form', () => {
   beforeEach(() => {
     cy.intercept(
-      { method: 'GET', path: '/api/properties/00012345' },
+      {
+        method: 'GET',
+        path: '/api/properties/00012345',
+        query: {
+          withContactDetails: 'true',
+        },
+      },
       { fixture: 'properties/property.json' }
     ).as('propertyRequest')
 

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -136,6 +136,9 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
       const data = await frontEndApiRequest({
         method: 'get',
         path: `/api/properties/${propertyReference}`,
+        params: {
+          withContactDetails: true
+        }
       })
       const priorities = await frontEndApiRequest({
         method: 'get',

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -137,8 +137,8 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
         method: 'get',
         path: `/api/properties/${propertyReference}`,
         params: {
-          withContactDetails: true
-        }
+          withContactDetails: true,
+        },
       })
       const priorities = await frontEndApiRequest({
         method: 'get',


### PR DESCRIPTION
### Description of change

Pass `withContactDetails` flag when raising a repair. Backend change requires this query parameter to include any contact details.