### PR TITLE
Remove frontend logging

### DIFF
--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -176,7 +176,6 @@ const OperativeMobileView = () => {
               <div style={{ marginTop: '30px' }}>
                 <MobileWorkingWorkOrdersView
                   currentUser={selectedOperative}
-                  loggingEnabled={false}
                 />
               </div>
             )}

--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -174,9 +174,7 @@ const OperativeMobileView = () => {
 
             {!!selectedOperative && (
               <div style={{ marginTop: '30px' }}>
-                <MobileWorkingWorkOrdersView
-                  currentUser={selectedOperative}
-                />
+                <MobileWorkingWorkOrdersView currentUser={selectedOperative} />
               </div>
             )}
           </div>

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrderListItems.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrderListItems.js
@@ -1,17 +1,20 @@
-import MobileWorkingWorkOrderListItem from '../../WorkOrder/MobileWorkingWorkOrderListItem';
+import MobileWorkingWorkOrderListItem from '../../WorkOrder/MobileWorkingWorkOrderListItem'
 
-export const MobileWorkingWorkOrderListItems = ({ workOrders, currentUser }) => {
+export const MobileWorkingWorkOrderListItems = ({
+  workOrders,
+  currentUser,
+}) => {
   const formatStatusText = (statusText) => {
-    const status = statusText.toLowerCase();
+    const status = statusText.toLowerCase()
 
-    if (status === 'no access') return 'No access';
-    if (status === 'completed') return 'Completed';
+    if (status === 'no access') return 'No access'
+    if (status === 'completed') return 'Completed'
 
-    return '';
-  };
+    return ''
+  }
 
   if (workOrders === null || workOrders?.length === 0) {
-    return <></>;
+    return <></>
   }
 
   return workOrders.map((workOrder, index) => (
@@ -20,6 +23,7 @@ export const MobileWorkingWorkOrderListItems = ({ workOrders, currentUser }) => 
       workOrder={workOrder}
       index={index}
       statusText={(() => formatStatusText(workOrder.status))()}
-      currentUser={currentUser} />
-  ));
-};
+      currentUser={currentUser}
+    />
+  ))
+}

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrderListItems.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrderListItems.js
@@ -1,0 +1,25 @@
+import MobileWorkingWorkOrderListItem from '../../WorkOrder/MobileWorkingWorkOrderListItem';
+
+export const MobileWorkingWorkOrderListItems = ({ workOrders, currentUser }) => {
+  const formatStatusText = (statusText) => {
+    const status = statusText.toLowerCase();
+
+    if (status === 'no access') return 'No access';
+    if (status === 'completed') return 'Completed';
+
+    return '';
+  };
+
+  if (workOrders === null || workOrders?.length === 0) {
+    return <></>;
+  }
+
+  return workOrders.map((workOrder, index) => (
+    <MobileWorkingWorkOrderListItem
+      key={index}
+      workOrder={workOrder}
+      index={index}
+      statusText={(() => formatStatusText(workOrder.status))()}
+      currentUser={currentUser} />
+  ));
+};

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -11,10 +11,7 @@ import { WorkOrder } from '../../../models/workOrder'
 
 const SIXTY_SECONDS = 60 * 1000
 
-const MobileWorkingWorkOrdersView = ({
-  currentUser,
-  loggingEnabled = true,
-}) => {
+const MobileWorkingWorkOrdersView = ({ currentUser }) => {
   const currentDate = beginningOfDay(new Date())
   const [visitedWorkOrders, setVisitedWorkOrders] = useState(null)
   const [sortedWorkOrders, setSortedWorkOrders] = useState(null)
@@ -50,24 +47,6 @@ const MobileWorkingWorkOrdersView = ({
 
       setVisitedWorkOrders(visitedWorkOrders)
       setSortedWorkOrders(sortedWorkOrderItems)
-
-      const inProgressWorkOrderIds = inProgressWorkOrders.map(
-        (x) => x.reference
-      )
-      const startedWorkOrderIds = startedWorkOrders.map((x) => x.reference)
-      const currentWorkOrderId = currentUser.isOneJobAtATime
-        ? sortedWorkOrderItems
-        : null
-
-      if (loggingEnabled) {
-        logWorkOrders(
-          currentUser.operativePayrollNumber,
-          currentUser.isOneJobAtATime,
-          inProgressWorkOrderIds,
-          startedWorkOrderIds,
-          currentWorkOrderId
-        )
-      }
     } catch (e) {
       setVisitedWorkOrders(null)
       setSortedWorkOrders(null)
@@ -144,32 +123,6 @@ const MobileWorkingWorkOrdersView = ({
         )
       })
       .slice(0, 1)
-  }
-
-  const logWorkOrders = async (
-    operativeId,
-    ojaatEnabled,
-    inProgressWorkOrderIds,
-    startedWorkOrderIds,
-    currentWorkOrderId
-  ) => {
-    const body = {
-      operativeId,
-      ojaatEnabled,
-      inProgressWorkOrderIds,
-      startedWorkOrderIds,
-      currentWorkOrderId,
-    }
-
-    try {
-      await frontEndApiRequest({
-        method: 'post',
-        path: '/api/frontend-logging/operative-mobile-view-work-orders',
-        requestData: body,
-      })
-    } catch (error) {
-      // fail silently - user doesnt need to know if logging fails
-    }
   }
 
   return (

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -4,10 +4,10 @@ import { beginningOfDay } from '@/utils/time'
 import { longMonthWeekday } from '@/utils/date'
 import Spinner from '../../Spinner'
 import ErrorMessage from '../../Errors/ErrorMessage'
-import MobileWorkingWorkOrderListItem from '../../WorkOrder/MobileWorkingWorkOrderListItem'
 import WarningInfoBox from '../../Template/WarningInfoBox'
 import Meta from '../../Meta'
 import { WorkOrder } from '../../../models/workOrder'
+import { MobileWorkingWorkOrderListItems } from './MobileWorkingWorkOrderListItems'
 
 const SIXTY_SECONDS = 60 * 1000
 
@@ -65,32 +65,6 @@ const MobileWorkingWorkOrdersView = ({ currentUser }) => {
     }
   }, [currentUser?.operativePayrollNumber])
 
-  const renderWorkOrderListItems = (workOrders) => {
-    if (workOrders === null || workOrders?.length === 0) {
-      return <></>
-    }
-
-    return workOrders.map((workOrder, index) => (
-      <MobileWorkingWorkOrderListItem
-        key={index}
-        workOrder={workOrder}
-        index={index}
-        statusText={(() => {
-          const status = workOrder.status.toLowerCase()
-
-          if (status === 'no access') {
-            return 'No access'
-          } else if (status === 'completed') {
-            return 'Completed'
-          } else {
-            return ''
-          }
-        })()}
-        currentUser={currentUser}
-      />
-    ))
-  }
-
   const sortWorkOrderItems = (currentUser, workOrders) => {
     const inProgressWorkOrders = workOrders.filter((wo) => !wo.hasBeenVisited())
 
@@ -129,12 +103,12 @@ const MobileWorkingWorkOrdersView = ({ currentUser }) => {
       ) : (
         <>
           {sortedWorkOrders?.length || visitedWorkOrders?.length ? (
-            <>
-              <ol className="lbh-list mobile-working-work-order-list">
-                {renderWorkOrderListItems(sortedWorkOrders)}
-                {renderWorkOrderListItems(visitedWorkOrders)}
-              </ol>
-            </>
+            <ol className="lbh-list mobile-working-work-order-list">
+              <MobileWorkingWorkOrderListItems
+                workOrders={[...sortedWorkOrders, ...visitedWorkOrders]}
+                currentUser={currentUser}
+              />
+            </ol>
           ) : (
             <WarningInfoBox
               header="No work orders displayed"

--- a/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
+++ b/src/components/WorkOrders/MobileWorkingWorkOrdersView/MobileWorkingWorkOrdersView.js
@@ -28,22 +28,9 @@ const MobileWorkingWorkOrdersView = ({ currentUser }) => {
       })
 
       const workOrders = data.map((wo) => new WorkOrder(wo))
-
-      const inProgressWorkOrders = workOrders.filter(
-        (wo) => !wo.hasBeenVisited()
-      )
-
       const visitedWorkOrders = workOrders.filter((wo) => wo.hasBeenVisited())
 
-      const startedWorkOrders = workOrders.filter(
-        (wo) => !wo.hasBeenVisited() && !!wo.appointment.startedAt?.length
-      )
-
-      const sortedWorkOrderItems = sortWorkOrderItems(
-        currentUser,
-        inProgressWorkOrders,
-        startedWorkOrders
-      )
+      const sortedWorkOrderItems = sortWorkOrderItems(currentUser, workOrders)
 
       setVisitedWorkOrders(visitedWorkOrders)
       setSortedWorkOrders(sortedWorkOrderItems)
@@ -104,11 +91,13 @@ const MobileWorkingWorkOrdersView = ({ currentUser }) => {
     ))
   }
 
-  const sortWorkOrderItems = (
-    currentUser,
-    inProgressWorkOrders,
-    startedWorkOrders
-  ) => {
+  const sortWorkOrderItems = (currentUser, workOrders) => {
+    const inProgressWorkOrders = workOrders.filter((wo) => !wo.hasBeenVisited())
+
+    const startedWorkOrders = workOrders.filter(
+      (wo) => !wo.hasBeenVisited() && !!wo.appointment.startedAt?.length
+    )
+
     // The operative is NOT an OJAAT operative
     if (!currentUser.isOneJobAtATime) return inProgressWorkOrders
 


### PR DESCRIPTION
## Summary of Changes

The frontend logging feature didnt provide much value over the existing logging in the getWorkOrdersForOperative endpoint. This PR removes the api call to reduce the complexity of the component. 

Also did a bit of refactoring, as I got carried away.