### PR TITLE
Fix date issue on work order notes

### DIFF
--- a/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.test.js
+++ b/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.test.js
@@ -4,7 +4,7 @@ import CompletedNoteContent from '.'
 describe('CompletedNoteContent component', () => {
   it('should match snapshot when user comment is empty', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Bonus',
       operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
     }
@@ -19,7 +19,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when user comment is not empty', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Bonus',
       operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
     }
@@ -34,7 +34,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when no operative', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Bonus',
       operatives: [],
     }
@@ -49,7 +49,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when one operative', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Bonus',
       operatives: [{ name: 'Operative Name', jobPercentage: 50 }],
     }
@@ -64,7 +64,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when multiple operatives', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Bonus',
       operatives: [
         { name: 'Operative One', jobPercentage: 50 },
@@ -82,7 +82,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when payment type is Bonus', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Bonus',
       operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
     }
@@ -97,7 +97,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when payment type is Close to Base', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'CloseToBase',
       operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
     }
@@ -112,7 +112,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when payment type is Overtime', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Overtime',
       operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
     }
@@ -127,7 +127,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when payment type is null', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: null,
       operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
     }
@@ -143,7 +143,7 @@ describe('CompletedNoteContent component', () => {
   describe('When further work is required', () => {
     it('should show the type of work', () => {
       const workOrder = {
-        closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+        closedDated: '2024-09-26T12:34:56',
         paymentType: null,
         operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
         followOnRequest: {
@@ -170,7 +170,7 @@ describe('CompletedNoteContent component', () => {
 
     it('should show materials', () => {
       const workOrder = {
-        closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+        closedDated: '2024-09-26T12:34:56',
         paymentType: null,
         operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
         followOnRequest: {
@@ -197,7 +197,7 @@ describe('CompletedNoteContent component', () => {
 
     it('should show additional notes', () => {
       const workOrder = {
-        closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+        closedDated: '2024-09-26T12:34:56',
         paymentType: null,
         operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
         followOnRequest: {

--- a/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.test.js
+++ b/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.test.js
@@ -142,7 +142,7 @@ describe('CompletedNoteContent component', () => {
 
   it('should match snapshot when user has uploaded photos', () => {
     const workOrder = {
-      closedDate: new Date('2024-09-26T12:34:56'), // Replace with actual date fixture
+      closedDated: '2024-09-26T12:34:56',
       paymentType: 'Bonus',
       operatives: [{ name: 'Operative Name', jobPercentage: 100 }],
       uploadedFileCount: {

--- a/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.tsx
+++ b/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const CompletedNoteContent = ({ note, workOrder }: Props) => {
   const completionDate = new Date(workOrder.closedDated)
-  
+
   const statusMessage = generateMessage(
     note.note,
     completionDate,

--- a/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.tsx
+++ b/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.tsx
@@ -7,9 +7,11 @@ interface Props {
 }
 
 const CompletedNoteContent = ({ note, workOrder }: Props) => {
+  const completionDate = new Date(workOrder.closedDated)
+  
   const statusMessage = generateMessage(
     note.note,
-    workOrder.closedDate,
+    completionDate,
     workOrder.operatives,
     workOrder.paymentType
   )

--- a/src/components/WorkOrder/Notes/NoteEntry.test.js
+++ b/src/components/WorkOrder/Notes/NoteEntry.test.js
@@ -53,7 +53,7 @@ describe('NoteEntry component', () => {
         otherType: 'completed',
       },
       workOrder: {
-        closedDate: new Date('2021-01-23T16:28:57.17811'),
+        closedDated: '2021-01-23T16:28:57.17811',
         operatives: [
           {
             name: 'Steve',

--- a/src/components/WorkOrder/Notes/types.ts
+++ b/src/components/WorkOrder/Notes/types.ts
@@ -10,7 +10,7 @@ export type Note = {
 }
 
 export type WorkOrderRequest = {
-  closedDate: Date
+  closedDated: string
   paymentType: string
   operatives: {
     name: string


### PR DESCRIPTION
### Description of change

The closedDate property from getWorkOrder endpoint is actually spelled `closedDated`. 

This caused the date to be missing from the note.
