### PR TITLE
Add media types for file upload

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,6 +11,9 @@ provider:
   lambdaHashingVersion: 20201221
   apiGateway:
     shouldStartNameWithService: true
+    binaryMediaTypes:
+      - image/jpg
+      - multipart/form-data
 
 package:
   individually: true


### PR DESCRIPTION
## Summary of changes

Cant upload files to S3 because API gateway doesnt accept the file binary. 