### PR TITLE
👥 Update CODEOWNERS to Housing Product team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @LBHackney-IT/repairs-hub-frontend
+* @LBHackney-IT/housing-products


### PR DESCRIPTION
Following [the agreed ownership doc](https://docs.google.com/spreadsheets/d/1LgO0NIONzxwwHfmddC-Y8JPKbLHRlFqQITKfrIZ5GfU/edit#gid=0) this updates the owners from a deprecated group to belong to the Housing Product team.

Once this is merged we can delete the [repairs-hub-frontend](https://github.com/orgs/LBHackney-IT/teams/repairs-hub-frontend) team.
