### PR TITLE
Added response headers for security

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,38 @@
 const { withSentryConfig } = require('@sentry/nextjs')
 
+const cspHeader = `
+  frame-ancestors 'none';
+`
+
+async function headers() {
+  return [
+    {
+      source: '/(.*)',
+      headers: [
+        {
+          key: 'Content-Security-Policy',
+          value: cspHeader.replace(/\n/g, ''),
+        },
+        {
+          key: 'Referrer-Policy',
+          value: 'strict-origin-when-cross-origin',
+        },
+        {
+          key: 'X-Content-Type-Options',
+          value: 'nosniff',
+        },
+      ],
+    },
+  ]
+}
+
 const moduleExports = {
   distDir: 'build/_next',
   target: 'server',
   experimental: {
     forceSwcTransforms: true,
   },
+  headers: () => headers(),
 }
 
 const { NODE_ENV, SENTRY_RELEASE } = process.env


### PR DESCRIPTION
Implemented recommended fixes for security tickets:

## [MR-773](https://hackney.atlassian.net/browse/MR-773) Missing clickjacking protection

Fixed by adding  `frame-ancestors 'none'` to the cspHeader

## [MR-774](https://hackney.atlassian.net/browse/MR-774) Referrer policy not defined

Fixed by adding to the app headers:
```json
{
  key: 'Referrer-Policy',
  value: 'strict-origin-when-cross-origin',
}
```

## [MR-775](https://hackney.atlassian.net/browse/MR-775) Browser content sniffing allowed

Fixed by adding to the app headers:
```json
{
  key: 'X-Content-Type-Options',
  value: 'nosniff',
}
```

Confirmed that the new headers are added in the network tab
![image](https://github.com/LBHackney-IT/repairs-hub-frontend/assets/74552077/1d1cde04-9327-4b76-a2b0-3894a0d8bdc9)



[MR-773]: https://hackney.atlassian.net/browse/MR-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MR-774]: https://hackney.atlassian.net/browse/MR-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MR-775]: https://hackney.atlassian.net/browse/MR-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ