### PR TITLE
re-enable raise work order form tests

### DIFF
--- a/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
+++ b/src/components/Property/RaiseWorkOrder/RaiseWorkOrderForm.test.js
@@ -44,7 +44,6 @@ describe('RaiseWorkOrderForm component', () => {
       canRaiseRepair: true,
     },
     tenure: {
-      id: 'tenureId1',
       typeCode: 'SEC',
       typeDescription: 'Secure',
       tenancyAgreementReference: 'tenancyAgreementRef1',
@@ -87,7 +86,7 @@ describe('RaiseWorkOrderForm component', () => {
     setBudgetCodeId: jest.fn(),
   }
 
-  it.skip('should render properly', async () => {
+  it('should render properly', async () => {
     const { asFragment } = render(
       <UserContext.Provider value={{ user: agent }}>
         <RaiseWorkOrderForm
@@ -119,14 +118,13 @@ describe('RaiseWorkOrderForm component', () => {
     await act(async () => {
       await waitForElementToBeRemoved([
         screen.getByTestId('spinner-locationAlerts'),
-        screen.getByTestId('spinner-personAlerts'),
       ])
     })
 
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it.skip('should render without possibility to choose budget code for a user without the budget code officer permission', async () => {
+  it('should render without possibility to choose budget code for a user without the budget code officer permission', async () => {
     const { asFragment } = render(
       <UserContext.Provider value={{ user: authorisationManager }}>
         <RaiseWorkOrderForm
@@ -158,14 +156,13 @@ describe('RaiseWorkOrderForm component', () => {
     await act(async () => {
       await waitForElementToBeRemoved([
         screen.getByTestId('spinner-locationAlerts'),
-        screen.getByTestId('spinner-personAlerts'),
       ])
     })
 
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it.skip('should limit the priorities list to voids when H02 contract is selected', async () => {
+  it('should limit the priorities list to voids when H02 contract is selected', async () => {
     const prioritiesWithVoids = [
       {
         priorityCode: IMMEDIATE_PRIORITY_CODE,
@@ -228,7 +225,6 @@ describe('RaiseWorkOrderForm component', () => {
     await act(async () => {
       await waitForElementToBeRemoved([
         screen.getByTestId('spinner-locationAlerts'),
-        screen.getByTestId('spinner-personAlerts'),
       ])
     })
 


### PR DESCRIPTION
Fixed and re-enable the tests that were temporarily skipped for the hotfix earlier

These tests were originally without a tenure.id field and don't expect that in the fixture

See here for the before/after: https://github.com/LBHackney-IT/repairs-hub-frontend/pull/800/files#diff-c66281f35b6b72e490be4b833eadd36123c3bf32d0580eb19f1c38454b405398