### PR TITLE
Add background fetch to mobile view

### DIFF
--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/CurrentUserWrapper.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/CurrentUserWrapper.js
@@ -5,7 +5,7 @@ import ErrorMessage from '../../Errors/ErrorMessage'
 import MobileWorkingWorkOrdersView from './MobileWorkingWorkOrdersView'
 
 const CurrentUserWrapper = () => {
-  const [currentUser, setCurrentUser] = useState({})
+  const [currentUser, setCurrentUser] = useState(null)
   const [error, setError] = useState()
   const [loading, setLoading] = useState(false)
 

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -100,7 +100,7 @@ const MobileWorkingWorkOrdersView = ({
   }, [currentUser?.operativePayrollNumber])
 
   const renderWorkOrderListItems = (workOrders) => {
-    if (workOrders.length === 0) {
+    if (workOrders === null || workOrders?.length === 0) {
       return <></>
     }
 

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -97,7 +97,7 @@ const MobileWorkingWorkOrdersView = ({
     return () => {
       clearInterval(intervalRef.current)
     }
-  }, [currentUser.operativePayrollNumber])
+  }, [currentUser?.operativePayrollNumber])
 
   const renderWorkOrderListItems = (workOrders) => {
     if (workOrders.length === 0) {

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -182,7 +182,7 @@ const MobileWorkingWorkOrdersView = ({
       </div>
 
       <h3 className="lbh-heading-h3">Work orders</h3>
-      {setSortedWorkOrders === null ? (
+      {sortedWorkOrders === null ? (
         <Spinner />
       ) : (
         <>

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef,  } from 'react'
 import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
 import { beginningOfDay } from '@/utils/time'
 import { longMonthWeekday } from '@/utils/date'
@@ -9,19 +9,19 @@ import WarningInfoBox from '../../Template/WarningInfoBox'
 import Meta from '../../Meta'
 import { WorkOrder } from '../../../models/workOrder'
 
+const SIXTY_SECONDS = 60 * 1000
+
 const MobileWorkingWorkOrdersView = ({
   currentUser,
   loggingEnabled = true,
 }) => {
   const currentDate = beginningOfDay(new Date())
-  const [visitedWorkOrders, setVisitedWorkOrders] = useState([])
-  const [sortedWorkOrders, setSortedWorkOrders] = useState([])
+  const [visitedWorkOrders, setVisitedWorkOrders] = useState(null)
+  const [sortedWorkOrders, setSortedWorkOrders] = useState(null)
 
   const [error, setError] = useState()
-  const [loading, setLoading] = useState(false)
 
   const getOperativeWorkOrderView = async () => {
-    setLoading(true)
     setError(null)
 
     try {
@@ -77,13 +77,27 @@ const MobileWorkingWorkOrdersView = ({
         `Oops an error occurred with error status: ${e.response?.status} with message: ${e.response?.data?.message}`
       )
     }
-
-    setLoading(false)
   }
 
+  const intervalRef = useRef(null)
+
   useEffect(() => {
+    // dont try fetch if currentUser not loaded yet
+    if (currentUser === null) return
+
+    // initial fetch (otherwise it wont fetch until interval)
     getOperativeWorkOrderView()
-  }, [currentUser])
+
+    const intervalId = setInterval(() => {
+      getOperativeWorkOrderView()
+    }, SIXTY_SECONDS)
+
+    intervalRef.current = intervalId
+
+    return () => {
+      clearInterval(intervalRef.current)
+    }
+  }, [currentUser.operativePayrollNumber])
 
   const renderWorkOrderListItems = (workOrders) => {
     if (workOrders.length === 0) {
@@ -168,7 +182,7 @@ const MobileWorkingWorkOrdersView = ({
       </div>
 
       <h3 className="lbh-heading-h3">Work orders</h3>
-      {loading ? (
+      {setSortedWorkOrders === null ? (
         <Spinner />
       ) : (
         <>

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef,  } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
 import { beginningOfDay } from '@/utils/time'
 import { longMonthWeekday } from '@/utils/date'


### PR DESCRIPTION
## Summary of Changes

- Fetch workOrders every 60 seconds
- Add fix for trying to fetch workOrders when user not loading ([resulting in 401](https://london-borough-of-hackney.sentry.io/issues/3069377254/?project=6146278&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0))
- Replace loading state with checking if null (otherwise, user would keep seeing the loading icon when the jobs update)