### PR TITLE
Add Damp & Mould form to Operative Mobile WorkOrder form

### DIFF
--- a/cypress/integration/work-order/attend/close.spec.js
+++ b/cypress/integration/work-order/attend/close.spec.js
@@ -98,7 +98,7 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      cy.get('.lbh-radios input[type="radio"]').check('No Access')
+      cy.get('.lbh-radios input[data-testid="reason"]').check('No Access')
 
       cy.get('#notes').type('I attended')
 
@@ -126,7 +126,9 @@ describe('Closing my own work order', () => {
         })
 
       cy.get('.modal-container').within(() => {
-        cy.contains(`Work order ${workOrderReference} successfully completed`)
+        cy.contains(
+          `Work order ${workOrderReference} successfully completed  with no access`
+        )
 
         cy.get('[data-testid="modal-close"]').click()
       })
@@ -152,7 +154,9 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      cy.get('.lbh-radios input[type="radio"]').check('Work Order Completed')
+      cy.get('.lbh-radios input[data-testid="reason"]').check(
+        'Work Order Completed'
+      )
 
       cy.get('#notes').type('I attended')
 
@@ -230,7 +234,7 @@ describe('Closing my own work order', () => {
           'Please select a reason for closing the work order'
         )
 
-        cy.get('.lbh-radios input[type="radio"]').check('No Access') // Checking by value, not text
+        cy.get('.lbh-radios input[data-testid="reason"]').check('No Access') // Checking by value, not text
 
         cy.get('.govuk-button').contains('Close work order').click()
 
@@ -257,7 +261,9 @@ describe('Closing my own work order', () => {
           })
 
         cy.get('.modal-container').within(() => {
-          cy.contains(`Work order ${workOrderReference} successfully completed`)
+          cy.contains(
+            `Work order ${workOrderReference} successfully completed with no access`
+          )
 
           cy.get('[data-testid="modal-close"]').click()
         })
@@ -363,6 +369,10 @@ describe('Closing my own work order', () => {
         cy.get('.govuk-form-group--error').contains(
           'Please select a reason for closing the work order'
         )
+
+        cy.get('.lbh-radios input[data-testid="reason"]').check(
+          'Work Order Completed'
+        ) // Checking by value, not text
 
         cy.get('.govuk-button').contains('Next').click()
 

--- a/cypress/integration/work-order/attend/close.spec.js
+++ b/cypress/integration/work-order/attend/close.spec.js
@@ -127,7 +127,7 @@ describe('Closing my own work order', () => {
 
       cy.get('.modal-container').within(() => {
         cy.contains(
-          `Work order ${workOrderReference} successfully completed  with no access`
+          `Work order ${workOrderReference} successfully closed with no access`
         )
 
         cy.get('[data-testid="modal-close"]').click()
@@ -262,7 +262,7 @@ describe('Closing my own work order', () => {
 
         cy.get('.modal-container').within(() => {
           cy.contains(
-            `Work order ${workOrderReference} successfully completed with no access`
+            `Work order ${workOrderReference} successfully closed with no access`
           )
 
           cy.get('[data-testid="modal-close"]').click()
@@ -299,6 +299,10 @@ describe('Closing my own work order', () => {
         cy.get('.govuk-form-group--error').contains(
           'Please select a reason for closing the work order'
         )
+
+        cy.get('.lbh-radios input[data-testid="reason"]').check(
+          'Work Order Completed'
+        ) // Checking by value, not text
 
         cy.get('.govuk-button').contains('Next').click()
 

--- a/cypress/integration/work-order/attend/close.spec.js
+++ b/cypress/integration/work-order/attend/close.spec.js
@@ -74,10 +74,21 @@ describe('Closing my own work order', () => {
       { body: [] }
     )
 
+    cy.intercept(
+      {
+        method: 'POST',
+        path: `/api/damp-and-mould/reports/${propertyReference}`,
+      },
+      {
+        statusCode: 201,
+        body: '',
+      }
+    ).as('dampAndMouldReportRequest')
+
     cy.loginWithOperativeRole()
   })
 
-  context('during normal working hours', () => {
+  context.only('during normal working hours', () => {
     beforeEach(() => {
       cy.clock(new Date(now).setHours(12, 0, 0))
     })
@@ -198,6 +209,251 @@ describe('Closing my own work order', () => {
       cy.get('.modal-container').should('not.exist')
 
       cy.get('.lbh-heading-h2').contains('Friday 11 June')
+    })
+
+    it('doesnt create a damp or mould report when no damp or mould presence in property', () => {
+      cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
+
+      cy.wait([
+        '@workOrderRequest',
+        '@propertyRequest',
+        '@tasksRequest',
+        '@locationAlerts',
+        '@personAlerts',
+      ])
+
+      // 1. Click confirm button - (navigate to close work order form)
+      cy.contains('button', 'Confirm').click()
+
+      // 2. Set job as completed
+      cy.get('.lbh-radios input[data-testid="reason"]').check(
+        'Work Order Completed'
+      )
+
+      // 3. Navigate to damp and mould part of form
+      cy.get('.govuk-button').contains('Next').click()
+
+      // 4. Select no damp or mould presence in property
+      cy.get('.lbh-radios input[data-testid="isDampOrMouldInProperty"]').check(
+        'No'
+      )
+
+      // 5. Assert subsequent radio fields and comments are hidden
+      cy.get(
+        '.lbh-radios input[data-testid="residentPreviouslyReported"]'
+      ).should('not.be.visible')
+      cy.get('.lbh-radios input[data-testid="resolvedAtTheTime"]').should(
+        'not.be.visible'
+      )
+      cy.get('textarea[data-testid="comments"]').should('not.be.visible')
+
+      // 6. Submit form
+      cy.get('.govuk-button').contains('Close work order').click()
+
+      cy.wait('@workOrderCompleteRequest')
+
+      // 7. Assert damp and mould report request not made
+      cy.get('@dampAndMouldReportRequest.all').then((interceptions) => {
+        expect(interceptions).to.have.length(0)
+      })
+
+      // 8. Assert confirmation message appeared
+      cy.get('.modal-container').within(() => {
+        cy.contains(`Work order ${workOrderReference} successfully completed`)
+      })
+    })
+
+    const testData = [
+      {
+        description: 'damp or mould presence confirmed',
+        optionLabel: 'Yes',
+        confirmed: true,
+      },
+      {
+        description: 'damp or mould presence uncomfirmed',
+        optionLabel: 'Not sure',
+        confirmed: false,
+      },
+    ]
+
+    testData.forEach(({ description, optionLabel, confirmed }) => {
+      it(`create a damp or mould report when potential ${description} in property`, () => {
+        cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
+
+        cy.wait([
+          '@workOrderRequest',
+          '@propertyRequest',
+          '@tasksRequest',
+          '@locationAlerts',
+          '@personAlerts',
+        ])
+
+        // 1. Click confirm button - (navigate to close work order form)
+        cy.contains('button', 'Confirm').click()
+
+        // 2. Set job as completed
+        cy.get('.lbh-radios input[data-testid="reason"]').check(
+          'Work Order Completed'
+        )
+
+        // 3. Navigate to damp and mould part of form
+        cy.get('.govuk-button').contains('Next').click()
+
+        // 4. Select potential presence in property
+        cy.get(
+          '.lbh-radios input[data-testid="isDampOrMouldInProperty"]'
+        ).check(optionLabel)
+
+        // 5. Select resident hasnt previously reported
+        cy.get(
+          '.lbh-radios input[data-testid="residentPreviouslyReported"]'
+        ).check('No')
+
+        // 6. Populate comments
+        cy.get('textarea[data-testid="comments"]').type('Comments')
+
+        // 7. Assert subsequent radio field is hidden
+        cy.get('.lbh-radios input[data-testid="resolvedAtTheTime"]').should(
+          'not.be.visible'
+        )
+
+        // 8. Submit form
+        cy.get('.govuk-button').contains('Close work order').click()
+
+        // 9. Assert damp and mould report request made
+        cy.wait(['@workOrderCompleteRequest', '@dampAndMouldReportRequest'])
+
+        cy.get('@dampAndMouldReportRequest')
+          .its('request.body')
+          .should('deep.equal', {
+            dampAndMouldPresenceConfirmed: confirmed,
+            previouslyReported: false,
+            comments: 'Comments',
+          })
+
+        // 10. Assert confirmation message appeared
+        cy.get('.modal-container').within(() => {
+          cy.contains(`Work order ${workOrderReference} successfully completed`)
+        })
+      })
+    })
+
+    it(`create a damp or mould report when resident has previously reported the property`, () => {
+      cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
+
+      cy.wait([
+        '@workOrderRequest',
+        '@propertyRequest',
+        '@tasksRequest',
+        '@locationAlerts',
+        '@personAlerts',
+      ])
+
+      // 1. Click confirm button - (navigate to close work order form)
+      cy.contains('button', 'Confirm').click()
+
+      // 2. Set job as completed
+      cy.get('.lbh-radios input[data-testid="reason"]').check(
+        'Work Order Completed'
+      )
+
+      // 3. Navigate to damp and mould part of form
+      cy.get('.govuk-button').contains('Next').click()
+
+      // 4. Select confirmed damp or mould presence in property
+      cy.get('.lbh-radios input[data-testid="isDampOrMouldInProperty"]').check(
+        'Yes'
+      )
+
+      // 5. Select resident has previously reported
+      cy.get(
+        '.lbh-radios input[data-testid="residentPreviouslyReported"]'
+      ).check('Yes')
+
+      // 6. Select previous report not resolved at the time
+      cy.get('.lbh-radios input[data-testid="resolvedAtTheTime"]').check('No')
+
+      // 7. Populate comments
+      cy.get('textarea[data-testid="comments"]').type('Comments')
+
+      // 8. Submit form
+      cy.get('.govuk-button').contains('Close work order').click()
+
+      // 9. Assert damp and mould report request made
+      cy.wait(['@workOrderCompleteRequest', '@dampAndMouldReportRequest'])
+
+      cy.get('@dampAndMouldReportRequest')
+        .its('request.body')
+        .should('deep.equal', {
+          dampAndMouldPresenceConfirmed: true,
+          previouslyReported: true,
+          previousReportResolved: false,
+          comments: 'Comments',
+        })
+
+      // 10. Assert confirmation message appeared
+      cy.get('.modal-container').within(() => {
+        cy.contains(`Work order ${workOrderReference} successfully completed`)
+      })
+    })
+
+    it(`create a damp or mould report when previously reported problem was resolved at the time`, () => {
+      cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
+
+      cy.wait([
+        '@workOrderRequest',
+        '@propertyRequest',
+        '@tasksRequest',
+        '@locationAlerts',
+        '@personAlerts',
+      ])
+
+      // 1. Click confirm button - (navigate to close work order form)
+      cy.contains('button', 'Confirm').click()
+
+      // 2. Set job as completed
+      cy.get('.lbh-radios input[data-testid="reason"]').check(
+        'Work Order Completed'
+      )
+
+      // 3. Navigate to damp and mould part of form
+      cy.get('.govuk-button').contains('Next').click()
+
+      // 4. Select confirmed damp or mould presence in property
+      cy.get('.lbh-radios input[data-testid="isDampOrMouldInProperty"]').check(
+        'Yes'
+      )
+
+      // 5. Select resident has previously reported
+      cy.get(
+        '.lbh-radios input[data-testid="residentPreviouslyReported"]'
+      ).check('Yes')
+
+      // 6. Select previous report not resolved at the time
+      cy.get('.lbh-radios input[data-testid="resolvedAtTheTime"]').check('Yes')
+
+      // 7. Populate comments
+      cy.get('textarea[data-testid="comments"]').type('Comments')
+
+      // 8. Submit form
+      cy.get('.govuk-button').contains('Close work order').click()
+
+      // 9. Assert damp and mould report request made
+      cy.wait(['@workOrderCompleteRequest', '@dampAndMouldReportRequest'])
+
+      cy.get('@dampAndMouldReportRequest')
+        .its('request.body')
+        .should('deep.equal', {
+          dampAndMouldPresenceConfirmed: true,
+          previouslyReported: true,
+          previousReportResolved: true,
+          comments: 'Comments',
+        })
+
+      // 10. Assert confirmation message appeared
+      cy.get('.modal-container').within(() => {
+        cy.contains(`Work order ${workOrderReference} successfully completed`)
+      })
     })
   })
 

--- a/src/components/Layout/BackButton/index.js
+++ b/src/components/Layout/BackButton/index.js
@@ -1,10 +1,10 @@
 import Router from 'next/router'
 
-const BackButton = () => (
+const BackButton = ({ onClick = null }) => (
   <a
     className="govuk-back-link lbh-back-link govuk-!-display-none-print"
     role="button"
-    onClick={() => Router.back()}
+    onClick={onClick === null ? () => Router.back() : onClick}
   >
     Back
   </a>

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -123,9 +123,14 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
 
     let dampAndMouldReportFormData = null
 
-    const dampAndMouldReportIncluded = data.reason === 'Work Order Completed'
+    // Only send report if workOrder completed, and there is potential
+    // damp or mould presence in the property
+    const sendDampAndMouldReport =
+      data.reason === 'Work Order Completed' &&
+      (data.isDampOrMouldInProperty === 'Yes' ||
+        data.isDampOrMouldInProperty === 'Not sure')
 
-    if (dampAndMouldReportIncluded) {
+    if (sendDampAndMouldReport) {
       dampAndMouldReportFormData = buildDampAndMouldReportData(
         data.isDampOrMouldInProperty,
         data.residentPreviouslyReported,
@@ -153,12 +158,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
         }),
       ]
 
-      // only submit report requests if status is completed and there is potential damp/mould presence
-      if (
-        dampAndMouldReportIncluded &&
-        (data.isDampOrMouldInProperty === 'Yes' ||
-          data.isDampOrMouldInProperty === 'Not sure')
-      ) {
+      if (sendDampAndMouldReport) {
         promiseList.push(
           frontEndApiRequest({
             method: 'post',

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -32,7 +32,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
 
   const [paymentType, setPaymentType] = useState(BONUS_PAYMENT_TYPE)
   const [workOrderProgressedToClose, setWorkOrderProgressedToClose] = useState(
-    true
+    false
   )
 
   const getWorkOrderView = async (workOrderReference) => {

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
@@ -6,49 +6,209 @@ import TextArea from '../Form/TextArea'
 import Radios from '../Form/Radios'
 import WarningInfoBox from '../Template/WarningInfoBox'
 import { CLOSURE_STATUS_OPTIONS } from '@/utils/statusCodes'
+import { useState } from 'react'
+
+const PAGES = {
+  WORK_ORDER_STATUS: '1',
+  DAMP_OR_MOULD: '2',
+}
 
 const MobileWorkingCloseWorkOrderForm = ({ onSubmit }) => {
-  const { handleSubmit, register, errors } = useForm({})
+  const { handleSubmit, register, errors, getValues, trigger, watch } = useForm(
+    {
+      shouldUnregister: false,
+    }
+  )
+
+  const [currentPage, setCurrentPage] = useState(PAGES.WORK_ORDER_STATUS)
+
+  const viewNextPage = async () => {
+    // validate form
+    const results = await trigger('reason')
+    if (!results) return
+
+    setCurrentPage(PAGES.DAMP_OR_MOULD)
+  }
+
+  const viewPreviousPage = async () => {
+    setCurrentPage(PAGES.WORK_ORDER_STATUS)
+  }
+
+  const watchedReasonField = watch('reason')
+  const watchedIsDampOrMouldInPropertyField = watch('isDampOrMouldInProperty')
+  const watchedResidentPreviouslyReportedField = watch(
+    'residentPreviouslyReported'
+  )
 
   return (
     <>
       <div>
-        <BackButton />
+        {/* if on second page, override back button */}
+        <BackButton
+          onClick={
+            currentPage === PAGES.DAMP_OR_MOULD ? viewPreviousPage : null
+          }
+        />
 
-        <h1 className="lbh-heading-h2">Close work order</h1>
+        <h1 className="lbh-heading-h2">Close work order form</h1>
 
         <form role="form" onSubmit={handleSubmit(onSubmit)}>
-          <Radios
-            label="Select reason for closing"
-            name="reason"
-            options={CLOSURE_STATUS_OPTIONS.map((r) => {
-              return {
-                text: r.text,
-                value: r.value,
-              }
-            })}
-            register={register({
-              required: 'Please select a reason for closing the work order',
-            })}
-            error={errors && errors.reason}
-          />
+          <div
+            style={{
+              display:
+                currentPage === PAGES.WORK_ORDER_STATUS ? 'block' : 'none',
+            }}
+          >
+            <h2 className="lbh-heading-h4" style={{ marginBottom: '60px' }}>
+              Work order status
+            </h2>
 
-          <TextArea
-            name="notes"
-            label="Add notes"
-            label={'Final report'}
-            register={register}
-            error={errors && errors.notes}
-          />
-
-          <div className="govuk-!-margin-top-8">
-            <WarningInfoBox
-              header="Other changes?"
-              text="Any follow on and material change must be made on paper."
+            <Radios
+              labelSize="s"
+              label="Select reason for closing"
+              name="reason"
+              options={CLOSURE_STATUS_OPTIONS.map((r) => {
+                return {
+                  text: r.text,
+                  value: r.value,
+                }
+              })}
+              register={register({
+                required: 'Please select a reason for closing the work order',
+              })}
+              error={errors && errors.reason}
             />
+
+            <TextArea
+              name="notes"
+              label="Final report"
+              register={register}
+              error={errors && errors.notes}
+            />
+
+            <div className="govuk-!-margin-top-8">
+              <WarningInfoBox
+                header="Other changes?"
+                text="Any follow on and material change must be made on paper."
+              />
+            </div>
+
+            {watchedReasonField === 'Work Order Completed' ? (
+              <PrimarySubmitButton
+                label="Next"
+                type="button"
+                onClick={viewNextPage}
+              />
+            ) : (
+              <PrimarySubmitButton label="Close work order" />
+            )}
           </div>
 
-          <PrimarySubmitButton label="Close work order" />
+          <div
+            style={{
+              display: currentPage === PAGES.DAMP_OR_MOULD ? 'block' : 'none',
+            }}
+          >
+            <h2 className="lbh-heading-h4" style={{ marginBottom: '60px' }}>
+              Damp and mould status
+            </h2>
+
+            <Radios
+              labelSize="s"
+              label="Is there damp or mould in the property?"
+              name="isDampOrMouldInProperty"
+              options={['Yes', 'No', 'Not sure']}
+              register={register({
+                validate: {
+                  required: (value) => {
+                    if (
+                      !value &&
+                      getValues('reason') === 'Work Order Completed'
+                    ) {
+                      return 'Please indicate whether there is damp or mould in the property'
+                    }
+
+                    return true
+                  },
+                },
+              })}
+              error={errors && errors.isDampOrMouldInProperty}
+            />
+
+            <div
+              style={{
+                display:
+                  watchedIsDampOrMouldInPropertyField === 'Yes' ||
+                  watchedIsDampOrMouldInPropertyField === 'Not sure'
+                    ? 'block'
+                    : 'none',
+              }}
+            >
+              <Radios
+                labelSize="s"
+                label="Has the resident previously reported damp or mould?"
+                name="residentPreviouslyReported"
+                options={['Yes', 'No']}
+                register={register({
+                  validate: {
+                    required: (value) => {
+                      const isDampOrMouldPresence =
+                        getValues('isDampOrMouldInProperty') === 'Yes' ||
+                        getValues('isDampOrMouldInProperty') === 'Not sure'
+
+                      if (!value && isDampOrMouldPresence) {
+                        return 'Please indicate whether the resident has previous reported damp or mould in the property'
+                      }
+
+                      return true
+                    },
+                  },
+                })}
+                error={errors && errors.residentPreviouslyReported}
+              />
+
+              <div
+                style={{
+                  display:
+                    watchedResidentPreviouslyReportedField === 'Yes'
+                      ? 'block'
+                      : 'none',
+                }}
+              >
+                <Radios
+                  labelSize="s"
+                  label="Was the previously reported damp or mould resolved at the time?"
+                  name="resolvedAtTheTime"
+                  options={['Yes', 'No']}
+                  register={register({
+                    validate: {
+                      required: (value) => {
+                        if (
+                          !value &&
+                          getValues('residentPreviouslyReported') === 'Yes'
+                        ) {
+                          return 'Please indicate whether the damp or mould was resolved after it was previously reported'
+                        }
+
+                        return true
+                      },
+                    },
+                  })}
+                  error={errors && errors.resolvedAtTheTime}
+                />
+              </div>
+
+              <TextArea
+                labelSize="s"
+                name="comments"
+                label="Comments"
+                register={register}
+                error={errors && errors.comments}
+              />
+            </div>
+
+            <PrimarySubmitButton label="Close work order" />
+          </div>
         </form>
       </div>
     </>

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
@@ -23,7 +23,7 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit }) => {
   const [currentPage, setCurrentPage] = useState(PAGES.WORK_ORDER_STATUS)
 
   const viewNextPage = async () => {
-    // validate form
+    // validate form fields on first page
     const results = await trigger('reason')
     if (!results) return
 

--- a/src/components/WorkOrders/__snapshots__/MobileWorkingCloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/MobileWorkingCloseWorkOrderForm.test.js.snap
@@ -12,127 +12,354 @@ exports[`MobileWorkingCloseWorkOrderForm component should render properly 1`] = 
     <h1
       class="lbh-heading-h2"
     >
-      Close work order
+      Close work order form
     </h1>
     <form
       role="form"
     >
       <div
-        class="govuk-form-group lbh-form-group"
+        style="display: block;"
       >
-        <label
-          class="govuk-label govuk-label--m"
-          for="reason"
+        <h2
+          class="lbh-heading-h4"
+          style="margin-bottom: 60px;"
         >
-          Select reason for closing 
-        </label>
+          Work order status
+        </h2>
         <div
-          class="govuk-radios lbh-radios"
+          class="govuk-form-group lbh-form-group"
         >
-          <div
-            class="govuk-radios__item"
+          <label
+            class="govuk-label govuk-label--s"
+            for="reason"
           >
-            <input
-              class="govuk-radios__input"
-              data-testid="reason"
-              id="reason_Work Order Completed"
-              name="reason"
-              type="radio"
-              value="Work Order Completed"
-            />
-            <label
-              class="govuk-label lbh-label govuk-radios__label"
-              for="reason_Work Order Completed"
-            >
-              Completed
-            </label>
-          </div>
+            Select reason for closing 
+          </label>
           <div
-            class="govuk-radios__item"
+            class="govuk-radios lbh-radios"
           >
-            <input
-              class="govuk-radios__input"
-              data-testid="reason"
-              id="reason_No Access"
-              name="reason"
-              type="radio"
-              value="No Access"
-            />
-            <label
-              class="govuk-label lbh-label govuk-radios__label"
-              for="reason_No Access"
-            >
-              No access
-            </label>
-          </div>
-        </div>
-      </div>
-      <div
-        class="govuk-form-group lbh-form-group"
-        id="notes-form-group"
-      >
-        <label
-          class="govuk-label lbh-label"
-          for="notes"
-        >
-          Final report 
-        </label>
-        <textarea
-          aria-describedby="notes-hint notes-error"
-          class="govuk-textarea lbh-textarea"
-          data-testid="notes"
-          id="notes"
-          name="notes"
-          rows="4"
-        />
-      </div>
-      <div
-        class="govuk-!-margin-top-8"
-      >
-        <div
-          class="warning-info-box govuk-inset-text lbh-inset-text"
-        >
-          <div
-            class="lbh-warning-text govuk-warning-text"
-          >
-            <span
-              aria-hidden="true"
-              class="govuk-warning-text__icon"
-            >
-              !
-            </span>
             <div
-              class="govuk-warning-text__text"
+              class="govuk-radios__item"
             >
-              <span
-                class="govuk-warning-text__assistive"
+              <input
+                class="govuk-radios__input"
+                data-testid="reason"
+                id="reason_Work Order Completed"
+                name="reason"
+                type="radio"
+                value="Work Order Completed"
+              />
+              <label
+                class="govuk-label lbh-label govuk-radios__label"
+                for="reason_Work Order Completed"
               >
-                Warning
-              </span>
-              <p
-                class="govuk-!-margin-top-0 lbh-body-s lbh-!-font-weight-bold"
+                Completed
+              </label>
+            </div>
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                data-testid="reason"
+                id="reason_No Access"
+                name="reason"
+                type="radio"
+                value="No Access"
+              />
+              <label
+                class="govuk-label lbh-label govuk-radios__label"
+                for="reason_No Access"
               >
-                Other changes?
-              </p>
-              <p
-                class="lbh-body-xs govuk-!-margin-top-1"
-              >
-                Any follow on and material change must be made on paper.
-              </p>
+                No access
+              </label>
             </div>
           </div>
         </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="notes-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="notes"
+          >
+            Final report 
+          </label>
+          <textarea
+            aria-describedby="notes-hint notes-error"
+            class="govuk-textarea lbh-textarea"
+            data-testid="notes"
+            id="notes"
+            name="notes"
+            rows="4"
+          />
+        </div>
+        <div
+          class="govuk-!-margin-top-8"
+        >
+          <div
+            class="warning-info-box govuk-inset-text lbh-inset-text"
+          >
+            <div
+              class="lbh-warning-text govuk-warning-text"
+            >
+              <span
+                aria-hidden="true"
+                class="govuk-warning-text__icon"
+              >
+                !
+              </span>
+              <div
+                class="govuk-warning-text__text"
+              >
+                <span
+                  class="govuk-warning-text__assistive"
+                >
+                  Warning
+                </span>
+                <p
+                  class="govuk-!-margin-top-0 lbh-body-s lbh-!-font-weight-bold"
+                >
+                  Other changes?
+                </p>
+                <p
+                  class="lbh-body-xs govuk-!-margin-top-1"
+                >
+                  Any follow on and material change must be made on paper.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Close work order
+          </button>
+        </div>
       </div>
       <div
-        class="govuk-form-group lbh-form-group"
+        style="display: none;"
       >
-        <button
-          class="govuk-button lbh-button"
-          data-module="govuk-button"
-          type="submit"
+        <h2
+          class="lbh-heading-h4"
+          style="margin-bottom: 60px;"
         >
-          Close work order
-        </button>
+          Damp and mould status
+        </h2>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <label
+            class="govuk-label govuk-label--s"
+            for="isDampOrMouldInProperty"
+          >
+            Is there damp or mould in the property? 
+          </label>
+          <div
+            class="govuk-radios lbh-radios"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                data-testid="isDampOrMouldInProperty"
+                id="isDampOrMouldInProperty_Yes"
+                name="isDampOrMouldInProperty"
+                type="radio"
+                value="Yes"
+              />
+              <label
+                class="govuk-label lbh-label govuk-radios__label"
+                for="isDampOrMouldInProperty_Yes"
+              >
+                Yes
+              </label>
+            </div>
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                data-testid="isDampOrMouldInProperty"
+                id="isDampOrMouldInProperty_No"
+                name="isDampOrMouldInProperty"
+                type="radio"
+                value="No"
+              />
+              <label
+                class="govuk-label lbh-label govuk-radios__label"
+                for="isDampOrMouldInProperty_No"
+              >
+                No
+              </label>
+            </div>
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                data-testid="isDampOrMouldInProperty"
+                id="isDampOrMouldInProperty_Not sure"
+                name="isDampOrMouldInProperty"
+                type="radio"
+                value="Not sure"
+              />
+              <label
+                class="govuk-label lbh-label govuk-radios__label"
+                for="isDampOrMouldInProperty_Not sure"
+              >
+                Not sure
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          style="display: none;"
+        >
+          <div
+            class="govuk-form-group lbh-form-group"
+          >
+            <label
+              class="govuk-label govuk-label--s"
+              for="residentPreviouslyReported"
+            >
+              Has the resident previously reported damp or mould? 
+            </label>
+            <div
+              class="govuk-radios lbh-radios"
+            >
+              <div
+                class="govuk-radios__item"
+              >
+                <input
+                  class="govuk-radios__input"
+                  data-testid="residentPreviouslyReported"
+                  id="residentPreviouslyReported_Yes"
+                  name="residentPreviouslyReported"
+                  type="radio"
+                  value="Yes"
+                />
+                <label
+                  class="govuk-label lbh-label govuk-radios__label"
+                  for="residentPreviouslyReported_Yes"
+                >
+                  Yes
+                </label>
+              </div>
+              <div
+                class="govuk-radios__item"
+              >
+                <input
+                  class="govuk-radios__input"
+                  data-testid="residentPreviouslyReported"
+                  id="residentPreviouslyReported_No"
+                  name="residentPreviouslyReported"
+                  type="radio"
+                  value="No"
+                />
+                <label
+                  class="govuk-label lbh-label govuk-radios__label"
+                  for="residentPreviouslyReported_No"
+                >
+                  No
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            style="display: none;"
+          >
+            <div
+              class="govuk-form-group lbh-form-group"
+            >
+              <label
+                class="govuk-label govuk-label--s"
+                for="resolvedAtTheTime"
+              >
+                Was the previously reported damp or mould resolved at the time? 
+              </label>
+              <div
+                class="govuk-radios lbh-radios"
+              >
+                <div
+                  class="govuk-radios__item"
+                >
+                  <input
+                    class="govuk-radios__input"
+                    data-testid="resolvedAtTheTime"
+                    id="resolvedAtTheTime_Yes"
+                    name="resolvedAtTheTime"
+                    type="radio"
+                    value="Yes"
+                  />
+                  <label
+                    class="govuk-label lbh-label govuk-radios__label"
+                    for="resolvedAtTheTime_Yes"
+                  >
+                    Yes
+                  </label>
+                </div>
+                <div
+                  class="govuk-radios__item"
+                >
+                  <input
+                    class="govuk-radios__input"
+                    data-testid="resolvedAtTheTime"
+                    id="resolvedAtTheTime_No"
+                    name="resolvedAtTheTime"
+                    type="radio"
+                    value="No"
+                  />
+                  <label
+                    class="govuk-label lbh-label govuk-radios__label"
+                    for="resolvedAtTheTime_No"
+                  >
+                    No
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="govuk-form-group lbh-form-group"
+            id="comments-form-group"
+          >
+            <label
+              class="govuk-label lbh-label"
+              for="comments"
+            >
+              Comments 
+            </label>
+            <textarea
+              aria-describedby="comments-hint comments-error"
+              class="govuk-textarea lbh-textarea"
+              data-testid="comments"
+              id="comments"
+              labelsize="s"
+              name="comments"
+              rows="4"
+            />
+          </div>
+        </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Close work order
+          </button>
+        </div>
       </div>
     </form>
   </div>

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.js
@@ -28,6 +28,26 @@ export const buildCloseWorkOrderData = (
   }
 }
 
+export const buildDampAndMouldReportData = (
+  isDampOrMouldInProperty,
+  residentPreviouslyReported,
+  resolvedAtTheTime,
+  comments
+) => {
+  const requestData = {
+    dampAndMouldPresenceConfirmed: isDampOrMouldInProperty === 'Yes',
+    previouslyReported: residentPreviouslyReported === 'Yes',
+    comments: comments ?? '',
+  }
+
+  if (requestData.previouslyReported) {
+    // resolvedAtTheTime only enabled if previously reported
+    requestData['previousReportResolved'] = resolvedAtTheTime === 'Yes'
+  }
+
+  return requestData
+}
+
 const operativesAndPercentagesForNotes = (
   operativesWithPercentages,
   showPercentages = true

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.js
@@ -36,6 +36,10 @@ export const buildDampAndMouldReportData = (
 ) => {
   const requestData = {
     dampAndMouldPresenceConfirmed: isDampOrMouldInProperty === 'Yes',
+    // following the logic, previouslyReported and comments would only be visible if there is
+    // potentially damp/mould presence in the property
+    // if there is no damp/mould, no report would be created
+    // hence, no need to conditionally add these fields
     previouslyReported: residentPreviouslyReported === 'Yes',
     comments: comments ?? '',
   }

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
@@ -1,7 +1,123 @@
 import {
   buildCloseWorkOrderData,
+  buildDampAndMouldReportData,
   buildWorkOrderCompleteNotes,
 } from './closeWorkOrder'
+
+describe.only('buildDampAndMouldReportData', () => {
+  describe('dampAndMouldPresenceConfirmed', () => {
+    ;[
+      {
+        value: 'Yes',
+        expectedOutput: true,
+        testDescription: 'It sets the value as true',
+      },
+      {
+        value: 'Not sure',
+        expectedOutput: false,
+        testDescription: 'It sets the value as false',
+      },
+    ].forEach(({ value, expectedOutput, testDescription }) => {
+      it(testDescription, () => {
+        // Arrange
+
+        // Act
+        const result = buildDampAndMouldReportData(value, '', '', '')
+
+        // Assert
+        expect(result.dampAndMouldPresenceConfirmed).toEqual(expectedOutput)
+      })
+    })
+  })
+
+  describe('previouslyReported', () => {
+    ;[
+      {
+        value: 'Yes',
+        expectedOutput: true,
+        testDescription: 'It sets the value as true',
+      },
+      {
+        value: 'No',
+        expectedOutput: false,
+        testDescription: 'It sets the value as false',
+      },
+    ].forEach(({ value, expectedOutput, testDescription }) => {
+      it(testDescription, () => {
+        // Arrange
+
+        // Act
+        const result = buildDampAndMouldReportData('', value, '', '')
+
+        // Assert
+        expect(result.previouslyReported).toEqual(expectedOutput)
+      })
+    })
+  })
+
+  // Comments
+  describe('comments', () => {
+    it('should include comments', () => {
+      // Arrange
+      const comments = 'Comments'
+
+      // Act
+      const result = buildDampAndMouldReportData('', '', '', comments)
+
+      // Assert
+      expect(result.comments).toEqual(comments)
+    })
+  })
+
+  // previousReportResolved ("YES")
+  // not resolved ("NO")
+
+  describe('previousReportResolved', () => {
+    ;[
+      {
+        value: 'Yes',
+        previouslyReportedValue: 'Yes',
+        expectedOutput: true,
+        testDescription: 'It sets the value as true',
+      },
+      {
+        value: 'Yes',
+        previouslyReportedValue: 'No',
+        expectedOutput: false,
+        testDescription:
+          'It sets the value as false if not previously reported',
+      },
+      {
+        value: 'No',
+        previouslyReportedValue: 'Yes',
+        expectedOutput: false,
+        testDescription: 'It sets the value as false',
+      },
+    ].forEach(
+      ({ value, expectedOutput, testDescription, previouslyReportedValue }) => {
+        it(testDescription, () => {
+          // Arrange
+
+          // Act
+          const result = buildDampAndMouldReportData(
+            '',
+            previouslyReportedValue,
+            value,
+            ''
+          )
+
+          // Assert
+
+          if (previouslyReportedValue === 'No') {
+            expect(result).not.toHaveProperty('previousReportResolved')
+          } else {
+            expect(result.previousReportResolved).toEqual(expectedOutput)
+          }
+        })
+      }
+    )
+  })
+})
 
 describe('buildCloseWorkOrderData', () => {
   const completionDate = new Date()

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
@@ -55,7 +55,6 @@ describe.only('buildDampAndMouldReportData', () => {
     })
   })
 
-  // Comments
   describe('comments', () => {
     it('should include comments', () => {
       // Arrange
@@ -68,9 +67,6 @@ describe.only('buildDampAndMouldReportData', () => {
       expect(result.comments).toEqual(comments)
     })
   })
-
-  // previousReportResolved ("YES")
-  // not resolved ("NO")
 
   describe('previousReportResolved', () => {
     ;[
@@ -107,7 +103,6 @@ describe.only('buildDampAndMouldReportData', () => {
           )
 
           // Assert
-
           if (previouslyReportedValue === 'No') {
             expect(result).not.toHaveProperty('previousReportResolved')
           } else {


### PR DESCRIPTION
## Ticket

[https://hackney.atlassian.net/browse/MR-868?atlOrigin=eyJpIjoiOTFmOTEwNTU3ZjdkNGU3MDhhYmMxOGMzMmRkZTBhOTUiLCJwIjoiaiJ9](https://hackney.atlassian.net/browse/MR-868?atlOrigin=eyJpIjoiOTFmOTEwNTU3ZjdkNGU3MDhhYmMxOGMzMmRkZTBhOTUiLCJwIjoiaiJ9)

## Summary of Changes

- Updating the heading/font sizing to make form layout better
- If user selects "No access" - no report is created (therefore no need to navigate to the form)
- If user selects "Completed", the submit button is replaced with a Next button
- Radio buttons conditionally shown based on previous radio button values
- Added unit tests for factory helper method

## Screenshots

### No access (no damp/mould report)
![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/88662046/94405578-fb21-4542-8f3e-116e063fd22c)

### Completed (next button goes to damp/mould form)
![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/88662046/edf7be8a-c125-4d0d-b83d-e67cac7560f4)

### Fields conditionally shown

![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/88662046/72319490-a736-4f03-a1c4-89a59cc4caa8)

![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/88662046/a4a4e31e-85f0-4ecd-b658-298e07dac51b)

![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/88662046/4be6f79c-5961-4f0d-98d5-867cc4361eeb)

