### PR TITLE
Add backoffice operative mobile view

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=test next dev -p 5000",
-    "dev-test": "next dev -p 5001",
+    "dev": "next dev -p 5000",
     "debug": "NODE_OPTIONS='--inspect' next dev -p 5000",
     "build": "next build",
     "deploy": "sls deploy",

--- a/src/components/BackOffice/BackOfficeDashboard/index.js
+++ b/src/components/BackOffice/BackOfficeDashboard/index.js
@@ -11,6 +11,10 @@ const BackOfficeDashboard = () => {
       description: 'Bulk-close workOrders',
       link: '/backoffice/close-workorders',
     },
+    {
+      description: 'Operative mobile work order view',
+      link: '/backoffice/mobile-view',
+    },
   ]
   return (
     <>

--- a/src/components/BackOffice/OperativeMobileView/SelectedOperative.js
+++ b/src/components/BackOffice/OperativeMobileView/SelectedOperative.js
@@ -1,0 +1,34 @@
+const SelectedOperative = (props) => {
+  const { operative } = props
+
+  return (
+    <div
+      style={{
+        background: '#f1f5f9',
+        color: '#475569',
+        padding: 15,
+      }}
+    >
+      <p>
+        Name:{' '}
+        <span style={{ color: '#090909', fontWeight: 'bold' }}>
+          {operative.name}
+        </span>
+      </p>
+      <p>
+        Payroll number:{' '}
+        <span style={{ color: '#090909', fontWeight: 'bold' }}>
+          {operative.operativePayrollNumber}
+        </span>
+      </p>
+      <p>
+        OJAAT Enabled:{' '}
+        <span style={{ color: '#090909', fontWeight: 'bold' }}>
+          {operative.isOneJobAtATime ? 'TRUE' : 'FALSE'}
+        </span>
+      </p>
+    </div>
+  )
+}
+
+export default SelectedOperative

--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -1,0 +1,122 @@
+import { useState, useEffect } from 'react'
+import { frontEndApiRequest } from '../../../utils/frontEndApiClient/requests'
+import WarningInfoBox from '../../Template/WarningInfoBox'
+import SelectedOperative from './SelectedOperative'
+import Layout from '../Layout'
+import MobileWorkingWorkOrdersView from '../../WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView'
+
+const OperativeMobileView = () => {
+  const fetchOperatives = async () => {
+    return await frontEndApiRequest({
+      method: 'get',
+      path: '/api/operatives',
+    })
+  }
+
+  const mapOperativeToHubUser = (operative) => {
+    return {
+      sub: 'placeholder',
+      name: operative.name,
+      email: 'placeholder',
+      varyLimit: 'placeholder',
+      raiseLimit: 'placeholder',
+      contractors: [],
+      operativePayrollNumber: operative.payrollNumber,
+      isOneJobAtATime: operative.isOnejobatatime,
+    }
+  }
+
+  useEffect(() => {
+    fetchOperatives().then((res) => {
+      const sortedOperatives = res
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(mapOperativeToHubUser)
+
+      setOperatives(sortedOperatives)
+
+      setIsLoading(false)
+    })
+  }, [])
+
+  const [operatives, setOperatives] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [operativeFilter, setOperativeFilter] = useState('')
+
+  const [operativePayrollNumber, setOperativePayrollNumber] = useState(null)
+
+  const filteredOperativeList =
+    operativeFilter === ''
+      ? operatives
+      : operatives.filter((x) =>
+          x.name.toLowerCase().includes(operativeFilter.toLowerCase())
+        )
+
+  const selectedOperative = operatives.filter(
+    (x) => x.operativePayrollNumber == operativePayrollNumber
+  )[0]
+
+  return (
+    <Layout title="Operative Mobile View">
+      <>
+        <WarningInfoBox
+          header="Warning"
+          text="This page uses same existing MobileWorkingWorkOrdersView component. This means you can click and view the jobs. Playing around with jobs will effect real operatives."
+        />
+
+        {isLoading ? (
+          <div>Loading..</div>
+        ) : (
+          <div>
+            <div>
+              <div>
+                <label>Filter operatives </label>
+
+                <input
+                  type="text"
+                  value={operativeFilter}
+                  onInput={(e) => setOperativeFilter(e.target.value)}
+                />
+              </div>
+
+              <div style={{ marginBottom: '30px' }}>
+                <select
+                  value={operativePayrollNumber}
+                  onChange={(e) => setOperativePayrollNumber(e.target.value)}
+                >
+                  <option value="-1" defaultChecked>
+                    Select an operative
+                  </option>
+
+                  {filteredOperativeList.map((x) => (
+                    <option
+                      key={x.operativePayrollNumber}
+                      value={x.operativePayrollNumber}
+                    >
+                      {x.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <p>{filteredOperativeList.length} operatives</p>
+              </div>
+
+              {!!selectedOperative && (
+                <SelectedOperative operative={selectedOperative} />
+              )}
+            </div>
+
+            {!!selectedOperative && (
+              <div style={{ marginTop: '30px' }}>
+                <MobileWorkingWorkOrdersView currentUser={selectedOperative} />
+              </div>
+            )}
+          </div>
+        )}
+      </>
+    </Layout>
+  )
+}
+
+export default OperativeMobileView

--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -4,6 +4,7 @@ import WarningInfoBox from '../../Template/WarningInfoBox'
 import SelectedOperative from './SelectedOperative'
 import Layout from '../Layout'
 import MobileWorkingWorkOrdersView from '../../WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView'
+import { filterOperatives } from './utils'
 
 const OperativeMobileView = () => {
   const fetchOperatives = async () => {
@@ -41,15 +42,15 @@ const OperativeMobileView = () => {
   const [operatives, setOperatives] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [operativeFilter, setOperativeFilter] = useState('')
+  const [showOnlyOJAT, setShowOnlyOJAT] = useState(false)
 
   const [operativePayrollNumber, setOperativePayrollNumber] = useState(null)
 
-  const filteredOperativeList =
-    operativeFilter === ''
-      ? operatives
-      : operatives.filter((x) =>
-          x.name.toLowerCase().includes(operativeFilter.toLowerCase())
-        )
+  const filteredOperativeList = filterOperatives(
+    operatives,
+    operativeFilter,
+    showOnlyOJAT
+  )
 
   const selectedOperative = operatives.filter(
     (x) => x.operativePayrollNumber == operativePayrollNumber
@@ -75,6 +76,16 @@ const OperativeMobileView = () => {
                   type="text"
                   value={operativeFilter}
                   onInput={(e) => setOperativeFilter(e.target.value)}
+                />
+              </div>
+
+              <div>
+                <label>Show only OJAT operatives?</label>
+                <input
+                  type="checkbox"
+                  value={false}
+                  checked={showOnlyOJAT}
+                  onInput={() => setShowOnlyOJAT((x) => !x)}
                 />
               </div>
 

--- a/src/components/BackOffice/OperativeMobileView/utils.js
+++ b/src/components/BackOffice/OperativeMobileView/utils.js
@@ -1,0 +1,17 @@
+export const filterOperatives = (operatives, operativeFilter, showOnlyOJAT) => {
+  let filteredOperativeList = operatives
+
+  if (operativeFilter !== '') {
+    filteredOperativeList = filteredOperativeList.filter((x) =>
+      x.name.toLowerCase().includes(operativeFilter.toLowerCase())
+    )
+  }
+
+  if (showOnlyOJAT) {
+    filteredOperativeList = filteredOperativeList.filter(
+      (x) => x.isOneJobAtATime
+    )
+  }
+
+  return filteredOperativeList
+}

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -51,7 +51,7 @@ const MobileWorkingWorkOrdersView = ({ currentUser }) => {
 
   useEffect(() => {
     getOperativeWorkOrderView()
-  }, [])
+  }, [currentUser])
 
   const renderWorkOrderListItems = (workOrders) => {
     return (

--- a/src/pages/backoffice/index.js
+++ b/src/pages/backoffice/index.js
@@ -1,7 +1,7 @@
 import { DATA_ADMIN_ROLE } from '@/utils/user'
+import Meta from '../../components/Meta'
 import { getQueryProps } from '../../utils/helpers/serverSideProps'
 import BackOfficeDashboard from '../../components/BackOffice/BackOfficeDashboard'
-import Meta from '../../components/Meta'
 
 const BackOfficePage = () => {
   return (

--- a/src/pages/backoffice/index.js
+++ b/src/pages/backoffice/index.js
@@ -1,8 +1,7 @@
 import { DATA_ADMIN_ROLE } from '@/utils/user'
-
-import Meta from '../../components/Meta'
 import { getQueryProps } from '../../utils/helpers/serverSideProps'
 import BackOfficeDashboard from '../../components/BackOffice/BackOfficeDashboard'
+import Meta from '../../components/Meta'
 
 const BackOfficePage = () => {
   return (

--- a/src/pages/backoffice/mobile-view.js
+++ b/src/pages/backoffice/mobile-view.js
@@ -1,0 +1,19 @@
+import { DATA_ADMIN_ROLE } from '@/utils/user'
+import Meta from '../../components/Meta'
+import { getQueryProps } from '../../utils/helpers/serverSideProps'
+import OperativeMobileView from '../../components/BackOffice/OperativeMobileView'
+
+const MobileView = () => {
+  return (
+    <>
+      <Meta title="BackOffice" />
+      <OperativeMobileView />
+    </>
+  )
+}
+
+export const getServerSideProps = getQueryProps
+
+MobileView.permittedRoles = [DATA_ADMIN_ROLE]
+
+export default MobileView


### PR DESCRIPTION
## Summary of Changes

Add Operative Mobile View to backoffice. This feature will help when debugging what jobs an operative can see.

- Uses the existing component for mobile view. Except allows you to view the jobs for any operative
- Filter operatives by name, or OJAT enabled
- Update `MobileWorkingWorkOrderView` component to reload when operative changes
- I havent added any tests because this is not a user facing feature. 
- The code is also not that clean, but again, this is not a user facing feature, so it doesnt matter

## Screenshots
![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/88662046/f9f57df0-f88c-40ed-bd03-f6a480314db3)
