### PR TITLE
Update follow-on trade values

### DIFF
--- a/cypress/integration/work-order/attend/close-by-proxy.spec.js
+++ b/cypress/integration/work-order/attend/close-by-proxy.spec.js
@@ -617,7 +617,7 @@ describe('Closing a work order on behalf of an operative', () => {
           isSameTrade: true,
           isDifferentTrades: true,
           isMultipleOperatives: false,
-          requiredFollowOnTrades: ['followon-trades-plumbing'],
+          requiredFollowOnTrades: ['Plumbing'],
           followOnTypeDescription: 'follow on description',
           stockItemsRequired: true,
           nonStockItemsRequired: false,

--- a/cypress/integration/work-order/attend/close.spec.js
+++ b/cypress/integration/work-order/attend/close.spec.js
@@ -286,7 +286,7 @@ describe('Closing my own work order', () => {
             isSameTrade: true,
             isDifferentTrades: true,
             isMultipleOperatives: false,
-            requiredFollowOnTrades: ['followon-trades-plumbing'],
+            requiredFollowOnTrades: ['Plumbing'],
             followOnTypeDescription: 'Blah blah blah',
             stockItemsRequired: true,
             nonStockItemsRequired: false,

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -128,8 +128,8 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
       const requiredFollowOnTrades = []
 
       if (data.isDifferentTrades) {
-        FOLLOW_ON_REQUEST_AVAILABLE_TRADES.forEach(({ name }) => {
-          if (data[name]) requiredFollowOnTrades.push(name)
+        FOLLOW_ON_REQUEST_AVAILABLE_TRADES.forEach(({ name, value }) => {
+          if (data[name]) requiredFollowOnTrades.push(value)
         })
       }
 

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -159,7 +159,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
 
       if (followOnData.isDifferentTrades) {
         requiredFollowOnTrades.push(
-          ...followOnData.requiredFollowOnTrades.map((x) => x.name)
+          ...followOnData.requiredFollowOnTrades.map((x) => x.value)
         )
       }
 

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.js
@@ -102,7 +102,7 @@ const SummaryCloseWorkOrder = ({
                           <li style={{ marginTop: '5px' }}>
                             Different trade(s) (
                             {followOnData.requiredFollowOnTrades
-                              .map((x) => x.label)
+                              .map((x) => x.value)
                               .join(', ')}
                             )
                           </li>

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.test.js
@@ -52,10 +52,10 @@ describe('SummaryCloseWorkOrder component', () => {
       isMultipleOperatives: true,
       requiredFollowOnTrades: [
         {
-          label: 'Plumbing',
+          value: 'Plumbing',
         },
-        { label: 'Electrical' },
-        { label: 'Other' },
+        { value: 'Electrical' },
+        { value: 'Other' },
       ],
       followOnTypeDescription:
         "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s",
@@ -89,10 +89,10 @@ describe('SummaryCloseWorkOrder component', () => {
       isMultipleOperatives: true,
       requiredFollowOnTrades: [
         {
-          label: 'Plumbing',
+          value: 'Plumbing',
         },
-        { label: 'Electrical' },
-        { label: 'Other' },
+        { value: 'Electrical' },
+        { value: 'Other' },
       ],
       followOnTypeDescription:
         "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s",

--- a/src/utils/statusCodes.js
+++ b/src/utils/statusCodes.js
@@ -57,17 +57,32 @@ export const FOLLOW_ON_STATUS_OPTIONS = [
   },
 ]
 
+// Value: value stored in DB
+// Name: form field name
+// Label: form field label
 export const FOLLOW_ON_REQUEST_AVAILABLE_TRADES = [
-  { name: 'followon-trades-carpentry', label: 'Carpentry' },
-  { name: 'followon-trades-drainage', label: 'Drainage' },
-  { name: 'followon-trades-gas', label: 'Gas' },
-  { name: 'followon-trades-electrical', label: 'Electrical' },
-  { name: 'followon-trades-multitrade', label: 'Multitrade' },
-  { name: 'followon-trades-painting', label: 'Painting' },
-  { name: 'followon-trades-plumbing', label: 'Plumbing' },
-  { name: 'followon-trades-roofing', label: 'Roofing' },
-  { name: 'followon-trades-UPVC', label: 'UPVC' },
-  { name: 'followon-trades-other', label: 'Other (please specify)' },
+  { name: 'followon-trades-carpentry', label: 'Carpentry', value: 'Carpentry' },
+  { name: 'followon-trades-drainage', label: 'Drainage', value: 'Drainage' },
+  { name: 'followon-trades-gas', label: 'Gas', value: 'Gas' },
+  {
+    name: 'followon-trades-electrical',
+    label: 'Electrical',
+    value: 'Electrical',
+  },
+  {
+    name: 'followon-trades-multitrade',
+    label: 'Multitrade',
+    value: 'Multitrade',
+  },
+  { name: 'followon-trades-painting', label: 'Painting', value: 'Painting' },
+  { name: 'followon-trades-plumbing', label: 'Plumbing', value: 'Plumbing' },
+  { name: 'followon-trades-roofing', label: 'Roofing', value: 'Roofing' },
+  { name: 'followon-trades-UPVC', label: 'UPVC', value: 'UPVC' },
+  {
+    name: 'followon-trades-other',
+    label: 'Other (please specify)',
+    value: 'Other',
+  },
 ]
 
 export const WORK_ORDERS_STATUSES = [


### PR DESCRIPTION
## Summary of Changes

Currently, the field names for additional trades are being sent to the db (eg. `followon-trades-plumbing`). This PR adds a value property to the `FOLLOW_ON_REQUEST_AVAILABLE_TRADES` array, containing a more readable value to be stored in the DB. 