### PR TITLE
Adjust by start datetime on FE

### DIFF
--- a/cypress/fixtures/operatives/workOrder.json
+++ b/cypress/fixtures/operatives/workOrder.json
@@ -16,6 +16,8 @@
     "description": "AM Slot",
     "start": "08:00",
     "end": "13:00",
+    "assignedStart": "09:00",
+    "assignedEnd": "10:00",
     "reason": null,
     "note": "School run"
   },

--- a/cypress/fixtures/operatives/workOrders.json
+++ b/cypress/fixtures/operatives/workOrders.json
@@ -19,7 +19,9 @@
       "start": "12:00",
       "end": "18:00",
       "reason": null,
-      "note": null
+      "note": null,
+      "assignedStart": "09:00",
+      "assignedEnd": "10:00"
     },
     "canAssignOperative": true,
     "totalSMVs": 76,
@@ -52,7 +54,9 @@
       "start": "16:00",
       "end": "18:00",
       "reason": null,
-      "note": null
+      "note": null,
+      "assignedStart": "10:00",
+      "assignedEnd": "11:00"
     },
     "canAssignOperative": true,
     "totalSMVs": 76,
@@ -86,7 +90,9 @@
       "start": "08:00",
       "end": "13:00",
       "reason": null,
-      "note": null
+      "note": null,
+      "assignedStart": "11:00",
+      "assignedEnd": "12:00"
     },
     "canAssignOperative": true,
     "totalSMVs": 76,
@@ -119,7 +125,9 @@
       "start": "17:00",
       "end": "18:00",
       "reason": null,
-      "note": null
+      "note": null,
+      "assignedStart": "12:00",
+      "assignedEnd": "13:00"
     },
     "canAssignOperative": true,
     "totalSMVs": 76,

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
@@ -95,7 +95,12 @@ const MobileWorkingWorkOrdersView = () => {
               <ol className="lbh-list mobile-working-work-order-list">
                 {renderWorkOrderListItems(
                   currentUser.isOneJobAtATime
-                    ? inProgressWorkOrders.slice(0, 1)
+                    ? inProgressWorkOrders.sort((a, b => {
+                      const dateA = new Date(a.assignedStartTime);
+                      const dateB = new Date(b.assignedStartTime);
+                      // Get first job by assigned start time
+                      return dateA - dateB;
+                    }).slice(0, 1))
                     : inProgressWorkOrders
                 )}
                 {renderWorkOrderListItems(visitedWorkOrders)}

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
@@ -76,6 +76,13 @@ const MobileWorkingWorkOrdersView = () => {
     ))
   }
 
+  const compareStartTime = (a, b) => {
+      const dateA = new Date(a.assignedStartTime);
+      const dateB = new Date(b.assignedStartTime);
+      // Get first job by assigned start time
+      return dateA - dateB;
+  }
+
   return (
     <>
       <Meta title="Manage work orders" />
@@ -96,12 +103,7 @@ const MobileWorkingWorkOrdersView = () => {
                 {renderWorkOrderListItems(
                   currentUser.isOneJobAtATime
                     ? inProgressWorkOrders
-                        .sort((a, b) => {
-                          const dateA = new Date(a.assignedStartTime)
-                          const dateB = new Date(b.assignedStartTime)
-                          // Get first job by assigned start time
-                          return dateA - dateB
-                        })
+                        .sort(compareStartTime)
                         .slice(0, 1)
                     : inProgressWorkOrders
                 )}

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
@@ -95,12 +95,14 @@ const MobileWorkingWorkOrdersView = () => {
               <ol className="lbh-list mobile-working-work-order-list">
                 {renderWorkOrderListItems(
                   currentUser.isOneJobAtATime
-                    ? inProgressWorkOrders.sort((a, b => {
-                      const dateA = new Date(a.assignedStartTime);
-                      const dateB = new Date(b.assignedStartTime);
-                      // Get first job by assigned start time
-                      return dateA - dateB;
-                    }).slice(0, 1))
+                    ? inProgressWorkOrders
+                        .sort((a, b) => {
+                          const dateA = new Date(a.assignedStartTime)
+                          const dateB = new Date(b.assignedStartTime)
+                          // Get first job by assigned start time
+                          return dateA - dateB
+                        })
+                        .slice(0, 1)
                     : inProgressWorkOrders
                 )}
                 {renderWorkOrderListItems(visitedWorkOrders)}

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView.js
@@ -77,10 +77,10 @@ const MobileWorkingWorkOrdersView = () => {
   }
 
   const compareStartTime = (a, b) => {
-      const dateA = new Date(a.assignedStartTime);
-      const dateB = new Date(b.assignedStartTime);
-      // Get first job by assigned start time
-      return dateA - dateB;
+    const dateA = new Date(a.assignedStartTime)
+    const dateB = new Date(b.assignedStartTime)
+    // Get first job by assigned start time
+    return dateA - dateB
   }
 
   return (
@@ -102,9 +102,7 @@ const MobileWorkingWorkOrdersView = () => {
               <ol className="lbh-list mobile-working-work-order-list">
                 {renderWorkOrderListItems(
                   currentUser.isOneJobAtATime
-                    ? inProgressWorkOrders
-                        .sort(compareStartTime)
-                        .slice(0, 1)
+                    ? inProgressWorkOrders.sort(compareStartTime).slice(0, 1)
                     : inProgressWorkOrders
                 )}
                 {renderWorkOrderListItems(visitedWorkOrders)}


### PR DESCRIPTION
- For one job at a time, jobs should be ordered by assigned start and end time
- Recently surfaced from backend under [https://github.com/LBHackney-IT/repairs-api-dotnet/pull/1054](https://github.com/LBHackney-IT/repairs-api-dotnet/pull/1054
)
Context: [https://hackney.atlassian.net/browse/MR-740](https://hackney.atlassian.net/browse/MR-740)
- 