### PR TITLE
Fetch contact details from new endpoint

### DIFF
--- a/cypress/fixtures/contactDetails/contactDetails.json
+++ b/cypress/fixtures/contactDetails/contactDetails.json
@@ -1,0 +1,10 @@
+[
+  {
+    "fullName": "Mark Gardner",
+    "phoneNumbers": [{ "value": "00000111111" }, { "value": "00000222222" }]
+  },
+  {
+    "fullName": "Luam Berhane",
+    "phoneNumbers": [{ "value": "00000666666" }]
+  }
+]

--- a/cypress/fixtures/properties/property.json
+++ b/cypress/fixtures/properties/property.json
@@ -16,7 +16,8 @@
   "tenure": {
     "typeCode": "SEC",
     "typeDescription": "Secure",
-    "tenancyAgreementReference": "tenancyAgreementRef1"
+    "tenancyAgreementReference": "tenancyAgreementRef1",
+    "id": "4552c539-2e00-8533-078d-9cc59d9115da"
   },
   "contactDetails": [
     {

--- a/cypress/integration/work-order/create/appointment-form.spec.js
+++ b/cypress/integration/work-order/create/appointment-form.spec.js
@@ -19,6 +19,14 @@ describe('Schedule appointment form', () => {
     cy.intercept(
       {
         method: 'GET',
+        path: '/api/contact-details/4552c539-2e00-8533-078d-9cc59d9115da',
+      },
+      { fixture: 'contactDetails/contactDetails.json' }
+    ).as('contactDetailsRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
         path: '/api/contractors?propertyReference=00012345&tradeCode=PL',
       },
       { fixture: 'contractors/contractors.json' }

--- a/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
+++ b/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
@@ -16,7 +16,7 @@ describe('Raise repair form', () => {
       },
       { fixture: 'contactDetails/contactDetails.json' }
     ).as('contactDetailsRequest')
-    
+
     cy.intercept(
       {
         method: 'GET',

--- a/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
+++ b/cypress/integration/work-order/create/create-with-adding-multiple-sors.spec.js
@@ -12,6 +12,14 @@ describe('Raise repair form', () => {
     cy.intercept(
       {
         method: 'GET',
+        path: '/api/contact-details/4552c539-2e00-8533-078d-9cc59d9115da',
+      },
+      { fixture: 'contactDetails/contactDetails.json' }
+    ).as('contactDetailsRequest')
+    
+    cy.intercept(
+      {
+        method: 'GET',
         path: '/api/contractors?propertyReference=00012345&tradeCode=PL',
       },
       { fixture: 'contractors/contractors.json' }

--- a/cypress/integration/work-order/create/create-with-appointment.spec.js
+++ b/cypress/integration/work-order/create/create-with-appointment.spec.js
@@ -20,6 +20,14 @@ describe('Schedule appointment form', () => {
     cy.intercept(
       {
         method: 'GET',
+        path: '/api/contact-details/4552c539-2e00-8533-078d-9cc59d9115da',
+      },
+      { fixture: 'contactDetails/contactDetails.json' }
+    ).as('contactDetailsRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
         path: '/api/contractors?propertyReference=00012345&tradeCode=PL',
       },
       { fixture: 'contractors/contractors.json' }

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -1143,11 +1143,7 @@ describe('Raise repair form', () => {
         it('searches SOR codes after loading them all into a list', () => {
           cy.visit('/properties/00012345')
 
-          cy.wait([
-            '@propertyRequest',
-            // '@contactDetailsRequest',
-            '@workOrdersRequest',
-          ])
+          cy.wait(['@propertyRequest', '@workOrdersRequest'])
 
           cy.get('.lbh-heading-h2')
             .contains('Raise a work order on this dwelling')
@@ -1155,7 +1151,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-            // '@contactDetailsRequest',
+
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1239,11 +1235,7 @@ describe('Raise repair form', () => {
         it('does not prevent loading of the form', () => {
           cy.visit('/properties/00012345')
 
-          cy.wait([
-            '@propertyRequest',
-            // '@contactDetailsRequest',
-            '@workOrdersRequest',
-          ])
+          cy.wait(['@propertyRequest', '@workOrdersRequest'])
 
           cy.get('.lbh-heading-h2')
             .contains('Raise a work order on this dwelling')
@@ -1251,7 +1243,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-            // '@contactDetailsRequest',
+
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1283,22 +1275,13 @@ describe('Raise repair form', () => {
     it('Submits an immediate priority work order', () => {
       cy.visit('/properties/00012345')
 
-      cy.wait([
-        '@propertyRequest',
-        // '@contactDetailsRequest',
-        '@workOrdersRequest',
-      ])
+      cy.wait(['@propertyRequest', '@workOrdersRequest'])
 
       cy.get('.lbh-heading-h2')
         .contains('Raise a work order on this dwelling')
         .click()
 
-      cy.wait([
-        '@propertyRequest',
-        // '@contactDetailsRequest',
-        '@sorPrioritiesRequest',
-        '@tradesRequest',
-      ])
+      cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
 
       cy.get('#repair-request-form').within(() => {
         cy.get('#trade').type('Plumbing - PL')
@@ -1686,11 +1669,7 @@ describe('Raise repair form', () => {
 
       cy.visit('/properties/00012345')
 
-      cy.wait([
-        '@propertyRequest',
-        // '@contactDetailsRequest',
-        '@workOrdersRequest',
-      ])
+      cy.wait(['@propertyRequest', '@workOrdersRequest'])
 
       cy.get('.lbh-heading-h2')
         .contains('Raise a work order on this dwelling')
@@ -1698,7 +1677,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        // '@contactDetailsRequest',
+
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepair',
@@ -1728,11 +1707,7 @@ describe('Raise repair form', () => {
 
         cy.visit('/properties/00012345')
 
-        cy.wait([
-          '@propertyRequest',
-          // '@contactDetailsRequest',
-          '@workOrdersRequest',
-        ])
+        cy.wait(['@propertyRequest', '@workOrdersRequest'])
 
         cy.get('.lbh-heading-h2')
           .contains('Raise a work order on this dwelling')
@@ -1740,7 +1715,7 @@ describe('Raise repair form', () => {
 
         cy.wait([
           '@propertyRequest',
-          // '@contactDetailsRequest',
+
           '@sorPrioritiesRequest',
           '@tradesRequest',
           '@propertyInLegalDisrepair',
@@ -1769,11 +1744,7 @@ describe('Raise repair form', () => {
 
       cy.visit('/properties/00012345')
 
-      cy.wait([
-        '@propertyRequest',
-        // '@contactDetailsRequest',
-        '@workOrdersRequest',
-      ])
+      cy.wait(['@propertyRequest', '@workOrdersRequest'])
 
       cy.get('.lbh-heading-h2')
         .contains('Raise a work order on this dwelling')
@@ -1781,7 +1752,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        // '@contactDetailsRequest',
+
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepairError',

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -20,6 +20,14 @@ describe('Raise repair form', () => {
     cy.intercept(
       {
         method: 'GET',
+        path: '/api/contact-details/4552c539-2e00-8533-078d-9cc59d9115da',
+      },
+      { fixture: 'contactDetails/contactDetails.json' }
+    ).as('contactDetailsRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
         path: '/api/contractors?propertyReference=00012345&tradeCode=PL',
       },
       { fixture: 'contractors/contractors.json' }
@@ -135,7 +143,12 @@ describe('Raise repair form', () => {
 
     cy.visit('/properties/00012345/raise-repair/new')
 
-    cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+    cy.wait([
+      '@propertyRequest',
+      '@contactDetailsRequest',
+      '@sorPrioritiesRequest',
+      '@tradesRequest',
+    ])
 
     cy.get('[type="submit"]')
       .contains('Create work order')
@@ -194,6 +207,7 @@ describe('Raise repair form', () => {
     cy.visit('/properties/00012345/raise-repair/new')
     cy.wait([
       '@propertyRequest',
+      '@contactDetailsRequest',
       '@sorPrioritiesRequest',
       '@tradesRequest',
       '@personAlerts',
@@ -238,6 +252,14 @@ describe('Raise repair form', () => {
       ).as('propertyRequest')
 
       cy.intercept(
+        {
+          method: 'GET',
+          path: '/api/contact-details/4552c539-2e00-8533-078d-9cc59d9115da',
+        },
+        { fixture: 'contactDetails/contactDetails.json' }
+      ).as('contactDetailsRequest')
+
+      cy.intercept(
         { method: 'GET', path: '/api/schedule-of-rates/priorities' },
         { fixture: 'scheduleOfRates/priorities.json' }
       ).as('sorPrioritiesRequest')
@@ -260,7 +282,12 @@ describe('Raise repair form', () => {
 
     it('Submits work order task details to raise a work order', () => {
       cy.visit('/properties/00012345/raise-repair/new')
-      cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+      cy.wait([
+        '@propertyRequest',
+        '@contactDetailsRequest',
+        '@sorPrioritiesRequest',
+        '@tradesRequest',
+      ])
 
       cy.get('.lbh-heading-h2').contains('Work order task details')
 
@@ -871,6 +898,7 @@ describe('Raise repair form', () => {
 
               cy.wait([
                 '@propertyRequest',
+                '@contactDetailsRequest',
                 '@sorPrioritiesRequest',
                 '@tradesRequest',
               ])
@@ -1115,7 +1143,11 @@ describe('Raise repair form', () => {
         it('searches SOR codes after loading them all into a list', () => {
           cy.visit('/properties/00012345')
 
-          cy.wait(['@propertyRequest', '@workOrdersRequest'])
+          cy.wait([
+            '@propertyRequest',
+            '@contactDetailsRequest',
+            '@workOrdersRequest',
+          ])
 
           cy.get('.lbh-heading-h2')
             .contains('Raise a work order on this dwelling')
@@ -1123,6 +1155,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
+            '@contactDetailsRequest',
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1206,7 +1239,11 @@ describe('Raise repair form', () => {
         it('does not prevent loading of the form', () => {
           cy.visit('/properties/00012345')
 
-          cy.wait(['@propertyRequest', '@workOrdersRequest'])
+          cy.wait([
+            '@propertyRequest',
+            '@contactDetailsRequest',
+            '@workOrdersRequest',
+          ])
 
           cy.get('.lbh-heading-h2')
             .contains('Raise a work order on this dwelling')
@@ -1214,6 +1251,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
+            '@contactDetailsRequest',
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1245,13 +1283,22 @@ describe('Raise repair form', () => {
     it('Submits an immediate priority work order', () => {
       cy.visit('/properties/00012345')
 
-      cy.wait(['@propertyRequest', '@workOrdersRequest'])
+      cy.wait([
+        '@propertyRequest',
+        '@contactDetailsRequest',
+        '@workOrdersRequest',
+      ])
 
       cy.get('.lbh-heading-h2')
         .contains('Raise a work order on this dwelling')
         .click()
 
-      cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+      cy.wait([
+        '@propertyRequest',
+        '@contactDetailsRequest',
+        '@sorPrioritiesRequest',
+        '@tradesRequest',
+      ])
 
       cy.get('#repair-request-form').within(() => {
         cy.get('#trade').type('Plumbing - PL')
@@ -1311,7 +1358,12 @@ describe('Raise repair form', () => {
 
       cy.visit('/properties/00012345/raise-repair/new')
 
-      cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+      cy.wait([
+        '@propertyRequest',
+        '@contactDetailsRequest',
+        '@sorPrioritiesRequest',
+        '@tradesRequest',
+      ])
 
       cy.get('#trade').type('Plumbing - PL')
       cy.wait('@contractorsRequest')
@@ -1461,7 +1513,12 @@ describe('Raise repair form', () => {
 
       it('Gets full list of budget codes', () => {
         cy.visit('/properties/00012345/raise-repair/new')
-        cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+        cy.wait([
+          '@propertyRequest',
+          '@contactDetailsRequest',
+          '@sorPrioritiesRequest',
+          '@tradesRequest',
+        ])
 
         cy.get('.lbh-heading-h2').contains('Work order task details')
         cy.get('#repair-request-form').within(() => {
@@ -1580,7 +1637,12 @@ describe('Raise repair form', () => {
     it('does not allow budget code selection', () => {
       cy.visit('/properties/00012345/raise-repair/new')
 
-      cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+      cy.wait([
+        '@propertyRequest',
+        '@contactDetailsRequest',
+        '@sorPrioritiesRequest',
+        '@tradesRequest',
+      ])
 
       cy.get('#repair-request-form').within(() => {
         cy.get('#trade').type('Plumbing - PL')
@@ -1624,7 +1686,11 @@ describe('Raise repair form', () => {
 
       cy.visit('/properties/00012345')
 
-      cy.wait(['@propertyRequest', '@workOrdersRequest'])
+      cy.wait([
+        '@propertyRequest',
+        '@contactDetailsRequest',
+        '@workOrdersRequest',
+      ])
 
       cy.get('.lbh-heading-h2')
         .contains('Raise a work order on this dwelling')
@@ -1632,6 +1698,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
+        '@contactDetailsRequest',
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepair',
@@ -1661,7 +1728,11 @@ describe('Raise repair form', () => {
 
         cy.visit('/properties/00012345')
 
-        cy.wait(['@propertyRequest', '@workOrdersRequest'])
+        cy.wait([
+          '@propertyRequest',
+          '@contactDetailsRequest',
+          '@workOrdersRequest',
+        ])
 
         cy.get('.lbh-heading-h2')
           .contains('Raise a work order on this dwelling')
@@ -1669,6 +1740,7 @@ describe('Raise repair form', () => {
 
         cy.wait([
           '@propertyRequest',
+          '@contactDetailsRequest',
           '@sorPrioritiesRequest',
           '@tradesRequest',
           '@propertyInLegalDisrepair',
@@ -1697,7 +1769,11 @@ describe('Raise repair form', () => {
 
       cy.visit('/properties/00012345')
 
-      cy.wait(['@propertyRequest', '@workOrdersRequest'])
+      cy.wait([
+        '@propertyRequest',
+        '@contactDetailsRequest',
+        '@workOrdersRequest',
+      ])
 
       cy.get('.lbh-heading-h2')
         .contains('Raise a work order on this dwelling')
@@ -1705,6 +1781,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
+        '@contactDetailsRequest',
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepairError',

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -1145,7 +1145,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-            '@contactDetailsRequest',
+            // '@contactDetailsRequest',
             '@workOrdersRequest',
           ])
 
@@ -1155,7 +1155,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-            '@contactDetailsRequest',
+            // '@contactDetailsRequest',
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1241,7 +1241,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-            '@contactDetailsRequest',
+            // '@contactDetailsRequest',
             '@workOrdersRequest',
           ])
 
@@ -1251,7 +1251,7 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-            '@contactDetailsRequest',
+            // '@contactDetailsRequest',
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1285,7 +1285,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        '@contactDetailsRequest',
+        // '@contactDetailsRequest',
         '@workOrdersRequest',
       ])
 
@@ -1295,7 +1295,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        '@contactDetailsRequest',
+        // '@contactDetailsRequest',
         '@sorPrioritiesRequest',
         '@tradesRequest',
       ])
@@ -1688,7 +1688,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        '@contactDetailsRequest',
+        // '@contactDetailsRequest',
         '@workOrdersRequest',
       ])
 
@@ -1698,7 +1698,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        '@contactDetailsRequest',
+        // '@contactDetailsRequest',
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepair',
@@ -1730,7 +1730,7 @@ describe('Raise repair form', () => {
 
         cy.wait([
           '@propertyRequest',
-          '@contactDetailsRequest',
+          // '@contactDetailsRequest',
           '@workOrdersRequest',
         ])
 
@@ -1740,7 +1740,7 @@ describe('Raise repair form', () => {
 
         cy.wait([
           '@propertyRequest',
-          '@contactDetailsRequest',
+          // '@contactDetailsRequest',
           '@sorPrioritiesRequest',
           '@tradesRequest',
           '@propertyInLegalDisrepair',
@@ -1771,7 +1771,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        '@contactDetailsRequest',
+        // '@contactDetailsRequest',
         '@workOrdersRequest',
       ])
 
@@ -1781,7 +1781,7 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-        '@contactDetailsRequest',
+        // '@contactDetailsRequest',
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepairError',

--- a/cypress/integration/work-order/create/create.spec.js
+++ b/cypress/integration/work-order/create/create.spec.js
@@ -1151,7 +1151,6 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1243,7 +1242,6 @@ describe('Raise repair form', () => {
 
           cy.wait([
             '@propertyRequest',
-
             '@sorPrioritiesRequest',
             '@tradesRequest',
           ])
@@ -1677,7 +1675,6 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepair',
@@ -1715,7 +1712,6 @@ describe('Raise repair form', () => {
 
         cy.wait([
           '@propertyRequest',
-
           '@sorPrioritiesRequest',
           '@tradesRequest',
           '@propertyInLegalDisrepair',
@@ -1752,7 +1748,6 @@ describe('Raise repair form', () => {
 
       cy.wait([
         '@propertyRequest',
-
         '@sorPrioritiesRequest',
         '@tradesRequest',
         '@propertyInLegalDisrepairError',

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -159,8 +159,6 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
         })
       }
 
-      
-
       setTenure(propertyResponse.tenure)
       setProperty(propertyResponse.property)
       setPriorities(priorities)

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -133,7 +133,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
     setError(null)
 
     try {
-      const data = await frontEndApiRequest({
+      const propertyResponse = await frontEndApiRequest({
         method: 'get',
         path: `/api/properties/${propertyReference}`,
       })
@@ -152,17 +152,17 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
 
       let contactDetails = []
 
-      if (data?.tenure?.id != null) {
+      if (propertyResponse?.tenure?.id != null) {
         contactDetails = await frontEndApiRequest({
           method: 'get',
-          path: `/api/contact-details/${data?.tenure?.id}`,
+          path: `/api/contact-details/${propertyResponse?.tenure?.id}`,
         })
       }
 
       
 
-      setTenure(data.tenure)
-      setProperty(data.property)
+      setTenure(propertyResponse.tenure)
+      setProperty(propertyResponse.property)
       setPriorities(priorities)
       setTrades(trades)
       setContacts(contactDetails)

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -171,7 +171,7 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
       setProperty(null)
       setPriorities(null)
       setTrades(null)
-      console.error('An error has occured:', e.response)
+      console.error('An error has occurred:', e.response)
       setError(
         `Oops an error occurred with error status: ${e.response?.status} with message: ${e.response?.data?.message}`
       )

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -150,11 +150,22 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
         path: '/api/hub-user',
       })
 
+      let contactDetails = []
+
+      if (data?.tenure?.id != null) {
+        contactDetails = await frontEndApiRequest({
+          method: 'get',
+          path: `/api/contact-details/${data?.tenure?.id}`,
+        })
+      }
+
+      
+
       setTenure(data.tenure)
       setProperty(data.property)
       setPriorities(priorities)
       setTrades(trades)
-      setContacts(data.contactDetails)
+      setContacts(contactDetails)
       setCurrentUser(user)
     } catch (e) {
       setProperty(null)

--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderFormView.js
@@ -133,22 +133,24 @@ const RaiseWorkOrderFormView = ({ propertyReference }) => {
     setError(null)
 
     try {
-      const propertyResponse = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/properties/${propertyReference}`,
-      })
-      const priorities = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/schedule-of-rates/priorities`,
-      })
-      const trades = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/schedule-of-rates/trades?propRef=${propertyReference}`,
-      })
-      const user = await frontEndApiRequest({
-        method: 'get',
-        path: '/api/hub-user',
-      })
+      const [propertyResponse, priorities, trades, user] = await Promise.all([
+        frontEndApiRequest({
+          method: 'get',
+          path: `/api/properties/${propertyReference}`,
+        }),
+        frontEndApiRequest({
+          method: 'get',
+          path: `/api/schedule-of-rates/priorities`,
+        }),
+        frontEndApiRequest({
+          method: 'get',
+          path: `/api/schedule-of-rates/trades?propRef=${propertyReference}`,
+        }),
+        frontEndApiRequest({
+          method: 'get',
+          path: '/api/hub-user',
+        }),
+      ])
 
       let contactDetails = []
 

--- a/src/pages/api/contact-details/[id]/index.js
+++ b/src/pages/api/contact-details/[id]/index.js
@@ -1,0 +1,29 @@
+import * as HttpStatus from 'http-status-codes'
+import {
+  serviceAPIRequest,
+  authoriseServiceAPIRequest,
+} from '@/utils/serviceApiClient'
+
+export default authoriseServiceAPIRequest(async (req, res, user) => {
+  req.query = { path: ['contact-details', req.query.id] }
+
+  if (
+    !user.hasAgentPermissions &&
+    !user.hasContractManagerPermissions &&
+    !user.hasAuthorisationManagerPermissions
+  ) {
+    // redact contact information for contractor responses
+    res.status(HttpStatus.OK).json(['REMOVED'])
+    return
+  }
+
+  try {
+    const data = await serviceAPIRequest(req, res)
+    res.status(HttpStatus.OK).json(data)
+  } catch (error) {
+    const errorToThrow = new Error(error)
+
+    errorToThrow.response = error.response
+    throw errorToThrow
+  }
+})

--- a/src/pages/api/contact-details/[id]/index.test.js
+++ b/src/pages/api/contact-details/[id]/index.test.js
@@ -17,21 +17,28 @@ const {
   CONTRACTORS_GOOGLE_GROUPNAME,
 } = process.env
 
+const TENURE_ID = '250af5a91f04316aac4a7a737e98874'
+
+const CONTACT_DETAILS = [
+  {
+    fullName: 'FirstName LastName',
+    phoneNumbers: ['0123456789', '0123456789'],
+  },
+  {
+    fullName: 'FirstName LastName',
+    phoneNumbers: ['0123456789', '0123456789'],
+  },
+]
+
 describe('GET /api/contact-details/[id] contact information redaction', () => {
   beforeEach(() => {
     axios.create = jest.fn(() => axios)
 
     axios.mockImplementationOnce(() =>
-      Promise.resolve([
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-      ])
+      Promise.resolve({
+        status: 200,
+        data: CONTACT_DETAILS,
+      })
     )
   })
 
@@ -57,7 +64,7 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
         method: 'get',
         headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
         query: {
-          id: '250af5a91f04316aac4a7a737e98874',
+          id: TENURE_ID,
         },
         params: {},
       })
@@ -70,24 +77,21 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
       expect(axios).toHaveBeenCalledWith({
         method: 'get',
         headers,
-        url: `${REPAIRS_SERVICE_API_URL}/contact-details/250af5a91f04316aac4a7a737e98874`,
+        url: `${REPAIRS_SERVICE_API_URL}/contact-details/${TENURE_ID}`,
         params: {},
         paramsSerializer,
         data: {},
       })
 
+      // var x = res._getData();
+      // expect(x).toEqual({name:"callum"})
+      //console.log(res._getData())
+
+      // const value = res.
+
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData).toEqual([
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-      ])
+      expect(parsedData).toEqual(CONTACT_DETAILS)
     })
   })
 
@@ -113,7 +117,7 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
         method: 'get',
         headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
         query: {
-          id: '250af5a91f04316aac4a7a737e98874',
+          id: TENURE_ID,
         },
         params: {},
       })
@@ -126,7 +130,7 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
       expect(axios).toHaveBeenCalledWith({
         method: 'get',
         headers,
-        url: `${REPAIRS_SERVICE_API_URL}/contact-details/250af5a91f04316aac4a7a737e98874`,
+        url: `${REPAIRS_SERVICE_API_URL}/contact-details/${TENURE_ID}`,
         params: {},
         paramsSerializer,
         data: {},
@@ -134,16 +138,7 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
 
       const parsedData = JSON.parse(res._getData())
 
-      expect(parsedData).toEqual([
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-        {
-          fullName: 'FirstName LastName',
-          phoneNumbers: ['0123456789', '0123456789'],
-        },
-      ])
+      expect(parsedData).toEqual(CONTACT_DETAILS)
     })
   })
 
@@ -157,35 +152,36 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
       HACKNEY_JWT_SECRET
     )
 
-    const headers = {
-      'Content-Type': 'application/json',
-      'x-api-key': REPAIRS_SERVICE_API_KEY,
-      'x-hackney-user': signedCookie,
-      Authorization: signedCookie,
-    }
+    // const headers = {
+    //   'Content-Type': 'application/json',
+    //   'x-api-key': REPAIRS_SERVICE_API_KEY,
+    //   'x-hackney-user': signedCookie,
+    //   Authorization: signedCookie,
+    // }
 
     test('response contact information is redacted', async () => {
       const req = createRequest({
         method: 'get',
         headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
         query: {
-          id: '250af5a91f04316aac4a7a737e98874',
+          id: TENURE_ID,
         },
+        params: {},
       })
 
       const res = createResponse()
 
       await contactDetailsEndpoint(req, res)
 
-      expect(axios).toHaveBeenCalledTimes(1)
-      expect(axios).toHaveBeenCalledWith({
-        method: 'get',
-        headers,
-        url: `${REPAIRS_SERVICE_API_URL}/contact-details/250af5a91f04316aac4a7a737e98874`,
-        params: {},
-        paramsSerializer,
-        data: {},
-      })
+      expect(axios).toHaveBeenCalledTimes(0)
+      // expect(axios).toHaveBeenCalledWith({
+      //   method: 'get',
+      //   headers,
+      //   url: `${REPAIRS_SERVICE_API_URL}/contact-details/${TENURE_ID}`,
+      //   params: {},
+      //   paramsSerializer,
+      //   data: {},
+      // })
 
       const parsedData = JSON.parse(res._getData())
 

--- a/src/pages/api/contact-details/[id]/index.test.js
+++ b/src/pages/api/contact-details/[id]/index.test.js
@@ -56,8 +56,8 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
       const req = createRequest({
         method: 'get',
         headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
-        _parsedUrl: {
-          pathname: '/contact-details/250af5a91f04316aac4a7a737e98874',
+        query: {
+          id: '250af5a91f04316aac4a7a737e98874',
         },
         params: {},
       })
@@ -112,8 +112,8 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
       const req = createRequest({
         method: 'get',
         headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
-        _parsedUrl: {
-          pathname: '/contact-details/250af5a91f04316aac4a7a737e98874',
+        query: {
+          id: '250af5a91f04316aac4a7a737e98874',
         },
         params: {},
       })
@@ -168,8 +168,8 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
       const req = createRequest({
         method: 'get',
         headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
-        _parsedUrl: {
-          pathname: '/contact-details/250af5a91f04316aac4a7a737e98874',
+        query: {
+          id: '250af5a91f04316aac4a7a737e98874',
         },
       })
 

--- a/src/pages/api/contact-details/[id]/index.test.js
+++ b/src/pages/api/contact-details/[id]/index.test.js
@@ -83,12 +83,6 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
         data: {},
       })
 
-      // var x = res._getData();
-      // expect(x).toEqual({name:"callum"})
-      //console.log(res._getData())
-
-      // const value = res.
-
       const parsedData = JSON.parse(res._getData())
 
       expect(parsedData).toEqual(CONTACT_DETAILS)
@@ -152,13 +146,6 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
       HACKNEY_JWT_SECRET
     )
 
-    // const headers = {
-    //   'Content-Type': 'application/json',
-    //   'x-api-key': REPAIRS_SERVICE_API_KEY,
-    //   'x-hackney-user': signedCookie,
-    //   Authorization: signedCookie,
-    // }
-
     test('response contact information is redacted', async () => {
       const req = createRequest({
         method: 'get',
@@ -173,15 +160,8 @@ describe('GET /api/contact-details/[id] contact information redaction', () => {
 
       await contactDetailsEndpoint(req, res)
 
+      // ["REMOVED"] is returned before API call if user doesn't have valid permissions
       expect(axios).toHaveBeenCalledTimes(0)
-      // expect(axios).toHaveBeenCalledWith({
-      //   method: 'get',
-      //   headers,
-      //   url: `${REPAIRS_SERVICE_API_URL}/contact-details/${TENURE_ID}`,
-      //   params: {},
-      //   paramsSerializer,
-      //   data: {},
-      // })
 
       const parsedData = JSON.parse(res._getData())
 

--- a/src/pages/api/contact-details/[id]/index.test.js
+++ b/src/pages/api/contact-details/[id]/index.test.js
@@ -1,0 +1,195 @@
+import axios from 'axios'
+import jsonwebtoken from 'jsonwebtoken'
+import { createRequest, createResponse } from 'node-mocks-http'
+import { paramsSerializer } from '@/utils/urls'
+
+import contactDetailsEndpoint from './index.js'
+
+jest.mock('axios')
+
+const {
+  REPAIRS_SERVICE_API_URL,
+  HACKNEY_JWT_SECRET,
+  GSSO_TOKEN_NAME,
+  REPAIRS_SERVICE_API_KEY,
+  AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME,
+  AGENTS_GOOGLE_GROUPNAME,
+  CONTRACTORS_GOOGLE_GROUPNAME,
+} = process.env
+
+describe('GET /api/contact-details/[id] contact information redaction', () => {
+  beforeEach(() => {
+    axios.create = jest.fn(() => axios)
+
+    axios.mockImplementationOnce(() =>
+      Promise.resolve([
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+      ])
+    )
+  })
+
+  describe('when the cookie is for an agent', () => {
+    const signedCookie = jsonwebtoken.sign(
+      {
+        name: 'name',
+        email: 'name@example.com',
+        groups: [AGENTS_GOOGLE_GROUPNAME],
+      },
+      HACKNEY_JWT_SECRET
+    )
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+      Authorization: signedCookie,
+    }
+
+    test('the response can include full contact information', async () => {
+      const req = createRequest({
+        method: 'get',
+        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
+        _parsedUrl: {
+          pathname: '/contact-details/250af5a91f04316aac4a7a737e98874',
+        },
+        params: {},
+      })
+
+      const res = createResponse()
+
+      await contactDetailsEndpoint(req, res)
+
+      expect(axios).toHaveBeenCalledTimes(1)
+      expect(axios).toHaveBeenCalledWith({
+        method: 'get',
+        headers,
+        url: `${REPAIRS_SERVICE_API_URL}/contact-details/250af5a91f04316aac4a7a737e98874`,
+        params: {},
+        paramsSerializer,
+        data: {},
+      })
+
+      const parsedData = JSON.parse(res._getData())
+
+      expect(parsedData).toEqual([
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+      ])
+    })
+  })
+
+  describe('when the cookie is for an authorisation manager', () => {
+    const signedCookie = jsonwebtoken.sign(
+      {
+        name: 'name',
+        email: 'name@example.com',
+        groups: [AUTHORISATION_MANAGERS_GOOGLE_GROUPNAME],
+      },
+      HACKNEY_JWT_SECRET
+    )
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+      Authorization: signedCookie,
+    }
+
+    test('the response can include full contact information', async () => {
+      const req = createRequest({
+        method: 'get',
+        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
+        _parsedUrl: {
+          pathname: '/contact-details/250af5a91f04316aac4a7a737e98874',
+        },
+        params: {},
+      })
+
+      const res = createResponse()
+
+      await contactDetailsEndpoint(req, res)
+
+      expect(axios).toHaveBeenCalledTimes(1)
+      expect(axios).toHaveBeenCalledWith({
+        method: 'get',
+        headers,
+        url: `${REPAIRS_SERVICE_API_URL}/contact-details/250af5a91f04316aac4a7a737e98874`,
+        params: {},
+        paramsSerializer,
+        data: {},
+      })
+
+      const parsedData = JSON.parse(res._getData())
+
+      expect(parsedData).toEqual([
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+        {
+          fullName: 'FirstName LastName',
+          phoneNumbers: ['0123456789', '0123456789'],
+        },
+      ])
+    })
+  })
+
+  describe('when the cookie is for a contractor', () => {
+    const signedCookie = jsonwebtoken.sign(
+      {
+        name: 'name',
+        email: 'name@example.com',
+        groups: [CONTRACTORS_GOOGLE_GROUPNAME],
+      },
+      HACKNEY_JWT_SECRET
+    )
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-api-key': REPAIRS_SERVICE_API_KEY,
+      'x-hackney-user': signedCookie,
+      Authorization: signedCookie,
+    }
+
+    test('response contact information is redacted', async () => {
+      const req = createRequest({
+        method: 'get',
+        headers: { Cookie: `${GSSO_TOKEN_NAME}=${signedCookie};` },
+        _parsedUrl: {
+          pathname: '/contact-details/250af5a91f04316aac4a7a737e98874',
+        },
+      })
+
+      const res = createResponse()
+
+      await contactDetailsEndpoint(req, res)
+
+      expect(axios).toHaveBeenCalledTimes(1)
+      expect(axios).toHaveBeenCalledWith({
+        method: 'get',
+        headers,
+        url: `${REPAIRS_SERVICE_API_URL}/contact-details/250af5a91f04316aac4a7a737e98874`,
+        params: {},
+        paramsSerializer,
+        data: {},
+      })
+
+      const parsedData = JSON.parse(res._getData())
+
+      expect(parsedData).toEqual(['REMOVED'])
+    })
+  })
+})


### PR DESCRIPTION
## Summary of changes

Fetch contact details directly from the contact details endpoint when raising a repair.

- Fetch contact details if `tenure.id` is returned in the property response
- Copy existing nextjs authorization to redact contact details if the user is unauthorized + tests

## Additional changes

- Added the four requests into a `Promise.all()` block so that the requests can run simultaneously (instead of in serial)/

## Next steps

Once these changes are deployed, contact details can be removed from the properties endpoint.