### PR TITLE
Add photo validation prompt to mobile close work order form

### DIFF
--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -501,15 +501,14 @@ describe('Closing my own work order', () => {
         // assert error messages arent visible yet
         cy.contains('Please select the type of work').should('not.exist')
         cy.contains('Please describe the work completed').should('not.exist')
-
-        // add follow on details
-        cy.contains('button', 'Add details').click()
       })
 
-      cy.get('form').within(() => {
-        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-        cy.contains('button', 'Add details').click()
+      // add follow on details
+      cy.contains('button', 'Add details').click()
+      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+      cy.contains('button', 'Add details').click()
 
+      cy.get('form').within(() => {
         // close work order
         cy.get('[type="submit"]').contains('Close work order').click()
 
@@ -592,15 +591,14 @@ describe('Closing my own work order', () => {
             cy.contains('label', 'Visit completed').click()
             cy.contains('label', 'Further work required').click()
           })
-
-        // add follow-on details
-        cy.contains('button', 'Add details').click()
       })
+
+      // add follow-on details
+      cy.contains('button', 'Add details').click()
       cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+      cy.contains('button', 'Add details').click()
 
       cy.get('form').within(() => {
-        cy.contains('button', 'Add details').click()
-
         cy.get('.govuk-button').contains('Close work order').click()
 
         // populate follow-on fields

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -490,65 +490,72 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      // cy.get('form').within(() => {
-      cy.contains('Reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'Further work required').click()
-        })
+      cy.get('form').within(() => {
+        cy.contains('Reason for closing')
+          .parent()
+          .within(() => {
+            cy.contains('label', 'Visit completed').click()
+            cy.contains('label', 'Further work required').click()
+          })
 
-      // assert error messages arent visible yet
-      cy.contains('Please select the type of work').should('not.exist')
-      cy.contains('Please describe the work completed').should('not.exist')
+        // assert error messages arent visible yet
+        cy.contains('Please select the type of work').should('not.exist')
+        cy.contains('Please describe the work completed').should('not.exist')
 
-      // add follow on details
-      cy.contains('button', 'Add details').click()
-      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-      cy.contains('button', 'Add details').click()
+        // add follow on details
+        cy.contains('button', 'Add details').click()
+      })
 
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
+      cy.get('form').within(() => {
+        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+        cy.contains('button', 'Add details').click()
 
-      // assert error messages visible
-      cy.contains('Please select the type of work')
-      cy.contains('Please describe the work completed')
+        // close work order
+        cy.get('[type="submit"]').contains('Close work order').click()
 
-      // select an option - error should disappear
-      cy.get('input[data-testid="isSameTrade"]').check()
-      cy.contains('Please select the type of work').should('not.exist')
+        // assert error messages visible
+        cy.contains('Please select the type of work')
+        cy.contains('Please describe the work completed')
 
-      // select different trade(s) - error should appear
-      cy.get('input[data-testid="isDifferentTrades"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please select at least one trade')
+        // select an option - error should disappear
+        cy.get('input[data-testid="isSameTrade"]').check()
+        cy.contains('Please select the type of work').should('not.exist')
 
-      // select a trade - error should disappear
-      cy.get('input[data-testid="followon-trades-plumbing"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please select at least one trade').should('not.exist')
+        // select different trade(s) - error should appear
+        cy.get('input[data-testid="isDifferentTrades"]').check()
+        cy.get('[type="submit"]').contains('Close work order').click()
+        cy.contains('Please select at least one trade')
 
-      // add description of work - error should disappear
-      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-        'Blah blah blah'
-      )
-      cy.contains('Please describe the work completed').should('not.exist')
+        // select a trade - error should disappear
+        cy.get('input[data-testid="followon-trades-plumbing"]').check()
+        cy.get('[type="submit"]').contains('Close work order').click()
+        cy.contains('Please select at least one trade').should('not.exist')
 
-      // when one of the material options is selected, the description must not be empty
-      cy.get('input[data-testid="stockItemsRequired"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please describe the materials required')
+        // add description of work - error should disappear
+        cy.get('textarea[data-testid="followOnTypeDescription"]').type(
+          'Blah blah blah'
+        )
+        cy.contains('Please describe the work completed').should('not.exist')
 
-      // Adding a description - error should disappear
-      cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
-      cy.contains('Please describe the materials required').should('not.exist')
+        // when one of the material options is selected, the description must not be empty
+        cy.get('input[data-testid="stockItemsRequired"]').check()
+        cy.get('[type="submit"]').contains('Close work order').click()
+        cy.contains('Please describe the materials required')
 
-      // additional notes
-      cy.get('textarea[data-testid="additionalNotes"]').type('Additional notes')
+        // Adding a description - error should disappear
+        cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
+        cy.contains('Please describe the materials required').should(
+          'not.exist'
+        )
 
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-      // })
+        // additional notes
+        cy.get('textarea[data-testid="additionalNotes"]').type(
+          'Additional notes'
+        )
+
+        // close work order
+        cy.get('[type="submit"]').contains('Close work order').click()
+      })
 
       // check for confirmation message
       cy.contains('Work order 10000621 successfully closed')
@@ -578,38 +585,41 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      // cy.get('form').within(() => {
-      cy.contains('Reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'Further work required').click()
-        })
+      cy.get('form').within(() => {
+        cy.contains('Reason for closing')
+          .parent()
+          .within(() => {
+            cy.contains('label', 'Visit completed').click()
+            cy.contains('label', 'Further work required').click()
+          })
 
-      // add follow-on details
-      cy.contains('button', 'Add details').click()
+        // add follow-on details
+        cy.contains('button', 'Add details').click()
+      })
       cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-      cy.contains('button', 'Add details').click()
 
-      cy.get('.govuk-button').contains('Close work order').click()
+      cy.get('form').within(() => {
+        cy.contains('button', 'Add details').click()
 
-      // populate follow-on fields
+        cy.get('.govuk-button').contains('Close work order').click()
 
-      cy.get('input[data-testid="isSameTrade"]').check()
-      cy.get('input[data-testid="isDifferentTrades"]').check()
-      cy.get('input[data-testid="followon-trades-plumbing"]').check()
-      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-        'follow on description'
-      )
-      cy.get('input[data-testid="stockItemsRequired"]').check()
-      cy.get('textarea[data-testid="materialNotes"]').type('material notes')
-      cy.get('textarea[data-testid="additionalNotes"]').type(
-        'Additional notes desc'
-      )
+        // populate follow-on fields
 
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-      // })
+        cy.get('input[data-testid="isSameTrade"]').check()
+        cy.get('input[data-testid="isDifferentTrades"]').check()
+        cy.get('input[data-testid="followon-trades-plumbing"]').check()
+        cy.get('textarea[data-testid="followOnTypeDescription"]').type(
+          'follow on description'
+        )
+        cy.get('input[data-testid="stockItemsRequired"]').check()
+        cy.get('textarea[data-testid="materialNotes"]').type('material notes')
+        cy.get('textarea[data-testid="additionalNotes"]').type(
+          'Additional notes desc'
+        )
+
+        // close work order
+        cy.get('[type="submit"]').contains('Close work order').click()
+      })
 
       cy.wait('@workOrderCompleteRequest')
 

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -601,8 +601,8 @@ describe('Closing my own work order', () => {
 
       // add follow-on details
       cy.contains('button', 'Add details').click()
-      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-      cy.contains('button', 'Add details').click()
+      // cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+      // cy.contains('button', 'Add details').click()
 
       cy.get('form').within(() => {
         cy.get('.govuk-button').contains('Close work order').click()

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -314,8 +314,6 @@ describe('Closing my own work order', () => {
       })
 
       cy.get('.govuk-button').contains('Close work order').click()
-      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-      cy.get('.govuk-button').contains('Close work order').click()
 
       cy.waitFor('@getLinksRequest')
       cy.waitFor('@uploadToS3Request')
@@ -492,69 +490,65 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      cy.get('form').within(() => {
-        cy.contains('Reason for closing')
-          .parent()
-          .within(() => {
-            cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'Further work required').click()
-          })
+      // cy.get('form').within(() => {
+      cy.contains('Reason for closing')
+        .parent()
+        .within(() => {
+          cy.contains('label', 'Visit completed').click()
+          cy.contains('label', 'Further work required').click()
+        })
 
-        // assert error messages arent visible yet
-        cy.contains('Please select the type of work').should('not.exist')
-        cy.contains('Please describe the work completed').should('not.exist')
+      // assert error messages arent visible yet
+      cy.contains('Please select the type of work').should('not.exist')
+      cy.contains('Please describe the work completed').should('not.exist')
 
-        // add follow on details
-        cy.contains('button', 'Add details').click()
+      // add follow on details
+      cy.contains('button', 'Add details').click()
+      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+      cy.contains('button', 'Add details').click()
 
-        // close work order
-        cy.get('[type="submit"]').contains('Close work order').click()
+      // close work order
+      cy.get('[type="submit"]').contains('Close work order').click()
 
-        // assert error messages visible
-        cy.contains('Please select the type of work')
-        cy.contains('Please describe the work completed')
+      // assert error messages visible
+      cy.contains('Please select the type of work')
+      cy.contains('Please describe the work completed')
 
-        // select an option - error should disappear
-        cy.get('input[data-testid="isSameTrade"]').check()
-        cy.contains('Please select the type of work').should('not.exist')
+      // select an option - error should disappear
+      cy.get('input[data-testid="isSameTrade"]').check()
+      cy.contains('Please select the type of work').should('not.exist')
 
-        // select different trade(s) - error should appear
-        cy.get('input[data-testid="isDifferentTrades"]').check()
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.contains('Please select at least one trade')
+      // select different trade(s) - error should appear
+      cy.get('input[data-testid="isDifferentTrades"]').check()
+      cy.get('[type="submit"]').contains('Close work order').click()
+      cy.contains('Please select at least one trade')
 
-        // select a trade - error should disappear
-        cy.get('input[data-testid="followon-trades-plumbing"]').check()
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.contains('Please select at least one trade').should('not.exist')
+      // select a trade - error should disappear
+      cy.get('input[data-testid="followon-trades-plumbing"]').check()
+      cy.get('[type="submit"]').contains('Close work order').click()
+      cy.contains('Please select at least one trade').should('not.exist')
 
-        // add description of work - error should disappear
-        cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-          'Blah blah blah'
-        )
-        cy.contains('Please describe the work completed').should('not.exist')
+      // add description of work - error should disappear
+      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
+        'Blah blah blah'
+      )
+      cy.contains('Please describe the work completed').should('not.exist')
 
-        // when one of the material options is selected, the description must not be empty
-        cy.get('input[data-testid="stockItemsRequired"]').check()
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.contains('Please describe the materials required')
+      // when one of the material options is selected, the description must not be empty
+      cy.get('input[data-testid="stockItemsRequired"]').check()
+      cy.get('[type="submit"]').contains('Close work order').click()
+      cy.contains('Please describe the materials required')
 
-        // Adding a description - error should disappear
-        cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
-        cy.contains('Please describe the materials required').should(
-          'not.exist'
-        )
+      // Adding a description - error should disappear
+      cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
+      cy.contains('Please describe the materials required').should('not.exist')
 
-        // additional notes
-        cy.get('textarea[data-testid="additionalNotes"]').type(
-          'Additional notes'
-        )
+      // additional notes
+      cy.get('textarea[data-testid="additionalNotes"]').type('Additional notes')
 
-        // close work order
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-        cy.get('.govuk-button').contains('Close work order').click()
-      })
+      // close work order
+      cy.get('[type="submit"]').contains('Close work order').click()
+      // })
 
       // check for confirmation message
       cy.contains('Work order 10000621 successfully closed')
@@ -584,36 +578,38 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      cy.get('form').within(() => {
-        cy.contains('Reason for closing')
-          .parent()
-          .within(() => {
-            cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'Further work required').click()
-          })
+      // cy.get('form').within(() => {
+      cy.contains('Reason for closing')
+        .parent()
+        .within(() => {
+          cy.contains('label', 'Visit completed').click()
+          cy.contains('label', 'Further work required').click()
+        })
 
-        // add follow-on details
-        cy.contains('button', 'Add details').click()
+      // add follow-on details
+      cy.contains('button', 'Add details').click()
+      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+      cy.contains('button', 'Add details').click()
 
-        // populate follow-on fields
+      cy.get('.govuk-button').contains('Close work order').click()
 
-        cy.get('input[data-testid="isSameTrade"]').check()
-        cy.get('input[data-testid="isDifferentTrades"]').check()
-        cy.get('input[data-testid="followon-trades-plumbing"]').check()
-        cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-          'follow on description'
-        )
-        cy.get('input[data-testid="stockItemsRequired"]').check()
-        cy.get('textarea[data-testid="materialNotes"]').type('material notes')
-        cy.get('textarea[data-testid="additionalNotes"]').type(
-          'Additional notes desc'
-        )
+      // populate follow-on fields
 
-        // close work order
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-        cy.get('.govuk-button').contains('Close work order').click()
-      })
+      cy.get('input[data-testid="isSameTrade"]').check()
+      cy.get('input[data-testid="isDifferentTrades"]').check()
+      cy.get('input[data-testid="followon-trades-plumbing"]').check()
+      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
+        'follow on description'
+      )
+      cy.get('input[data-testid="stockItemsRequired"]').check()
+      cy.get('textarea[data-testid="materialNotes"]').type('material notes')
+      cy.get('textarea[data-testid="additionalNotes"]').type(
+        'Additional notes desc'
+      )
+
+      // close work order
+      cy.get('[type="submit"]').contains('Close work order').click()
+      // })
 
       cy.wait('@workOrderCompleteRequest')
 
@@ -733,7 +729,6 @@ describe('Closing my own work order', () => {
         cy.contains('label', 'No further work required').click()
 
         cy.get('.govuk-button').contains('Close work order').click()
-
         cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
         cy.get('.govuk-button').contains('Close work order').click()
 

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -314,6 +314,8 @@ describe('Closing my own work order', () => {
       })
 
       cy.get('.govuk-button').contains('Close work order').click()
+      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+      cy.get('.govuk-button').contains('Close work order').click()
 
       cy.waitFor('@getLinksRequest')
       cy.waitFor('@uploadToS3Request')
@@ -349,6 +351,8 @@ describe('Closing my own work order', () => {
 
       cy.get('#notes').type('I attended')
 
+      cy.get('.govuk-button').contains('Close work order').click()
+      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
       cy.get('.govuk-button').contains('Close work order').click()
 
       cy.wait('@workOrderCompleteRequest')
@@ -412,6 +416,8 @@ describe('Closing my own work order', () => {
 
       cy.get('#notes').type('I attended')
 
+      cy.get('.govuk-button').contains('Close work order').click()
+      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
       cy.get('.govuk-button').contains('Close work order').click()
 
       cy.wait('@workOrderCompleteRequest')
@@ -546,6 +552,8 @@ describe('Closing my own work order', () => {
 
         // close work order
         cy.get('[type="submit"]').contains('Close work order').click()
+        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+        cy.get('.govuk-button').contains('Close work order').click()
       })
 
       // check for confirmation message
@@ -603,6 +611,8 @@ describe('Closing my own work order', () => {
 
         // close work order
         cy.get('[type="submit"]').contains('Close work order').click()
+        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+        cy.get('.govuk-button').contains('Close work order').click()
       })
 
       cy.wait('@workOrderCompleteRequest')
@@ -648,6 +658,9 @@ describe('Closing my own work order', () => {
 
         cy.get('.lbh-radios input[data-testid="reason"]').check('No Access') // Checking by value, not text
 
+        cy.get('.govuk-button').contains('Close work order').click()
+
+        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
         cy.get('.govuk-button').contains('Close work order').click()
 
         cy.wait('@workOrderCompleteRequest')
@@ -721,6 +734,9 @@ describe('Closing my own work order', () => {
 
         cy.get('.govuk-button').contains('Close work order').click()
 
+        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+        cy.get('.govuk-button').contains('Close work order').click()
+
         cy.wait('@workOrderCompleteRequest')
 
         cy.get('@workOrderCompleteRequest')
@@ -789,6 +805,9 @@ describe('Closing my own work order', () => {
         ) // Checking by value, not text
         cy.contains('label', 'No further work required').click()
 
+        cy.get('.govuk-button').contains('Close work order').click()
+
+        cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
         cy.get('.govuk-button').contains('Close work order').click()
 
         cy.wait('@workOrderCompleteRequest')

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -496,71 +496,63 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      cy.get('form').within(() => {
-        cy.contains('Reason for closing')
-          .parent()
-          .within(() => {
-            cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'Further work required').click()
-          })
+      cy.contains('Reason for closing')
+        .parent()
+        .within(() => {
+          cy.contains('label', 'Visit completed').click()
+          cy.contains('label', 'Further work required').click()
+        })
 
-        // assert error messages arent visible yet
-        cy.contains('Please select the type of work').should('not.exist')
-        cy.contains('Please describe the work completed').should('not.exist')
-      })
+      // assert error messages arent visible yet
+      cy.contains('Please select the type of work').should('not.exist')
+      cy.contains('Please describe the work completed').should('not.exist')
 
       // add follow on details
       cy.contains('button', 'Add details').click()
       cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
       cy.contains('button', 'Add details').click()
 
-      cy.get('form').within(() => {
-        // close work order
-        cy.get('[type="submit"]').contains('Close work order').click()
+      // close work order
+      cy.get('[type="submit"]').contains('Close work order').click()
 
-        // assert error messages visible
-        cy.contains('Please select the type of work')
-        cy.contains('Please describe the work completed')
+      // assert error messages visible
+      cy.contains('Please select the type of work')
+      cy.contains('Please describe the work completed')
 
-        // select an option - error should disappear
-        cy.get('input[data-testid="isSameTrade"]').check()
-        cy.contains('Please select the type of work').should('not.exist')
+      // select an option - error should disappear
+      cy.get('input[data-testid="isSameTrade"]').check()
+      cy.contains('Please select the type of work').should('not.exist')
 
-        // select different trade(s) - error should appear
-        cy.get('input[data-testid="isDifferentTrades"]').check()
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.contains('Please select at least one trade')
+      // select different trade(s) - error should appear
+      cy.get('input[data-testid="isDifferentTrades"]').check()
+      cy.get('[type="submit"]').contains('Close work order').click()
+      cy.contains('Please select at least one trade')
 
-        // select a trade - error should disappear
-        cy.get('input[data-testid="followon-trades-plumbing"]').check()
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.contains('Please select at least one trade').should('not.exist')
+      // select a trade - error should disappear
+      cy.get('input[data-testid="followon-trades-plumbing"]').check()
+      cy.get('[type="submit"]').contains('Close work order').click()
+      cy.contains('Please select at least one trade').should('not.exist')
 
-        // add description of work - error should disappear
-        cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-          'Blah blah blah'
-        )
-        cy.contains('Please describe the work completed').should('not.exist')
+      // add description of work - error should disappear
+      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
+        'Blah blah blah'
+      )
+      cy.contains('Please describe the work completed').should('not.exist')
 
-        // when one of the material options is selected, the description must not be empty
-        cy.get('input[data-testid="stockItemsRequired"]').check()
-        cy.get('[type="submit"]').contains('Close work order').click()
-        cy.contains('Please describe the materials required')
+      // when one of the material options is selected, the description must not be empty
+      cy.get('input[data-testid="stockItemsRequired"]').check()
+      cy.get('[type="submit"]').contains('Close work order').click()
+      cy.contains('Please describe the materials required')
 
-        // Adding a description - error should disappear
-        cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
-        cy.contains('Please describe the materials required').should(
-          'not.exist'
-        )
+      // Adding a description - error should disappear
+      cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
+      cy.contains('Please describe the materials required').should('not.exist')
 
-        // additional notes
-        cy.get('textarea[data-testid="additionalNotes"]').type(
-          'Additional notes'
-        )
+      // additional notes
+      cy.get('textarea[data-testid="additionalNotes"]').type('Additional notes')
 
-        // close work order
-        cy.get('[type="submit"]').contains('Close work order').click()
-      })
+      // close work order
+      cy.get('[type="submit"]').contains('Close work order').click()
 
       // check for confirmation message
       cy.contains('Work order 10000621 successfully closed')
@@ -590,40 +582,36 @@ describe('Closing my own work order', () => {
 
       cy.contains('button', 'Confirm').click()
 
-      cy.get('form').within(() => {
-        cy.contains('Reason for closing')
-          .parent()
-          .within(() => {
-            cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'Further work required').click()
-          })
-      })
+      cy.contains('Reason for closing')
+        .parent()
+        .within(() => {
+          cy.contains('label', 'Visit completed').click()
+          cy.contains('label', 'Further work required').click()
+        })
 
       // add follow-on details
       cy.contains('button', 'Add details').click()
-      // cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-      // cy.contains('button', 'Add details').click()
+      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
+      cy.contains('button', 'Add details').click()
 
-      cy.get('form').within(() => {
-        cy.get('.govuk-button').contains('Close work order').click()
+      cy.get('.govuk-button').contains('Close work order').click()
 
-        // populate follow-on fields
+      // populate follow-on fields
 
-        cy.get('input[data-testid="isSameTrade"]').check()
-        cy.get('input[data-testid="isDifferentTrades"]').check()
-        cy.get('input[data-testid="followon-trades-plumbing"]').check()
-        cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-          'follow on description'
-        )
-        cy.get('input[data-testid="stockItemsRequired"]').check()
-        cy.get('textarea[data-testid="materialNotes"]').type('material notes')
-        cy.get('textarea[data-testid="additionalNotes"]').type(
-          'Additional notes desc'
-        )
+      cy.get('input[data-testid="isSameTrade"]').check()
+      cy.get('input[data-testid="isDifferentTrades"]').check()
+      cy.get('input[data-testid="followon-trades-plumbing"]').check()
+      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
+        'follow on description'
+      )
+      cy.get('input[data-testid="stockItemsRequired"]').check()
+      cy.get('textarea[data-testid="materialNotes"]').type('material notes')
+      cy.get('textarea[data-testid="additionalNotes"]').type(
+        'Additional notes desc'
+      )
 
-        // close work order
-        cy.get('[type="submit"]').contains('Close work order').click()
-      })
+      // close work order
+      cy.get('[type="submit"]').contains('Close work order').click()
 
       cy.wait('@workOrderCompleteRequest')
 

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -1,6 +1,12 @@
 /// <reference types="cypress" />
 import 'cypress-audit/commands'
 
+Cypress.on('uncaught:exception', (err, runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})
+
 describe('Closing my own work order', () => {
   const now = new Date('Friday June 11 2021 13:49:15Z')
   const workOrderReference = '10000621'

--- a/src/components/Form/CheckboxSmall/index.js
+++ b/src/components/Form/CheckboxSmall/index.js
@@ -1,0 +1,82 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+
+const CheckboxSmall = ({
+  label,
+  name,
+  register,
+  error,
+  checked,
+  className,
+  hidden,
+  labelClassName,
+  hintText,
+  children,
+  showChildren,
+  size = 'LARGE',
+  ...otherProps
+}) => (
+  <div
+    className="govuk-checkboxes--small"
+    style={{
+      overflow: 'auto',
+      paddingLeft: '10px',
+    }}
+  >
+    <div
+      className={cx(`govuk-checkboxes__item ${className}`, {
+        'govuk-!-display-none': hidden,
+      })}
+    >
+      <input
+        className={cx('govuk-checkboxes__input', {
+          'govuk-input--error': error,
+        })}
+        id={name}
+        name={name}
+        type="checkbox"
+        ref={register}
+        data-testid={name}
+        {...(checked && { defaultChecked: checked })}
+        {...otherProps}
+      />
+      <label
+        className={cx('govuk-label govuk-checkboxes__label', labelClassName)}
+        htmlFor={name}
+      >
+        {label}
+      </label>
+      {hintText && (
+        <span
+          id="government-gateway-item-hint"
+          className="govuk-hint govuk-checkboxes__hint lbh-hint"
+        >
+          {hintText}
+        </span>
+      )}
+
+      {children !== null && children !== undefined && showChildren && (
+        <div
+          style={{
+            marginLeft: '18px',
+            paddingLeft: '33px',
+            borderLeft: `4px solid ${error ? '#be3a34' : '#b1b4b6'}`,
+          }}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  </div>
+)
+
+CheckboxSmall.propTypes = {
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  name: PropTypes.string.isRequired,
+  register: PropTypes.func.isRequired,
+  error: PropTypes.shape({ message: PropTypes.string.isRequired }),
+  labelClassName: PropTypes.string,
+  hintText: PropTypes.string,
+}
+
+export default CheckboxSmall

--- a/src/components/Form/CheckboxSmall/index.test.js
+++ b/src/components/Form/CheckboxSmall/index.test.js
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react'
+import CheckboxSmall from '.'
+
+describe('CheckboxSmall', () => {
+  it('renders a checkbox', () => {
+    const checkboxName = 'my-checkbox'
+    const checkboxLabel = 'My Checkbox'
+    const { getByLabelText } = render(
+      <CheckboxSmall
+        name={checkboxName}
+        label={checkboxLabel}
+        register={jest.fn()}
+      />
+    )
+
+    const checkbox = getByLabelText(checkboxLabel)
+
+    expect(checkbox).toBeInTheDocument()
+    expect(checkbox.id).toEqual(checkboxName)
+    expect(checkbox.name).toEqual(checkboxName)
+  })
+})

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
@@ -46,8 +46,14 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
   // So we dont show the error immediately
   const [photosTouched, setPhotosTouched] = useState(false)
 
-  const viewFollowOnDetailsPage = () => {
-    trigger(FIELD_NAMES_ON_FIRST_PAGE)
+  const viewFollowOnDetailsPage = (e) => {
+    e.preventDefault()
+
+    try {
+      trigger(FIELD_NAMES_ON_FIRST_PAGE)
+    } catch (e) {
+      console.error('Trigger failed', e)
+    }
 
     if (Object.keys(errors).length > 0) return
 

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
@@ -16,6 +16,13 @@ const PAGES = {
   FOLLOW_ON_DETAILS: '2',
 }
 
+const FIELD_NAMES_ON_FIRST_PAGE = [
+  'reason',
+  'followOnStatus',
+  'fileUpload',
+  'description',
+]
+
 const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
   const {
     handleSubmit,
@@ -25,6 +32,7 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
     clearErrors,
     watch,
     getValues,
+    trigger,
   } = useForm({
     shouldUnregister: false,
   })
@@ -39,6 +47,16 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
   const [photosTouched, setPhotosTouched] = useState(false)
 
   const viewFollowOnDetailsPage = () => {
+    trigger(FIELD_NAMES_ON_FIRST_PAGE)
+
+    if (Object.keys(errors).length > 0) return
+
+    // validate file uploaded
+    if (files.length === 0 && !closeWithoutPhotos) {
+      // user must confirm submit without photos
+      return
+    }
+
     setCurrentPage(PAGES.FOLLOW_ON_DETAILS)
   }
 

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
@@ -46,14 +46,8 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
   // So we dont show the error immediately
   const [photosTouched, setPhotosTouched] = useState(false)
 
-  const viewFollowOnDetailsPage = (e) => {
-    e.preventDefault()
-
-    try {
-      trigger(FIELD_NAMES_ON_FIRST_PAGE)
-    } catch (e) {
-      console.error('Trigger failed', e)
-    }
+  const viewFollowOnDetailsPage = () => {
+    trigger(FIELD_NAMES_ON_FIRST_PAGE)
 
     if (Object.keys(errors).length > 0) return
 

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
@@ -9,6 +9,7 @@ import FollowOnRequestTypeOfWorkForm from './CloseWorkOrderFormComponents/Follow
 import CloseWorkOrderFormReasonForClosing from './CloseWorkOrderFormComponents/CloseWorkOrderFormReasonForClosing'
 import validateFileUpload from '../WorkOrder/Photos/hooks/validateFileUpload'
 import ControlledFileInput from '../WorkOrder/Photos/ControlledFileInput'
+import CheckboxSmall from '../Form/CheckboxSmall'
 
 const PAGES = {
   WORK_ORDER_STATUS: '1',
@@ -33,6 +34,10 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
 
   const [currentPage, setCurrentPage] = useState(PAGES.WORK_ORDER_STATUS)
 
+  const [closeWithoutPhotos, setCloseWithoutPhotos] = useState(false)
+  // So we dont show the error immediately
+  const [photosTouched, setPhotosTouched] = useState(false)
+
   const viewFollowOnDetailsPage = () => {
     setCurrentPage(PAGES.FOLLOW_ON_DETAILS)
   }
@@ -56,7 +61,14 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
 
       <form
         role="form"
-        onSubmit={handleSubmit((data) => onSubmit(data, files))}
+        onSubmit={handleSubmit((data) => {
+          if (files.length === 0 && !closeWithoutPhotos) {
+            // user must confirm submit without photos
+            return
+          }
+
+          onSubmit(data, files)
+        })}
       >
         <div
           style={{
@@ -79,6 +91,8 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
               isLoading={isLoading}
               register={register('fileUpload', {
                 validate: () => {
+                  setPhotosTouched(true)
+
                   const validation = validateFileUpload(files)
 
                   if (validation === null) return true
@@ -94,6 +108,34 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
                 showAsOptional
                 register={register}
               />
+            )}
+
+            {files.length === 0 && photosTouched && (
+              <div className="lbh-page-announcement lbh-page-announcement--warning">
+                <h3 className="lbh-page-announcement__title">
+                  No photos were selected
+                </h3>
+                <div className="lbh-page-announcement__content">
+                  <div>
+                    {' '}
+                    Adding photos will help improve the identification of
+                    follow-ons required and reduce errors.
+                  </div>
+
+                  <div style={{ marginTop: '30px !important' }}>
+                    <CheckboxSmall
+                      className="govuk-!-margin-0"
+                      labelClassName="lbh-body-xs govuk-!-margin-0 govuk-!-margin-bottom-5"
+                      name={'closeWorkOrderWithoutPhotos'}
+                      label={'I want to close the work order without photos'}
+                      onChange={() => {
+                        setCloseWithoutPhotos(() => !closeWithoutPhotos)
+                      }}
+                      checked={closeWithoutPhotos}
+                    />
+                  </div>
+                </div>
+              </div>
             )}
           </div>
 

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -39,6 +39,13 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
 @import 'components/contact-details-table.scss';
 @import 'components/photos.scss';
 
+
+
+// checkbox
+.govuk-checkboxes--small .govuk-label.govuk-checkboxes__label {
+  margin-bottom: 0 !important;
+}
+
 // Form layout consistancy changes
 // only apply to specific forms
 

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -38,13 +38,7 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
 @import '@reach/dialog/styles.css';
 @import 'components/contact-details-table.scss';
 @import 'components/photos.scss';
-
-
-
-// checkbox
-.govuk-checkboxes--small .govuk-label.govuk-checkboxes__label {
-  margin-bottom: 0 !important;
-}
+@import 'components/checkboxSmall.scss';
 
 // Form layout consistancy changes
 // only apply to specific forms

--- a/src/styles/components/checkboxSmall.scss
+++ b/src/styles/components/checkboxSmall.scss
@@ -1,0 +1,4 @@
+// checkbox
+.govuk-checkboxes--small .govuk-label.govuk-checkboxes__label {
+  margin-bottom: 0 !important;
+}


### PR DESCRIPTION
## Ticket

https://hackney.atlassian.net/browse/HPT-470?atlOrigin=eyJpIjoiNTIwNWZiNWQzNTM0NGY0MTkxMjQxYTc5Y2U5N2ZlYjAiLCJwIjoiaiJ9

### Description of change

Add prompt when user hasnt selected any photos to upload.

- Found a bug where clicking the 'add details' button doesnt trigger validation
- Updated existing tests to confirm no photos to be uploaded
- Cypress bug causing tests to fail. Added event handler for 'uncaught:exception' to prevent the tests from failing

> The UI will be updated in later PRs. This PR is more about functionality

![image](https://github.com/user-attachments/assets/53d02efd-22b8-4294-9307-54fdb77db14c)
