### PR TITLE
Add feature toggle for follow-on functionality

### DIFF
--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -1,9 +1,9 @@
 /// <reference types="cypress" />
 import 'cypress-audit/commands'
 
-describe('Closing a work order on behalf of an operative', () => {
+describe('Closing a work order on behalf of an operative - When follow-ons are enabled', () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
+    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
 
     cy.intercept(
       {

--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -2,9 +2,19 @@
 import 'cypress-audit/commands'
 
 describe('Closing a work order on behalf of an operative - When follow-ons are enabled', () => {
-  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'true')
-
   beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/simple-feature-toggle',
+      },
+      {
+        body: {
+          followOnFunctionalityEnabled: true,
+        },
+      }
+    ).as('feature-toggle')
+
     cy.intercept(
       {
         method: 'GET',

--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -2,9 +2,9 @@
 import 'cypress-audit/commands'
 
 describe('Closing a work order on behalf of an operative - When follow-ons are enabled', () => {
-  beforeEach(() => {
-    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
+  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'true')
 
+  beforeEach(() => {
     cy.intercept(
       {
         method: 'GET',

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -250,9 +250,9 @@ describe('Closing a work order on behalf of an operative', () => {
           {
             typeCode: '0',
             otherType: 'completed',
-            noteGeneratedOnFrontend: true,
+            noteGeneratedOnFrontend: false,
             comments:
-              'This has been repaired and I forgot I did it on a completely different date and time.',
+              'Work order closed - This has been repaired and I forgot I did it on a completely different date and time.',
             eventTime: '2021-02-19T13:01:00.000Z',
           },
         ],
@@ -1192,10 +1192,10 @@ describe('Closing a work order on behalf of an operative', () => {
                 {
                   typeCode: '0',
                   otherType: 'completed',
-                  comments: 'A note',
+                  comments: 'Work order closed - A note',
                   eventTime: '2021-01-19T13:01:00.000Z',
                   paymentType: 'Bonus',
-                  noteGeneratedOnFrontend: true,
+                  noteGeneratedOnFrontend: false,
                 },
               ],
             })

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -2,9 +2,19 @@
 import 'cypress-audit/commands'
 
 describe('Closing a work order on behalf of an operative', () => {
-  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'false')
-
   beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/simple-feature-toggle',
+      },
+      {
+        body: {
+          followOnFunctionalityEnabled: false,
+        },
+      }
+    ).as('feature-toggle')
+
     cy.intercept(
       {
         method: 'GET',

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -2,9 +2,9 @@
 import 'cypress-audit/commands'
 
 describe('Closing a work order on behalf of an operative', () => {
-  beforeEach(() => {
-    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
+  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'false')
 
+  beforeEach(() => {
     cy.intercept(
       {
         method: 'GET',

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -691,7 +691,7 @@ describe('Closing a work order on behalf of an operative', () => {
         .should(
           'have.deep.nested.property',
           'jobStatusUpdates[0].comments',
-          'A note'
+          'Work order closed - A note - Assigned operatives Operative A : 100% - Bonus calculation'
         )
 
       cy.get('@apiCheck')
@@ -744,7 +744,7 @@ describe('Closing a work order on behalf of an operative', () => {
         .should(
           'have.deep.nested.property',
           'jobStatusUpdates[0].comments',
-          'A note'
+          'Work order closed - A note - Assigned operatives Operative A - Overtime work order (SMVs not included in Bonus)'
         )
 
       cy.get('@apiCheck')
@@ -796,7 +796,7 @@ describe('Closing a work order on behalf of an operative', () => {
         .should(
           'have.deep.nested.property',
           'jobStatusUpdates[0].comments',
-          'A note'
+          'Work order closed - A note - Assigned operatives Operative A : 100% - Close to base (Operative payment made)'
         )
 
       cy.get('@apiCheck')
@@ -1192,7 +1192,8 @@ describe('Closing a work order on behalf of an operative', () => {
                 {
                   typeCode: '0',
                   otherType: 'completed',
-                  comments: 'Work order closed - A note',
+                  comments:
+                    'Work order closed - A note - Assigned operatives Operative A : 40%, Operative B : 60% - Bonus calculation',
                   eventTime: '2021-01-19T13:01:00.000Z',
                   paymentType: 'Bonus',
                   noteGeneratedOnFrontend: false,
@@ -1384,7 +1385,7 @@ describe('Closing a work order on behalf of an operative', () => {
         .should(
           'have.deep.nested.property',
           'jobStatusUpdates[0].comments',
-          'A note'
+          'Work order closed - A note'
         )
 
       // no operative assignment request made

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -136,7 +136,6 @@ describe('Closing a work order on behalf of an operative', () => {
         .parent()
         .within(() => {
           cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'No further work required').click()
         })
 
       cy.get('#completionDate').type('2021-01-18') //Raised on 2021-01-18, 15:28
@@ -197,7 +196,6 @@ describe('Closing a work order on behalf of an operative', () => {
         .parent()
         .within(() => {
           cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'No further work required').click()
         })
 
       cy.get('#completionDate').type('2021-02-19')
@@ -651,7 +649,6 @@ describe('Closing a work order on behalf of an operative', () => {
           .parent()
           .within(() => {
             cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'No further work required').click()
           })
 
         cy.get('#completionDate').type('2021-01-23')
@@ -706,7 +703,6 @@ describe('Closing a work order on behalf of an operative', () => {
           .parent()
           .within(() => {
             cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'No further work required').click()
           })
 
         cy.get('#completionDate').type('2021-01-23')
@@ -760,7 +756,6 @@ describe('Closing a work order on behalf of an operative', () => {
           .parent()
           .within(() => {
             cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'No further work required').click()
           })
 
         cy.get('#completionDate').type('2021-01-23')
@@ -850,7 +845,6 @@ describe('Closing a work order on behalf of an operative', () => {
             .parent()
             .within(() => {
               cy.contains('label', 'No access').click()
-              // cy.contains('label', 'No further work required').click()
             })
 
           cy.get('#completionDate').type('2021-01-19')
@@ -1114,7 +1108,6 @@ describe('Closing a work order on behalf of an operative', () => {
             .parent()
             .within(() => {
               cy.contains('label', 'Visit completed').click()
-              cy.contains('label', 'No further work required').click()
             })
 
           cy.get('#completionDate').type('2021-01-19')
@@ -1357,7 +1350,6 @@ describe('Closing a work order on behalf of an operative', () => {
           .parent()
           .within(() => {
             cy.contains('label', 'Visit completed').click()
-            cy.contains('label', 'No further work required').click()
           })
 
         cy.get('#completionDate').type('2021-01-23')
@@ -1395,200 +1387,5 @@ describe('Closing a work order on behalf of an operative', () => {
           'jobStatusUpdates[0].paymentType'
         )
     })
-  })
-
-  it('shows validation message when further works required not specified', () => {
-    cy.visit('/work-orders/10000040/close')
-    cy.wait('@workOrder')
-
-    cy.contains('Reason for closing')
-      .parent()
-      .within(() => {
-        cy.contains('label', 'Visit completed').click()
-      })
-
-    cy.get('[type="submit"]').contains('Close work order').click()
-
-    cy.contains('Please confirm if further work is required')
-  })
-
-  it('shows validation when user enters follow-on details', () => {
-    cy.visit('/work-orders/10000040/close')
-    cy.wait('@workOrder')
-
-    cy.get('form').within(() => {
-      cy.contains('Reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'Further work required').click()
-        })
-
-      // assert error messages arent visible yet
-      cy.contains('Please select the type of work').should('not.exist')
-      cy.contains('Please describe the work completed').should('not.exist')
-
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-
-      // assert error messages visible
-      cy.contains('Please select the type of work')
-      cy.contains('Please describe the work completed')
-
-      // select an option - error should disappear
-      cy.get('input[data-testid="isSameTrade"]').check()
-      cy.contains('Please select the type of work').should('not.exist')
-
-      // select different trade(s) - error should appear
-      cy.get('input[data-testid="isDifferentTrades"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please select at least one trade')
-
-      // select a trade - error should disappear
-      cy.get('input[data-testid="followon-trades-plumbing"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please select at least one trade').should('not.exist')
-
-      // add description of work - error should disappear
-      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-        'Blah blah blah'
-      )
-      cy.contains('Please describe the work completed').should('not.exist')
-
-      // when one of the material options is selected, the description must not be empty
-      cy.get('input[data-testid="stockItemsRequired"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please describe the materials required')
-
-      // Adding a description - error should disappear
-      cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
-      cy.contains('Please describe the materials required').should('not.exist')
-
-      // additional notes
-      cy.get('textarea[data-testid="additionalNotes"]').type('Additional notes')
-
-      // other fields
-
-      cy.get('#completionDate').type('2021-01-23')
-
-      cy.get('[data-testid=completionTime-hour]').type('12')
-      cy.get('[data-testid=completionTime-minutes]').type('00')
-
-      cy.get('#notes').type('A note')
-
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-    })
-
-    // assert validation passed, and on next page
-    cy.contains('Summary of updates to work order')
-  })
-
-  it('submits a request and shows summary page when user enters follow-on details', () => {
-    cy.fixture('workOrders/workOrder.json').then((workOrder) => {
-      workOrder.reference = 10000040
-      workOrder.canAssignOperative = false
-
-      cy.intercept(
-        { method: 'GET', path: '/api/workOrders/10000040' },
-        { body: workOrder }
-      ).as('workOrder')
-    })
-
-    cy.visit('/work-orders/10000040/close')
-
-    cy.wait('@workOrder')
-
-    cy.get('form').within(() => {
-      cy.contains('Reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'Further work required').click()
-        })
-
-      // populate follow-on fields
-
-      cy.get('input[data-testid="isSameTrade"]').check()
-      cy.get('input[data-testid="isDifferentTrades"]').check()
-      cy.get('input[data-testid="followon-trades-plumbing"]').check()
-      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-        'follow on description'
-      )
-      cy.get('input[data-testid="stockItemsRequired"]').check()
-      cy.get('textarea[data-testid="materialNotes"]').type('material notes')
-      cy.get('textarea[data-testid="additionalNotes"]').type(
-        'Additional notes desc'
-      )
-
-      // other fields
-      cy.get('#completionDate').type('2021-01-23')
-      cy.get('[data-testid=completionTime-hour]').type('12')
-      cy.get('[data-testid=completionTime-minutes]').type('00')
-      cy.get('#notes').type('A note')
-
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-    })
-
-    // assert validation passed, and on next page
-    cy.contains('Summary of updates to work order')
-    cy.get('.govuk-table__row').contains('Completion time')
-    cy.get('.govuk-table__row').contains('2021/01/23')
-    cy.get('.govuk-table__row').contains('12:00:00')
-    cy.get('.govuk-table__row').contains('Reason')
-    cy.get('.govuk-table__row').contains('Work Order Completed')
-    cy.get('.govuk-table__row').contains('Notes')
-    cy.get('.govuk-table__row').contains('A note')
-
-    cy.contains('Summary of further work required')
-
-    cy.get('.govuk-table__row').contains('Type of work required')
-    cy.get('.govuk-table__row').contains('Same trade')
-    cy.get('.govuk-table__row').contains('Different trade(s) (Plumbing)')
-    cy.get('.govuk-table__row').contains('follow on description')
-
-    cy.get('.govuk-table__row').contains('Materials required')
-    cy.get('.govuk-table__row').contains('Stock items required')
-    cy.get('.govuk-table__row').contains('material notes')
-
-    cy.get('.govuk-table__row').contains('Additional notes')
-    cy.get('.govuk-table__row').contains('Additional notes desc')
-
-    // validate request object
-
-    cy.get('[type="submit"]').contains('Confirm and close').click()
-
-    cy.wait('@apiCheck')
-
-    cy.get('@apiCheck')
-      .its('request.body')
-      .should('deep.equal', {
-        workOrderReference: {
-          id: '10000040',
-          description: '',
-          allocatedBy: '',
-        },
-        jobStatusUpdates: [
-          {
-            typeCode: '0',
-            otherType: 'completed',
-            comments: 'A note',
-            eventTime: '2021-01-23T12:00:00.000Z',
-            noteGeneratedOnFrontend: true,
-          },
-        ],
-        followOnRequest: {
-          isSameTrade: true,
-          isDifferentTrades: true,
-          isMultipleOperatives: false,
-          requiredFollowOnTrades: ['Plumbing'],
-          followOnTypeDescription: 'follow on description',
-          stockItemsRequired: true,
-          nonStockItemsRequired: false,
-          materialNotes: 'material notes',
-          additionalNotes: 'Additional notes desc',
-        },
-      })
   })
 })

--- a/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
@@ -7,13 +7,13 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   return false
 })
 
-describe('Closing my own work order', () => {
+describe('Closing my own work order - When follow-ons are enabled', () => {
   const now = new Date('Friday June 11 2021 13:49:15Z')
   const workOrderReference = '10000621'
   const propertyReference = '00012345'
 
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
+    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
 
     cy.intercept(`/api/workOrders/${workOrderReference}`, {
       fixture: 'workOrders/workOrder.json',

--- a/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
@@ -12,9 +12,9 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
   const workOrderReference = '10000621'
   const propertyReference = '00012345'
 
-  beforeEach(() => {
-    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
+  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'true')
 
+  beforeEach(() => {
     cy.intercept(`/api/workOrders/${workOrderReference}`, {
       fixture: 'workOrders/workOrder.json',
     }).as('workOrderRequest')

--- a/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
@@ -12,9 +12,19 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
   const workOrderReference = '10000621'
   const propertyReference = '00012345'
 
-  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'true')
-
   beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/simple-feature-toggle',
+      },
+      {
+        body: {
+          followOnFunctionalityEnabled: true,
+        },
+      }
+    ).as('feature-toggle')
+
     cy.intercept(`/api/workOrders/${workOrderReference}`, {
       fixture: 'workOrders/workOrder.json',
     }).as('workOrderRequest')

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -452,10 +452,10 @@ describe('Closing my own work order', () => {
             {
               typeCode: '0',
               otherType: 'completed',
-              comments: 'I attended',
+              comments: 'Work order closed - I attended',
               eventTime: new Date(now.setHours(12, 0, 0)).toISOString(),
               paymentType: 'Bonus',
-              noteGeneratedOnFrontend: true,
+              noteGeneratedOnFrontend: false,
             },
           ],
         })
@@ -603,10 +603,10 @@ describe('Closing my own work order', () => {
               {
                 typeCode: '0',
                 otherType: 'completed',
-                comments: 'I attended',
+                comments: 'Work order closed - I attended',
                 eventTime: new Date(now.setHours(16, 0, 1)).toISOString(),
                 paymentType: 'Overtime',
-                noteGeneratedOnFrontend: true,
+                noteGeneratedOnFrontend: false,
               },
             ],
           })
@@ -678,10 +678,10 @@ describe('Closing my own work order', () => {
               {
                 typeCode: '0',
                 otherType: 'completed',
-                comments: 'I attended',
+                comments: 'Work order closed - I attended',
                 eventTime: new Date(now.setHours(16, 0, 1)).toISOString(),
                 paymentType: 'Bonus',
-                noteGeneratedOnFrontend: true,
+                noteGeneratedOnFrontend: false,
               },
             ],
           })

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -102,7 +102,7 @@ describe('Closing my own work order', () => {
 
   context('during normal working hours', () => {
     beforeEach(() => {
-      // cy.clock(new Date(now).setHours(12, 0, 0))
+      cy.clock(new Date(now).setHours(12, 0, 0))
     })
 
     it('shows a validation error when no reason is selected', () => {
@@ -477,7 +477,7 @@ describe('Closing my own work order', () => {
 
   context('when outside working hours (overtime could apply)', () => {
     beforeEach(() => {
-      // cy.clock(new Date(now).setHours(16, 0, 1))
+      cy.clock(new Date(now).setHours(16, 0, 1))
     })
 
     context('and the overtime payment type is chosen', () => {

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -12,9 +12,9 @@ describe('Closing my own work order', () => {
   const workOrderReference = '10000621'
   const propertyReference = '00012345'
 
-  beforeEach(() => {
-    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
+  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'false')
 
+  beforeEach(() => {
     cy.intercept(`/api/workOrders/${workOrderReference}`, {
       fixture: 'workOrders/workOrder.json',
     }).as('workOrderRequest')
@@ -92,7 +92,7 @@ describe('Closing my own work order', () => {
 
   context('during normal working hours', () => {
     beforeEach(() => {
-      cy.clock(new Date(now).setHours(12, 0, 0))
+      // cy.clock(new Date(now).setHours(12, 0, 0))
     })
 
     it('shows a validation error when no reason is selected', () => {
@@ -467,7 +467,7 @@ describe('Closing my own work order', () => {
 
   context('when outside working hours (overtime could apply)', () => {
     beforeEach(() => {
-      cy.clock(new Date(now).setHours(16, 0, 1))
+      // cy.clock(new Date(now).setHours(16, 0, 1))
     })
 
     context('and the overtime payment type is chosen', () => {

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -12,9 +12,19 @@ describe('Closing my own work order', () => {
   const workOrderReference = '10000621'
   const propertyReference = '00012345'
 
-  Cypress.env('NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED', 'false')
-
   beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/simple-feature-toggle',
+      },
+      {
+        body: {
+          followOnFunctionalityEnabled: false,
+        },
+      }
+    ).as('feature-toggle')
+
     cy.intercept(`/api/workOrders/${workOrderReference}`, {
       fixture: 'workOrders/workOrder.json',
     }).as('workOrderRequest')

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -421,7 +421,6 @@ describe('Closing my own work order', () => {
       cy.get('.lbh-radios input[data-testid="reason"]').check(
         'Work Order Completed'
       )
-      cy.contains('label', 'No further work required').click()
 
       cy.get('#notes').type('I attended')
 
@@ -463,168 +462,6 @@ describe('Closing my own work order', () => {
       cy.contains('button', 'Close').click()
 
       cy.get('.lbh-heading-h2').contains('Friday 11 June')
-    })
-
-    it('shows validation message when further works required not specified', () => {
-      cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
-
-      cy.wait([
-        '@workOrderRequest',
-        '@propertyRequest',
-        '@tasksRequest',
-        '@photosRequest',
-        '@locationAlerts',
-        '@personAlerts',
-      ])
-
-      cy.contains('button', 'Confirm').click()
-
-      cy.contains('Reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Visit completed').click()
-        })
-
-      cy.get('[type="submit"]').contains('Close work order').click()
-
-      cy.contains('Please confirm if further work is required')
-    })
-
-    it('shows validation when user enters follow-on details', () => {
-      cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
-
-      cy.wait([
-        '@workOrderRequest',
-        '@propertyRequest',
-        '@tasksRequest',
-        '@photosRequest',
-        '@locationAlerts',
-        '@personAlerts',
-      ])
-
-      cy.contains('button', 'Confirm').click()
-
-      cy.contains('Reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'Further work required').click()
-        })
-
-      // assert error messages arent visible yet
-      cy.contains('Please select the type of work').should('not.exist')
-      cy.contains('Please describe the work completed').should('not.exist')
-
-      // add follow on details
-      cy.contains('button', 'Add details').click()
-      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-      cy.contains('button', 'Add details').click()
-
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-
-      // assert error messages visible
-      cy.contains('Please select the type of work')
-      cy.contains('Please describe the work completed')
-
-      // select an option - error should disappear
-      cy.get('input[data-testid="isSameTrade"]').check()
-      cy.contains('Please select the type of work').should('not.exist')
-
-      // select different trade(s) - error should appear
-      cy.get('input[data-testid="isDifferentTrades"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please select at least one trade')
-
-      // select a trade - error should disappear
-      cy.get('input[data-testid="followon-trades-plumbing"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please select at least one trade').should('not.exist')
-
-      // add description of work - error should disappear
-      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-        'Blah blah blah'
-      )
-      cy.contains('Please describe the work completed').should('not.exist')
-
-      // when one of the material options is selected, the description must not be empty
-      cy.get('input[data-testid="stockItemsRequired"]').check()
-      cy.get('[type="submit"]').contains('Close work order').click()
-      cy.contains('Please describe the materials required')
-
-      // Adding a description - error should disappear
-      cy.get('textarea[data-testid="materialNotes"]').type('Blah blah blah')
-      cy.contains('Please describe the materials required').should('not.exist')
-
-      // additional notes
-      cy.get('textarea[data-testid="additionalNotes"]').type('Additional notes')
-
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-
-      // check for confirmation message
-      cy.contains('Work order 10000621 successfully closed')
-    })
-
-    it('submits a request when user enters follow-on details', () => {
-      cy.fixture('workOrders/workOrder.json').then((workOrder) => {
-        workOrder.reference = 10000040
-        workOrder.canAssignOperative = false
-
-        cy.intercept(
-          { method: 'GET', path: '/api/workOrders/10000040' },
-          { body: workOrder }
-        ).as('workOrder')
-      })
-
-      cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
-
-      cy.wait([
-        '@workOrderRequest',
-        '@propertyRequest',
-        '@tasksRequest',
-        '@photosRequest',
-        '@locationAlerts',
-        '@personAlerts',
-      ])
-
-      cy.contains('button', 'Confirm').click()
-
-      cy.contains('Reason for closing')
-        .parent()
-        .within(() => {
-          cy.contains('label', 'Visit completed').click()
-          cy.contains('label', 'Further work required').click()
-        })
-
-      // add follow-on details
-      cy.contains('button', 'Add details').click()
-      cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
-      cy.contains('button', 'Add details').click()
-
-      cy.get('.govuk-button').contains('Close work order').click()
-
-      // populate follow-on fields
-
-      cy.get('input[data-testid="isSameTrade"]').check()
-      cy.get('input[data-testid="isDifferentTrades"]').check()
-      cy.get('input[data-testid="followon-trades-plumbing"]').check()
-      cy.get('textarea[data-testid="followOnTypeDescription"]').type(
-        'follow on description'
-      )
-      cy.get('input[data-testid="stockItemsRequired"]').check()
-      cy.get('textarea[data-testid="materialNotes"]').type('material notes')
-      cy.get('textarea[data-testid="additionalNotes"]').type(
-        'Additional notes desc'
-      )
-
-      // close work order
-      cy.get('[type="submit"]').contains('Close work order').click()
-
-      cy.wait('@workOrderCompleteRequest')
-
-      // check for confirmation message
-      cy.contains('Work order 10000621 successfully closed')
     })
   })
 
@@ -737,7 +574,6 @@ describe('Closing my own work order', () => {
         cy.get('.lbh-radios input[data-testid="reason"]').check(
           'Work Order Completed'
         ) // Checking by value, not text
-        cy.contains('label', 'No further work required').click()
 
         cy.get('.govuk-button').contains('Close work order').click()
         cy.get('[data-testid="closeWorkOrderWithoutPhotos"]').check()
@@ -812,7 +648,6 @@ describe('Closing my own work order', () => {
         cy.get('.lbh-radios input[data-testid="reason"]').check(
           'Work Order Completed'
         ) // Checking by value, not text
-        cy.contains('label', 'No further work required').click()
 
         cy.get('.govuk-button').contains('Close work order').click()
 

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -452,7 +452,7 @@ describe('Closing my own work order', () => {
             {
               typeCode: '0',
               otherType: 'completed',
-              comments: 'Work order closed - I attended',
+              comments: 'Work order closed - I attended - Bonus calculation',
               eventTime: new Date(now.setHours(12, 0, 0)).toISOString(),
               paymentType: 'Bonus',
               noteGeneratedOnFrontend: false,
@@ -603,7 +603,8 @@ describe('Closing my own work order', () => {
               {
                 typeCode: '0',
                 otherType: 'completed',
-                comments: 'Work order closed - I attended',
+                comments:
+                  'Work order closed - I attended - Overtime work order (SMVs not included in Bonus)',
                 eventTime: new Date(now.setHours(16, 0, 1)).toISOString(),
                 paymentType: 'Overtime',
                 noteGeneratedOnFrontend: false,
@@ -678,7 +679,7 @@ describe('Closing my own work order', () => {
               {
                 typeCode: '0',
                 otherType: 'completed',
-                comments: 'Work order closed - I attended',
+                comments: 'Work order closed - I attended - Bonus calculation',
                 eventTime: new Date(now.setHours(16, 0, 1)).toISOString(),
                 paymentType: 'Bonus',
                 noteGeneratedOnFrontend: false,

--- a/serverless.yml
+++ b/serverless.yml
@@ -70,6 +70,7 @@ functions:
       SENTRY_DSN: ${ssm:/repairs-hub/${self:provider.stage}/sentry-dsn}
       SENTRY_ENVIRONMENT: ${self:provider.stage}
       SENTRY_RELEASE: ${env:CIRCLE_SHA1}
+      FOLLOW_ON_FUNCTIONALITY_ENABLED: ${ssm:/repairs-hub/${self:provider.stage}/repairs-hub-enable-followon-functionality}
 
 resources:
   Resources:

--- a/src/components/Form/Radios/index.tsx
+++ b/src/components/Form/Radios/index.tsx
@@ -5,7 +5,7 @@ import { Fragment } from 'react'
 const defaultOptions = ['Yes', 'No']
 
 interface Props {
-  label: string
+  label?: string
   labelSize?: 's' | 'm' | 'l' | 'xl'
   showAsOptional?: boolean
   hint?: string

--- a/src/components/SpinnerWithLabel/index.tsx
+++ b/src/components/SpinnerWithLabel/index.tsx
@@ -1,0 +1,21 @@
+import Spinner from '../Spinner'
+
+interface Props {
+  label: string
+}
+
+const SpinnerWithLabel = (props: Props) => {
+  const { label } = props
+
+  return (
+    <div
+      className="govuk-body"
+      style={{ display: 'flex', alignItems: 'center' }}
+    >
+      <Spinner />
+      <span style={{ margin: '0 0 0 15px' }}>{label}</span>
+    </div>
+  )
+}
+
+export default SpinnerWithLabel

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types'
 import { useState, useEffect, useContext } from 'react'
 import Spinner from '../Spinner'
 import ErrorMessage from '../Errors/ErrorMessage'
-import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
+import {
+  fetchSimpleFeatureToggles,
+  frontEndApiRequest,
+} from '@/utils/frontEndApiClient/requests'
 import { WorkOrder } from '@/models/workOrder'
 import { sortObjectsByDateKey } from '@/utils/date'
 import MobileWorkingWorkOrder from './MobileWorkingWorkOrder'
@@ -18,6 +21,7 @@ import { BONUS_PAYMENT_TYPE } from '@/utils/paymentTypes'
 import { FOLLOW_ON_REQUEST_AVAILABLE_TRADES } from '../../utils/statusCodes'
 import uploadFiles from './Photos/hooks/uploadFiles'
 import { workOrderNoteFragmentForPaymentType } from '../../utils/paymentTypes'
+import SpinnerWithLabel from '../SpinnerWithLabel'
 
 const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
   const { setModalFlashMessage } = useContext(FlashMessageContext)
@@ -47,10 +51,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
         path: `/api/workOrders/${workOrderReference}`,
       })
 
-      const featureToggleData = await frontEndApiRequest({
-        method: 'get',
-        path: '/api/simple-feature-toggle',
-      })
+      const featureToggleData = await fetchSimpleFeatureToggles()
 
       const propertyObject = await frontEndApiRequest({
         method: 'get',
@@ -226,53 +227,43 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
     }
   }
 
+  if (loadingStatus) return <SpinnerWithLabel label={loadingStatus} />
+
   return (
     <>
-      {loadingStatus ? (
-        <div
-          className="govuk-body"
-          style={{ display: 'flex', alignItems: 'center' }}
-        >
-          <Spinner />
-          <span style={{ margin: '0 0 0 15px' }}>{loadingStatus}</span>
-        </div>
-      ) : (
-        <>
-          {!workOrderProgressedToClose &&
-            property &&
-            property.address &&
-            property.hierarchyType &&
-            tenure &&
-            workOrder && (
-              <>
-                <MobileWorkingWorkOrder
-                  workOrderReference={workOrderReference}
-                  property={property}
-                  tenure={tenure}
-                  workOrder={workOrder}
-                  tasksAndSors={tasksAndSors}
-                  error={error}
-                  onFormSubmit={onWorkOrderProgressToCloseSubmit}
-                  currentUserPayrollNumber={currentUser.operativePayrollNumber}
-                  paymentType={paymentType}
-                  photos={photos}
-                />
-              </>
-            )}
-
-          {workOrderProgressedToClose && (
-            <MobileWorkingCloseWorkOrderForm
-              onSubmit={onWorkOrderCompleteSubmit}
-              isLoading={loadingStatus !== null}
-              followOnFunctionalityEnabled={
-                featureToggles?.followOnFunctionalityEnabled ?? false
-              }
+      {!workOrderProgressedToClose &&
+        property &&
+        property.address &&
+        property.hierarchyType &&
+        tenure &&
+        workOrder && (
+          <>
+            <MobileWorkingWorkOrder
+              workOrderReference={workOrderReference}
+              property={property}
+              tenure={tenure}
+              workOrder={workOrder}
+              tasksAndSors={tasksAndSors}
+              error={error}
+              onFormSubmit={onWorkOrderProgressToCloseSubmit}
+              currentUserPayrollNumber={currentUser.operativePayrollNumber}
+              paymentType={paymentType}
+              photos={photos}
             />
-          )}
+          </>
+        )}
 
-          {error && <ErrorMessage label={error} />}
-        </>
+      {workOrderProgressedToClose && (
+        <MobileWorkingCloseWorkOrderForm
+          onSubmit={onWorkOrderCompleteSubmit}
+          isLoading={loadingStatus !== null}
+          followOnFunctionalityEnabled={
+            featureToggles?.followOnFunctionalityEnabled ?? false
+          }
+        />
       )}
+
+      {error && <ErrorMessage label={error} />}
     </>
   )
 }

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -28,6 +28,8 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
   const [tasksAndSors, setTasksAndSors] = useState([])
   const [tenure, setTenure] = useState({})
   const [photos, setPhotos] = useState([])
+  const [featureToggles, setFeatureToggles] = useState({})
+
   const [loadingStatus, setLoadingStatus] = useState(null)
   const [error, setError] = useState()
 
@@ -44,6 +46,12 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
         method: 'get',
         path: `/api/workOrders/${workOrderReference}`,
       })
+
+      const featureToggleData = await frontEndApiRequest({
+        method: 'get',
+        path: '/api/simple-feature-toggle',
+      })
+
       const propertyObject = await frontEndApiRequest({
         method: 'get',
         path: `/api/properties/${workOrder.propertyReference}`,
@@ -64,6 +72,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
         path: `/api/workOrders/images/${workOrderReference}`,
       })
 
+      setFeatureToggles(featureToggleData)
       setPhotos(photos)
       setCurrentUser(currentUser)
 
@@ -255,6 +264,9 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
             <MobileWorkingCloseWorkOrderForm
               onSubmit={onWorkOrderCompleteSubmit}
               isLoading={loadingStatus !== null}
+              followOnFunctionalityEnabled={
+                featureToggles?.followOnFunctionalityEnabled ?? false
+              }
             />
           )}
 

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -163,17 +163,17 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
       )
     }
 
+    const followOnFunctionalityEnabled =
+      featureToggles?.followOnFunctionalityEnabled ?? false
+
     let notes = data.notes // notes written by user
 
-    if (data.reason == 'No Access') {
+    if (data.reason == 'No Access' || !followOnFunctionalityEnabled) {
       notes = `Work order closed - ${[
         data.notes,
         workOrderNoteFragmentForPaymentType(paymentType),
       ].join(' - ')}`
     }
-
-    const followOnFunctionalityEnabled =
-      featureToggles?.followOnFunctionalityEnabled ?? false
 
     const closeWorkOrderFormData = buildCloseWorkOrderData(
       new Date().toISOString(),

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -172,12 +172,16 @@ const MobileWorkingWorkOrderView = ({ workOrderReference, operativeId }) => {
       ].join(' - ')}`
     }
 
+    const followOnFunctionalityEnabled =
+      featureToggles?.followOnFunctionalityEnabled ?? false
+
     const closeWorkOrderFormData = buildCloseWorkOrderData(
       new Date().toISOString(),
       notes,
       workOrderReference,
       data.reason,
       paymentType,
+      followOnFunctionalityEnabled,
       followOnRequest
     )
 

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -196,18 +196,18 @@ const CloseWorkOrderByProxy = ({ reference }) => {
       )
     }
 
+    const followOnFunctionalityEnabled =
+      featureToggles?.followOnFunctionalityEnabled ?? false
+
     let comments = notes // notes written by user
 
-    if (reason == 'No Access') {
+    if (reason == 'No Access' || !followOnFunctionalityEnabled) {
       comments = `Work order closed - ${buildWorkOrderCompleteNotes(
         notes,
         operativesWithPercentages,
         paymentType
       )}`
     }
-
-    const followOnFunctionalityEnabled =
-      featureToggles?.followOnFunctionalityEnabled ?? false
 
     const closeWorkOrderFormData = buildCloseWorkOrderData(
       completionDate,

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -43,6 +43,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
   const [availableOperatives, setAvailableOperatives] = useState([])
   const [selectedOperatives, setSelectedOperatives] = useState([])
   const [workOrder, setWorkOrder] = useState()
+  const [featureToggles, setFeatureToggles] = useState({})
   const [operativesWithPercentages, setOperativesWithPercentages] = useState([])
   const [
     selectedPercentagesToShowOnEdit,
@@ -116,7 +117,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     }
   }
 
-  const getCloseWorkOrder = async () => {
+  const fetchInitialData = async () => {
     setError(null)
 
     try {
@@ -124,6 +125,13 @@ const CloseWorkOrderByProxy = ({ reference }) => {
         method: 'get',
         path: `/api/workOrders/${reference}`,
       })
+
+      const featureToggleData = await frontEndApiRequest({
+        method: 'get',
+        path: '/api/simple-feature-toggle',
+      })
+
+      setFeatureToggles(featureToggleData)
 
       setWorkOrder(new WorkOrder(workOrder))
 
@@ -154,7 +162,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
   useEffect(() => {
     setLoadingStatus('Loading workorder')
 
-    getCloseWorkOrder()
+    fetchInitialData()
   }, [])
 
   const onJobSubmit = async () => {
@@ -346,6 +354,9 @@ const CloseWorkOrderByProxy = ({ reference }) => {
                   existingStartTime={workOrder.startTime !== null}
                   followOnData={followOnData}
                   isLoading={loadingStatus !== null}
+                  followOnFunctionalityEnabled={
+                    featureToggles?.followOnFunctionalityEnabled ?? false
+                  }
                 />
               )}
 

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -206,12 +206,16 @@ const CloseWorkOrderByProxy = ({ reference }) => {
       )}`
     }
 
+    const followOnFunctionalityEnabled =
+      featureToggles?.followOnFunctionalityEnabled ?? false
+
     const closeWorkOrderFormData = buildCloseWorkOrderData(
       completionDate,
       comments,
       reference,
       reason,
       paymentType,
+      followOnFunctionalityEnabled,
       followOnDataRequest
     )
 

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -44,6 +44,7 @@ const CloseWorkOrderForm = ({
   isLoading,
   defaultFiles,
   description,
+  followOnFunctionalityEnabled,
 }) => {
   const {
     handleSubmit,
@@ -98,8 +99,8 @@ const CloseWorkOrderForm = ({
           errors={errors}
           watch={watch}
           reason={reason}
-          followOnData={followOnData}
           followOnStatus={followOnStatus}
+          followOnFunctionalityEnabled={followOnFunctionalityEnabled}
         />
 
         {showFurtherWorkFields && (
@@ -298,6 +299,7 @@ CloseWorkOrderForm.propTypes = {
   jobIsSplitByOperative: PropTypes.bool.isRequired,
   paymentType: PropTypes.string,
   existingStartTime: PropTypes.bool.isRequired,
+  followOnFunctionalityEnabled: PropTypes.bool.isRequired,
 }
 
 export default CloseWorkOrderForm

--- a/src/components/WorkOrders/CloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.test.js
@@ -4,8 +4,6 @@ import UserContext from '../UserContext'
 import CloseWorkOrderForm from './CloseWorkOrderForm'
 
 describe('CloseWorkOrderForm component', () => {
-  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
-
   const operatives = [
     {
       id: 1,
@@ -58,6 +56,7 @@ describe('CloseWorkOrderForm component', () => {
           jobIsSplitByOperative={false}
           paymentType={'Overtime'}
           existingStartTime={false}
+          followOnFunctionalityEnabled={false}
         />
       </UserContext.Provider>
     )
@@ -90,6 +89,7 @@ describe('CloseWorkOrderForm component', () => {
           jobIsSplitByOperative={false}
           paymentType={'Overtime'}
           existingStartTime={true}
+          followOnFunctionalityEnabled={false}
         />
       </UserContext.Provider>
     )
@@ -98,8 +98,6 @@ describe('CloseWorkOrderForm component', () => {
 })
 
 describe('CloseWorkOrderForm component - when follow-on functionality is enabled', () => {
-  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
-
   const operatives = [
     {
       id: 1,
@@ -152,6 +150,7 @@ describe('CloseWorkOrderForm component - when follow-on functionality is enabled
           jobIsSplitByOperative={false}
           paymentType={'Overtime'}
           existingStartTime={false}
+          followOnFunctionalityEnabled={true}
         />
       </UserContext.Provider>
     )
@@ -184,6 +183,7 @@ describe('CloseWorkOrderForm component - when follow-on functionality is enabled
           jobIsSplitByOperative={false}
           paymentType={'Overtime'}
           existingStartTime={true}
+          followOnFunctionalityEnabled={true}
         />
       </UserContext.Provider>
     )

--- a/src/components/WorkOrders/CloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.test.js
@@ -4,6 +4,102 @@ import UserContext from '../UserContext'
 import CloseWorkOrderForm from './CloseWorkOrderForm'
 
 describe('CloseWorkOrderForm component', () => {
+  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
+
+  const operatives = [
+    {
+      id: 1,
+      name: 'Operative A',
+    },
+    {
+      id: 2,
+      name: 'Operative B',
+    },
+  ]
+
+  const props = {
+    reference: 10000012,
+    onSubmit: jest.fn(),
+    notes: 'this is a note',
+    completionTime: '14:30',
+    completionDate: new Date('2021-01-12T16:24:26.632Z'),
+    startTime: '14:30',
+    startDate: new Date('2021-01-12T16:24:26.632Z'),
+    operatives: operatives,
+    availableOperatives: operatives,
+    reason: 'No Access',
+    selectedPercentagesToShowOnEdit: [],
+    totalSMVs: 76,
+  }
+
+  it('should render properly', () => {
+    const { asFragment } = render(
+      <UserContext.Provider
+        value={{
+          user: agent,
+        }}
+      >
+        <CloseWorkOrderForm
+          reference={props.reference}
+          onSubmit={props.onSubmit}
+          notes={props.notes}
+          completionTime={props.completionTime}
+          completionDate={props.completionDate}
+          startTime={props.startTime}
+          startDate={props.startDate}
+          reason={props.reason}
+          operativeAssignmentMandatory={true}
+          assignedOperativesToWorkOrder={props.operatives}
+          availableOperatives={props.availableOperatives}
+          selectedPercentagesToShowOnEdit={
+            props.selectedPercentagesToShowOnEdit
+          }
+          totalSMV={props.totalSMVs}
+          jobIsSplitByOperative={false}
+          paymentType={'Overtime'}
+          existingStartTime={false}
+        />
+      </UserContext.Provider>
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should not render startDate or startTime', () => {
+    const { asFragment } = render(
+      <UserContext.Provider
+        value={{
+          user: agent,
+        }}
+      >
+        <CloseWorkOrderForm
+          reference={props.reference}
+          onSubmit={props.onSubmit}
+          notes={props.notes}
+          completionTime={props.completionTime}
+          completionDate={props.completionDate}
+          startTime={props.startTime}
+          startDate={props.startDate}
+          reason={props.reason}
+          operativeAssignmentMandatory={true}
+          assignedOperativesToWorkOrder={props.operatives}
+          availableOperatives={props.availableOperatives}
+          selectedPercentagesToShowOnEdit={
+            props.selectedPercentagesToShowOnEdit
+          }
+          totalSMV={props.totalSMVs}
+          jobIsSplitByOperative={false}
+          paymentType={'Overtime'}
+          existingStartTime={true}
+        />
+      </UserContext.Provider>
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})
+
+describe('CloseWorkOrderForm component - when follow-on functionality is enabled', () => {
+  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
+
   const operatives = [
     {
       id: 1,

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/CloseWorkOrderFormReasonForClosing.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/CloseWorkOrderFormReasonForClosing.tsx
@@ -9,17 +9,22 @@ interface Props {
   watch: any
   reason: string
   followOnStatus: string
+  followOnFunctionalityEnabled: boolean
 }
 
 const CloseWorkOrderFormReasonForClosing = (props: Props) => {
-  const { register, errors, watch, reason, followOnStatus } = props
+  const {
+    register,
+    errors,
+    watch,
+    reason,
+    followOnStatus,
+    followOnFunctionalityEnabled,
+  } = props
 
   const [showFurtherWorkRadio, setShowFurtherWorkRadio] = useState(false)
 
   const reasonWatchedValue = watch('reason')
-
-  const enableFollowOnOptions =
-    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED === 'true'
 
   useEffect(() => {
     // When navigating back from summary page, the watch hook isnt updating
@@ -41,7 +46,7 @@ const CloseWorkOrderFormReasonForClosing = (props: Props) => {
       options={CLOSURE_STATUS_OPTIONS.map((r) => ({
         ...r,
         defaultChecked: r.value === reason,
-        children: enableFollowOnOptions ? (
+        children: followOnFunctionalityEnabled ? (
           r.value === 'Work Order Completed' ? (
             <FurtherWorkRadio
               error={errors?.followOnStatus}

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/CloseWorkOrderFormReasonForClosing.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/CloseWorkOrderFormReasonForClosing.tsx
@@ -1,45 +1,25 @@
-import {
-  CLOSURE_STATUS_OPTIONS,
-  FOLLOW_ON_STATUS_OPTIONS,
-} from '@/root/src/utils/statusCodes'
+import { CLOSURE_STATUS_OPTIONS } from '@/root/src/utils/statusCodes'
 import Radios from '../../Form/Radios'
 import { useEffect, useState } from 'react'
+import FurtherWorkRadio from './FurtherWorksRadio'
 
-const FurtherWorkRadio = (props) => {
-  const { errors, visible, register, followOnStatus } = props
-
-  if (!visible) return null
-
-  return (
-    <Radios
-      name="followOnStatus"
-      options={FOLLOW_ON_STATUS_OPTIONS.map((x) => {
-        return {
-          ...x,
-          defaultChecked: x.value === followOnStatus,
-        }
-      })}
-      register={register({
-        required: 'Please confirm if further work is required',
-      })}
-      error={errors && errors.followOnStatus}
-    />
-  )
+interface Props {
+  register: any
+  errors: { [key: string]: { message: string } }
+  watch: any
+  reason: string
+  followOnStatus: string
 }
 
-const CloseWorkOrderFormReasonForClosing = (props) => {
-  const {
-    register,
-    errors,
-    watch,
-    reason,
-    followOnData,
-    followOnStatus,
-  } = props
+const CloseWorkOrderFormReasonForClosing = (props: Props) => {
+  const { register, errors, watch, reason, followOnStatus } = props
 
   const [showFurtherWorkRadio, setShowFurtherWorkRadio] = useState(false)
 
   const reasonWatchedValue = watch('reason')
+
+  const enableFollowOnOptions =
+    process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED === 'true'
 
   useEffect(() => {
     // When navigating back from summary page, the watch hook isnt updating
@@ -61,16 +41,16 @@ const CloseWorkOrderFormReasonForClosing = (props) => {
       options={CLOSURE_STATUS_OPTIONS.map((r) => ({
         ...r,
         defaultChecked: r.value === reason,
-        children:
+        children: enableFollowOnOptions ? (
           r.value === 'Work Order Completed' ? (
             <FurtherWorkRadio
-              errors={errors}
+              error={errors?.followOnStatus}
               register={register}
               visible={showFurtherWorkRadio}
-              followOnData={followOnData}
               followOnStatus={followOnStatus}
             />
-          ) : null,
+          ) : null
+        ) : null,
       }))}
       register={register({
         required: 'Please select a reason for closing the work order',

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FurtherWorksRadio.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FurtherWorksRadio.tsx
@@ -1,0 +1,33 @@
+import { FOLLOW_ON_STATUS_OPTIONS } from '@/root/src/utils/statusCodes'
+import Radios from '../../Form/Radios'
+
+interface Props {
+  error: { message: string } | null
+  visible: boolean
+  register: any
+  followOnStatus: string
+}
+
+const FurtherWorkRadio = (props: Props) => {
+  const { error, visible, register, followOnStatus } = props
+
+  if (!visible) return null
+
+  return (
+    <Radios
+      name="followOnStatus"
+      options={FOLLOW_ON_STATUS_OPTIONS.map((x) => {
+        return {
+          ...x,
+          defaultChecked: x.value === followOnStatus,
+        }
+      })}
+      register={register({
+        required: 'Please confirm if further work is required',
+      })}
+      error={error}
+    />
+  )
+}
+
+export default FurtherWorkRadio

--- a/src/components/WorkOrders/ConfirmCloseWorkOrderView/index.tsx
+++ b/src/components/WorkOrders/ConfirmCloseWorkOrderView/index.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react'
 import ConfirmCloseWorkOrderWithoutPhotosForm from '../ConfirmCloseWorkOrderWithoutPhotosForm'
 import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
 
-import Spinner from '../../Spinner'
 import { useRouter } from 'next/router'
 import ErrorMessage from '../../Errors/ErrorMessage'
+import SpinnerWithLabel from '../../SpinnerWithLabel'
 
 interface Props {
   workOrderId: string
@@ -88,16 +88,7 @@ const ConfirmCloseWorkOrderView = (props: Props) => {
       })
   }
 
-  if (loadingStatus)
-    return (
-      <div
-        className="govuk-body"
-        style={{ display: 'flex', alignItems: 'center' }}
-      >
-        <Spinner />
-        <span style={{ margin: '0 0 0 15px' }}>{loadingStatus}</span>
-      </div>
-    )
+  if (loadingStatus) return <SpinnerWithLabel label={loadingStatus} />
 
   return (
     <div>

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.js
@@ -23,7 +23,11 @@ const FIELD_NAMES_ON_FIRST_PAGE = [
   'description',
 ]
 
-const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
+const MobileWorkingCloseWorkOrderForm = ({
+  onSubmit,
+  isLoading,
+  followOnFunctionalityEnabled,
+}) => {
   const {
     handleSubmit,
     register,
@@ -99,6 +103,7 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
             register={register}
             errors={errors}
             watch={watch}
+            followOnFunctionalityEnabled={followOnFunctionalityEnabled}
           />
 
           <div className="govuk-form-group lbh-form-group">
@@ -213,6 +218,8 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
 
 MobileWorkingCloseWorkOrderForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  followOnFunctionalityEnabled: PropTypes.bool.isRequired,
 }
 
 export default MobileWorkingCloseWorkOrderForm

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.test.js
@@ -2,6 +2,19 @@ import { render } from '@testing-library/react'
 import MobileWorkingCloseWorkOrderForm from './MobileWorkingCloseWorkOrderForm'
 
 describe('MobileWorkingCloseWorkOrderForm component', () => {
+  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
+
+  it('should render properly', () => {
+    const { asFragment } = render(
+      <MobileWorkingCloseWorkOrderForm onSubmit={jest.fn()} />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})
+
+describe('MobileWorkingCloseWorkOrderForm component - when follow-on functionality is enabled', () => {
+  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
+
   it('should render properly', () => {
     const { asFragment } = render(
       <MobileWorkingCloseWorkOrderForm onSubmit={jest.fn()} />

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.test.js
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.test.js
@@ -2,22 +2,24 @@ import { render } from '@testing-library/react'
 import MobileWorkingCloseWorkOrderForm from './MobileWorkingCloseWorkOrderForm'
 
 describe('MobileWorkingCloseWorkOrderForm component', () => {
-  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'false'
-
   it('should render properly', () => {
     const { asFragment } = render(
-      <MobileWorkingCloseWorkOrderForm onSubmit={jest.fn()} />
+      <MobileWorkingCloseWorkOrderForm
+        onSubmit={jest.fn()}
+        followOnFunctionalityEnabled={false}
+      />
     )
     expect(asFragment()).toMatchSnapshot()
   })
 })
 
 describe('MobileWorkingCloseWorkOrderForm component - when follow-on functionality is enabled', () => {
-  process.env.NEXT_PUBLIC_FOLLOW_ON_FUNCTIONALITY_ENABLED = 'true'
-
   it('should render properly', () => {
     const { asFragment } = render(
-      <MobileWorkingCloseWorkOrderForm onSubmit={jest.fn()} />
+      <MobileWorkingCloseWorkOrderForm
+        onSubmit={jest.fn()}
+        followOnFunctionalityEnabled={true}
+      />
     )
     expect(asFragment()).toMatchSnapshot()
   })

--- a/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
@@ -1369,10 +1369,6 @@ exports[`CloseWorkOrderForm component should not render startDate or startTime 1
             </label>
           </div>
           <div
-            class="govuk-radios__conditional"
-            id="conditional-contact"
-          />
-          <div
             class="govuk-radios__item"
           >
             <input
@@ -1981,10 +1977,6 @@ exports[`CloseWorkOrderForm component should render properly 1`] = `
               Visit completed
             </label>
           </div>
-          <div
-            class="govuk-radios__conditional"
-            id="conditional-contact"
-          />
           <div
             class="govuk-radios__item"
           >

--- a/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/CloseWorkOrderForm.test.js.snap
@@ -1,5 +1,1321 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CloseWorkOrderForm component - when follow-on functionality is enabled should not render startDate or startTime 1`] = `
+<DocumentFragment>
+  <div
+    class="close-work-order-form"
+  >
+    <a
+      class="govuk-back-link lbh-back-link govuk-!-display-none-print"
+      role="button"
+    >
+      Back
+    </a>
+    <h1
+      class="lbh-heading-h2"
+    >
+      Close work order: 10000012
+    </h1>
+    <form
+      role="form"
+    >
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <legend
+          class="govuk-fieldset__legend govuk-fieldset__legend--s"
+        >
+          Reason for closing 
+        </legend>
+        <span
+          class="govuk-hint lbh-hint"
+          id="reason-hint"
+        />
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_Work Order Completed"
+              name="reason"
+              type="radio"
+              value="Work Order Completed"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_Work Order Completed"
+            >
+              Visit completed
+            </label>
+          </div>
+          <div
+            class="govuk-radios__conditional"
+            id="conditional-contact"
+          />
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              checked=""
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_No Access"
+              name="reason"
+              type="radio"
+              value="No Access"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_No Access"
+            >
+              No access
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <div>
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+            for="fileUpload"
+            id="fileUploadLegend"
+          >
+            Photos 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="photos-hint"
+          >
+            Select all the photos you want to add (up to 10 photos)
+          </span>
+          <input
+            accept=".jpg, .jpeg, .png"
+            aria-labelledby="fileUploadLegend"
+            class="govuk-file-upload custom-file-input"
+            data-testid="fileUploadInput"
+            id="fileUpload"
+            multiple=""
+            name="fileUpload"
+            style="margin-top: 10px;"
+            type="file"
+          />
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label lbh-label govuk-label--m"
+          for="completionDate"
+        >
+          Select completion date 
+        </label>
+        <span
+          class="govuk-hint lbh-hint"
+          id="completionDate-hint"
+        >
+          For example, 15/05/2021
+        </span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          data-testid="completionDate"
+          id="completionDate"
+          name="completionDate"
+          type="date"
+          value="2021-01-12"
+        />
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <fieldset
+          aria-describedby="completionTime-hint"
+          class="govuk-fieldset lbh-fieldset"
+          role="group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Completion time 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="completionTime-hint"
+          >
+            Use 24h format. For example, 14:30
+          </span>
+          <div
+            class="govuk-date-input lbh-date-input"
+            id="completionTime"
+          >
+            <div
+              class="govuk-date-input__item"
+            >
+              <label
+                class="govuk-label lbh-label govuk-date-input__label"
+                for="completionTime-hour"
+              >
+                Hour
+              </label>
+              <input
+                class="govuk-input lbh-input govuk-date-input__input govuk-input--width-2"
+                data-testid="completionTime-hour"
+                id="completionTime-hour"
+                inputmode="numeric"
+                name="completionTime-hour"
+                pattern="^\\\\d{1,2}$"
+                type="text"
+                value="14"
+              />
+            </div>
+            <div
+              class="govuk-date-input__item"
+            >
+              <label
+                class="govuk-label lbh-label govuk-date-input__label"
+                for="completionTime-minutes"
+              >
+                Minutes
+              </label>
+              <input
+                class="govuk-input govuk-date-input__input govuk-input--width-2"
+                data-testid="completionTime-minutes"
+                id="completionTime-minutes"
+                inputmode="numeric"
+                name="completionTime-minutes"
+                pattern="^\\\\d{1,2}$"
+                type="text"
+                value="30"
+              />
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <fieldset
+        aria-describedby="completionTime-hint"
+        class="govuk-fieldset lbh-fieldset"
+        role="group"
+      >
+        <div
+          class="operatives govuk-form-group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Operatives
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="completionTime-hint"
+          >
+            Search by operative name and select from the list
+          </span>
+          <div
+            class="operatives-group"
+          >
+            <div
+              class="govuk-form-group lbh-form-group operative-datalist"
+              id="operative-0-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="operative-0"
+              >
+                Operative name 1 *  
+              </label>
+              <input
+                autocomplete="off"
+                class="govuk-select lbh-select govuk-!-width-full"
+                data-testid="operative-0"
+                id="operative-0"
+                list="autocomplete-list-operative-0"
+                name="operative-0"
+                value="Operative A [1]"
+              />
+              <datalist
+                id="autocomplete-list-operative-0"
+              >
+                <option
+                  value="Operative A [1]"
+                />
+                <option
+                  value="Operative B [2]"
+                />
+              </datalist>
+            </div>
+            <div
+              class="select-percentage"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+                id="percentage-0-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label"
+                  for="percentage-0"
+                >
+                  Work done 
+                </label>
+                <select
+                  class="govuk-select lbh-select undefined"
+                  data-testid="percentage-0"
+                  id="percentage-0"
+                  name="percentage-0"
+                >
+                  <option
+                    value=""
+                  />
+                  <option
+                    value="100%"
+                  >
+                    100%
+                  </option>
+                  <option
+                    value="90%"
+                  >
+                    90%
+                  </option>
+                  <option
+                    value="80%"
+                  >
+                    80%
+                  </option>
+                  <option
+                    value="70%"
+                  >
+                    70%
+                  </option>
+                  <option
+                    value="60%"
+                  >
+                    60%
+                  </option>
+                  <option
+                    value="50%"
+                  >
+                    50%
+                  </option>
+                  <option
+                    value="40%"
+                  >
+                    40%
+                  </option>
+                  <option
+                    value="30%"
+                  >
+                    30%
+                  </option>
+                  <option
+                    value="20%"
+                  >
+                    20%
+                  </option>
+                  <option
+                    value="10%"
+                  >
+                    10%
+                  </option>
+                  <option
+                    value="-"
+                  >
+                    -
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div
+              class="smv-read-only"
+            >
+              <p
+                class="lbh-body smv-read-only--label"
+              >
+                SMV
+              </p>
+              <p
+                class="lbh-body smv-read-only--value"
+              >
+                38
+              </p>
+            </div>
+          </div>
+          <div
+            class="operatives-group"
+          >
+            <div
+              class="govuk-form-group lbh-form-group operative-datalist"
+              id="operative-1-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="operative-1"
+              >
+                Operative name 2 *  
+              </label>
+              <input
+                autocomplete="off"
+                class="govuk-select lbh-select govuk-!-width-full"
+                data-testid="operative-1"
+                id="operative-1"
+                list="autocomplete-list-operative-1"
+                name="operative-1"
+                value="Operative B [2]"
+              />
+              <datalist
+                id="autocomplete-list-operative-1"
+              >
+                <option
+                  value="Operative A [1]"
+                />
+                <option
+                  value="Operative B [2]"
+                />
+              </datalist>
+            </div>
+            <div
+              class="select-percentage"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+                id="percentage-1-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label"
+                  for="percentage-1"
+                >
+                  Work done 
+                </label>
+                <select
+                  class="govuk-select lbh-select undefined"
+                  data-testid="percentage-1"
+                  id="percentage-1"
+                  name="percentage-1"
+                >
+                  <option
+                    value=""
+                  />
+                  <option
+                    value="100%"
+                  >
+                    100%
+                  </option>
+                  <option
+                    value="90%"
+                  >
+                    90%
+                  </option>
+                  <option
+                    value="80%"
+                  >
+                    80%
+                  </option>
+                  <option
+                    value="70%"
+                  >
+                    70%
+                  </option>
+                  <option
+                    value="60%"
+                  >
+                    60%
+                  </option>
+                  <option
+                    value="50%"
+                  >
+                    50%
+                  </option>
+                  <option
+                    value="40%"
+                  >
+                    40%
+                  </option>
+                  <option
+                    value="30%"
+                  >
+                    30%
+                  </option>
+                  <option
+                    value="20%"
+                  >
+                    20%
+                  </option>
+                  <option
+                    value="10%"
+                  >
+                    10%
+                  </option>
+                  <option
+                    value="-"
+                  >
+                    -
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div
+              class="smv-read-only"
+            >
+              <p
+                class="lbh-body smv-read-only--label"
+              >
+                SMV
+              </p>
+              <p
+                class="lbh-body smv-read-only--value"
+              >
+                38
+              </p>
+            </div>
+          </div>
+          <div>
+            <a
+              class="lbh-link"
+              href="#"
+            >
+              + Add operative
+            </a>
+          </div>
+          <div>
+            <a
+              class="lbh-link"
+              href="#"
+            >
+              - Remove last operative
+            </a>
+          </div>
+        </div>
+      </fieldset>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <legend
+          class="govuk-fieldset__legend govuk-fieldset__legend--s"
+        >
+          Payment type 
+        </legend>
+        <span
+          class="govuk-hint lbh-hint"
+          id="paymentType-hint"
+        />
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Bonus"
+              name="paymentType"
+              type="radio"
+              value="Bonus"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Bonus"
+            >
+              Bonus calculation
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-overtime-hint"
+              checked=""
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Overtime"
+              name="paymentType"
+              type="radio"
+              value="Overtime"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Overtime"
+            >
+              Overtime work order
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-overtime-hint"
+            >
+              SMVs not included in Bonus
+            </span>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-closetobase-hint"
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_CloseToBase"
+              name="paymentType"
+              type="radio"
+              value="CloseToBase"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_CloseToBase"
+            >
+              Close to base
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-closetobase-hint"
+            >
+              Operative payment made
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+        id="notes-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="notes"
+        >
+          Add notes
+        </label>
+        <textarea
+          aria-describedby="notes-hint notes-error"
+          class="govuk-textarea lbh-textarea"
+          data-testid="notes"
+          id="notes"
+          name="notes"
+          rows="4"
+        >
+          this is a note
+        </textarea>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <button
+          class="govuk-button lbh-button"
+          data-module="govuk-button"
+          type="submit"
+        >
+          Close work order
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`CloseWorkOrderForm component - when follow-on functionality is enabled should render properly 1`] = `
+<DocumentFragment>
+  <div
+    class="close-work-order-form"
+  >
+    <a
+      class="govuk-back-link lbh-back-link govuk-!-display-none-print"
+      role="button"
+    >
+      Back
+    </a>
+    <h1
+      class="lbh-heading-h2"
+    >
+      Close work order: 10000012
+    </h1>
+    <form
+      role="form"
+    >
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <legend
+          class="govuk-fieldset__legend govuk-fieldset__legend--s"
+        >
+          Reason for closing 
+        </legend>
+        <span
+          class="govuk-hint lbh-hint"
+          id="reason-hint"
+        />
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_Work Order Completed"
+              name="reason"
+              type="radio"
+              value="Work Order Completed"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_Work Order Completed"
+            >
+              Visit completed
+            </label>
+          </div>
+          <div
+            class="govuk-radios__conditional"
+            id="conditional-contact"
+          />
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              checked=""
+              class="govuk-radios__input"
+              data-testid="reason"
+              id="reason_No Access"
+              name="reason"
+              type="radio"
+              value="No Access"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="reason_No Access"
+            >
+              No access
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <div>
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+            for="fileUpload"
+            id="fileUploadLegend"
+          >
+            Photos 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="photos-hint"
+          >
+            Select all the photos you want to add (up to 10 photos)
+          </span>
+          <input
+            accept=".jpg, .jpeg, .png"
+            aria-labelledby="fileUploadLegend"
+            class="govuk-file-upload custom-file-input"
+            data-testid="fileUploadInput"
+            id="fileUpload"
+            multiple=""
+            name="fileUpload"
+            style="margin-top: 10px;"
+            type="file"
+          />
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label lbh-label govuk-label--m"
+          for="startDate"
+        >
+          Select start date (optional) 
+        </label>
+        <span
+          class="govuk-hint lbh-hint"
+          id="startDate-hint"
+        >
+          For example, 15/05/2021
+        </span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          data-testid="startDate"
+          id="startDate"
+          name="startDate"
+          type="date"
+          value="2021-01-12"
+        />
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <fieldset
+          aria-describedby="startTime-hint"
+          class="govuk-fieldset lbh-fieldset"
+          role="group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Start time (optional) 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="startTime-hint"
+          >
+            Use 24h format. For example, 14:30
+          </span>
+          <div
+            class="govuk-date-input lbh-date-input"
+            id="startTime"
+          >
+            <div
+              class="govuk-date-input__item"
+            >
+              <label
+                class="govuk-label lbh-label govuk-date-input__label"
+                for="startTime-hour"
+              >
+                Hour
+              </label>
+              <input
+                class="govuk-input lbh-input govuk-date-input__input govuk-input--width-2"
+                data-testid="startTime-hour"
+                id="startTime-hour"
+                inputmode="numeric"
+                name="startTime-hour"
+                pattern="^\\\\d{1,2}$"
+                type="text"
+                value="14"
+              />
+            </div>
+            <div
+              class="govuk-date-input__item"
+            >
+              <label
+                class="govuk-label lbh-label govuk-date-input__label"
+                for="startTime-minutes"
+              >
+                Minutes
+              </label>
+              <input
+                class="govuk-input govuk-date-input__input govuk-input--width-2"
+                data-testid="startTime-minutes"
+                id="startTime-minutes"
+                inputmode="numeric"
+                name="startTime-minutes"
+                pattern="^\\\\d{1,2}$"
+                type="text"
+                value="30"
+              />
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <label
+          class="govuk-label lbh-label govuk-label--m"
+          for="completionDate"
+        >
+          Select completion date 
+        </label>
+        <span
+          class="govuk-hint lbh-hint"
+          id="completionDate-hint"
+        >
+          For example, 15/05/2021
+        </span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          data-testid="completionDate"
+          id="completionDate"
+          name="completionDate"
+          type="date"
+          value="2021-01-12"
+        />
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <fieldset
+          aria-describedby="completionTime-hint"
+          class="govuk-fieldset lbh-fieldset"
+          role="group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Completion time 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="completionTime-hint"
+          >
+            Use 24h format. For example, 14:30
+          </span>
+          <div
+            class="govuk-date-input lbh-date-input"
+            id="completionTime"
+          >
+            <div
+              class="govuk-date-input__item"
+            >
+              <label
+                class="govuk-label lbh-label govuk-date-input__label"
+                for="completionTime-hour"
+              >
+                Hour
+              </label>
+              <input
+                class="govuk-input lbh-input govuk-date-input__input govuk-input--width-2"
+                data-testid="completionTime-hour"
+                id="completionTime-hour"
+                inputmode="numeric"
+                name="completionTime-hour"
+                pattern="^\\\\d{1,2}$"
+                type="text"
+                value="14"
+              />
+            </div>
+            <div
+              class="govuk-date-input__item"
+            >
+              <label
+                class="govuk-label lbh-label govuk-date-input__label"
+                for="completionTime-minutes"
+              >
+                Minutes
+              </label>
+              <input
+                class="govuk-input govuk-date-input__input govuk-input--width-2"
+                data-testid="completionTime-minutes"
+                id="completionTime-minutes"
+                inputmode="numeric"
+                name="completionTime-minutes"
+                pattern="^\\\\d{1,2}$"
+                type="text"
+                value="30"
+              />
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <fieldset
+        aria-describedby="completionTime-hint"
+        class="govuk-fieldset lbh-fieldset"
+        role="group"
+      >
+        <div
+          class="operatives govuk-form-group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Operatives
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="completionTime-hint"
+          >
+            Search by operative name and select from the list
+          </span>
+          <div
+            class="operatives-group"
+          >
+            <div
+              class="govuk-form-group lbh-form-group operative-datalist"
+              id="operative-0-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="operative-0"
+              >
+                Operative name 1 *  
+              </label>
+              <input
+                autocomplete="off"
+                class="govuk-select lbh-select govuk-!-width-full"
+                data-testid="operative-0"
+                id="operative-0"
+                list="autocomplete-list-operative-0"
+                name="operative-0"
+                value="Operative A [1]"
+              />
+              <datalist
+                id="autocomplete-list-operative-0"
+              >
+                <option
+                  value="Operative A [1]"
+                />
+                <option
+                  value="Operative B [2]"
+                />
+              </datalist>
+            </div>
+            <div
+              class="select-percentage"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+                id="percentage-0-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label"
+                  for="percentage-0"
+                >
+                  Work done 
+                </label>
+                <select
+                  class="govuk-select lbh-select undefined"
+                  data-testid="percentage-0"
+                  id="percentage-0"
+                  name="percentage-0"
+                >
+                  <option
+                    value=""
+                  />
+                  <option
+                    value="100%"
+                  >
+                    100%
+                  </option>
+                  <option
+                    value="90%"
+                  >
+                    90%
+                  </option>
+                  <option
+                    value="80%"
+                  >
+                    80%
+                  </option>
+                  <option
+                    value="70%"
+                  >
+                    70%
+                  </option>
+                  <option
+                    value="60%"
+                  >
+                    60%
+                  </option>
+                  <option
+                    value="50%"
+                  >
+                    50%
+                  </option>
+                  <option
+                    value="40%"
+                  >
+                    40%
+                  </option>
+                  <option
+                    value="30%"
+                  >
+                    30%
+                  </option>
+                  <option
+                    value="20%"
+                  >
+                    20%
+                  </option>
+                  <option
+                    value="10%"
+                  >
+                    10%
+                  </option>
+                  <option
+                    value="-"
+                  >
+                    -
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div
+              class="smv-read-only"
+            >
+              <p
+                class="lbh-body smv-read-only--label"
+              >
+                SMV
+              </p>
+              <p
+                class="lbh-body smv-read-only--value"
+              >
+                38
+              </p>
+            </div>
+          </div>
+          <div
+            class="operatives-group"
+          >
+            <div
+              class="govuk-form-group lbh-form-group operative-datalist"
+              id="operative-1-form-group"
+            >
+              <label
+                class="govuk-label lbh-label"
+                for="operative-1"
+              >
+                Operative name 2 *  
+              </label>
+              <input
+                autocomplete="off"
+                class="govuk-select lbh-select govuk-!-width-full"
+                data-testid="operative-1"
+                id="operative-1"
+                list="autocomplete-list-operative-1"
+                name="operative-1"
+                value="Operative B [2]"
+              />
+              <datalist
+                id="autocomplete-list-operative-1"
+              >
+                <option
+                  value="Operative A [1]"
+                />
+                <option
+                  value="Operative B [2]"
+                />
+              </datalist>
+            </div>
+            <div
+              class="select-percentage"
+            >
+              <div
+                class="govuk-form-group lbh-form-group"
+                id="percentage-1-form-group"
+              >
+                <label
+                  class="govuk-label lbh-label"
+                  for="percentage-1"
+                >
+                  Work done 
+                </label>
+                <select
+                  class="govuk-select lbh-select undefined"
+                  data-testid="percentage-1"
+                  id="percentage-1"
+                  name="percentage-1"
+                >
+                  <option
+                    value=""
+                  />
+                  <option
+                    value="100%"
+                  >
+                    100%
+                  </option>
+                  <option
+                    value="90%"
+                  >
+                    90%
+                  </option>
+                  <option
+                    value="80%"
+                  >
+                    80%
+                  </option>
+                  <option
+                    value="70%"
+                  >
+                    70%
+                  </option>
+                  <option
+                    value="60%"
+                  >
+                    60%
+                  </option>
+                  <option
+                    value="50%"
+                  >
+                    50%
+                  </option>
+                  <option
+                    value="40%"
+                  >
+                    40%
+                  </option>
+                  <option
+                    value="30%"
+                  >
+                    30%
+                  </option>
+                  <option
+                    value="20%"
+                  >
+                    20%
+                  </option>
+                  <option
+                    value="10%"
+                  >
+                    10%
+                  </option>
+                  <option
+                    value="-"
+                  >
+                    -
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div
+              class="smv-read-only"
+            >
+              <p
+                class="lbh-body smv-read-only--label"
+              >
+                SMV
+              </p>
+              <p
+                class="lbh-body smv-read-only--value"
+              >
+                38
+              </p>
+            </div>
+          </div>
+          <div>
+            <a
+              class="lbh-link"
+              href="#"
+            >
+              + Add operative
+            </a>
+          </div>
+          <div>
+            <a
+              class="lbh-link"
+              href="#"
+            >
+              - Remove last operative
+            </a>
+          </div>
+        </div>
+      </fieldset>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <legend
+          class="govuk-fieldset__legend govuk-fieldset__legend--s"
+        >
+          Payment type 
+        </legend>
+        <span
+          class="govuk-hint lbh-hint"
+          id="paymentType-hint"
+        />
+        <div
+          class="govuk-radios lbh-radios"
+        >
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Bonus"
+              name="paymentType"
+              type="radio"
+              value="Bonus"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Bonus"
+            >
+              Bonus calculation
+            </label>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-overtime-hint"
+              checked=""
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_Overtime"
+              name="paymentType"
+              type="radio"
+              value="Overtime"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_Overtime"
+            >
+              Overtime work order
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-overtime-hint"
+            >
+              SMVs not included in Bonus
+            </span>
+          </div>
+          <div
+            class="govuk-radios__item"
+          >
+            <input
+              aria-describedby="paymentType-closetobase-hint"
+              class="govuk-radios__input"
+              data-testid="paymentType"
+              id="paymentType_CloseToBase"
+              name="paymentType"
+              type="radio"
+              value="CloseToBase"
+            />
+            <label
+              class="govuk-label lbh-label govuk-radios__label"
+              for="paymentType_CloseToBase"
+            >
+              Close to base
+            </label>
+            <span
+              class="govuk-hint govuk-radios__hint"
+              id="paymentType-closetobase-hint"
+            >
+              Operative payment made
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+        id="notes-form-group"
+      >
+        <label
+          class="govuk-label lbh-label"
+          for="notes"
+        >
+          Add notes
+        </label>
+        <textarea
+          aria-describedby="notes-hint notes-error"
+          class="govuk-textarea lbh-textarea"
+          data-testid="notes"
+          id="notes"
+          name="notes"
+          rows="4"
+        >
+          this is a note
+        </textarea>
+      </div>
+      <div
+        class="govuk-form-group lbh-form-group"
+      >
+        <button
+          class="govuk-button lbh-button"
+          data-module="govuk-button"
+          type="submit"
+        >
+          Close work order
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`CloseWorkOrderForm component should not render startDate or startTime 1`] = `
 <DocumentFragment>
   <div

--- a/src/components/WorkOrders/__snapshots__/MobileWorkingCloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/MobileWorkingCloseWorkOrderForm.test.js.snap
@@ -1,5 +1,333 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MobileWorkingCloseWorkOrderForm component - when follow-on functionality is enabled should render properly 1`] = `
+<DocumentFragment>
+  <div
+    class="mobile-working-close-work-order-form"
+  >
+    <a
+      class="govuk-back-link lbh-back-link govuk-!-display-none-print"
+      role="button"
+    >
+      Back
+    </a>
+    <form
+      role="form"
+    >
+      <div
+        style="display: block;"
+      >
+        <h1
+          class="lbh-heading-h2"
+        >
+          Close work order
+        </h1>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend--s"
+          >
+            Reason for closing 
+          </legend>
+          <span
+            class="govuk-hint lbh-hint"
+            id="reason-hint"
+          />
+          <div
+            class="govuk-radios lbh-radios"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                data-testid="reason"
+                id="reason_Work Order Completed"
+                name="reason"
+                type="radio"
+                value="Work Order Completed"
+              />
+              <label
+                class="govuk-label lbh-label govuk-radios__label"
+                for="reason_Work Order Completed"
+              >
+                Visit completed
+              </label>
+            </div>
+            <div
+              class="govuk-radios__conditional"
+              id="conditional-contact"
+            />
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                data-testid="reason"
+                id="reason_No Access"
+                name="reason"
+                type="radio"
+                value="No Access"
+              />
+              <label
+                class="govuk-label lbh-label govuk-radios__label"
+                for="reason_No Access"
+              >
+                No access
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <div>
+            <legend
+              class="govuk-fieldset__legend govuk-fieldset__legend--s"
+              for="fileUpload"
+              id="fileUploadLegend"
+            >
+              Photos 
+            </legend>
+            <span
+              class="govuk-hint lbh-hint"
+              id="photos-hint"
+            >
+              Select all the photos you want to add (up to 10 photos)
+            </span>
+            <input
+              accept=".jpg, .jpeg, .png"
+              aria-labelledby="fileUploadLegend"
+              class="govuk-file-upload custom-file-input"
+              data-testid="fileUploadInput"
+              id="fileUpload"
+              multiple=""
+              name="fileUpload"
+              style="margin-top: 10px;"
+              type="file"
+            />
+          </div>
+        </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="notes-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="notes"
+          >
+            Final report
+          </label>
+          <textarea
+            aria-describedby="notes-hint notes-error"
+            class="govuk-textarea lbh-textarea"
+            data-testid="notes"
+            id="notes"
+            name="notes"
+            rows="4"
+          />
+        </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Close work order
+          </button>
+        </div>
+      </div>
+      <div
+        style="display: none;"
+      >
+        <h1
+          class="lbh-heading-h2"
+        >
+          Details of further work required
+        </h1>
+        <fieldset
+          class="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2 lbh-fieldset"
+        >
+          <div
+            class="lbh-form-group"
+          >
+            <label
+              class="govuk-label govuk-label--m"
+              for=""
+            >
+              Type of work required
+            </label>
+            <div
+              class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-margin-bottom-5"
+            >
+              <input
+                class="govuk-checkboxes__input"
+                data-testid="isSameTrade"
+                id="isSameTrade"
+                name="isSameTrade"
+                type="checkbox"
+              />
+              <label
+                class="govuk-label govuk-checkboxes__label lbh-body-xs govuk-!-margin-0"
+                for="isSameTrade"
+              >
+                Same trade
+              </label>
+            </div>
+            <div
+              class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-margin-bottom-5"
+            >
+              <input
+                class="govuk-checkboxes__input"
+                data-testid="isDifferentTrades"
+                id="isDifferentTrades"
+                name="isDifferentTrades"
+                type="checkbox"
+              />
+              <label
+                class="govuk-label govuk-checkboxes__label lbh-body-xs govuk-!-margin-0"
+                for="isDifferentTrades"
+              >
+                Different trade(s)
+              </label>
+            </div>
+            <div
+              class="govuk-checkboxes__item govuk-!-margin-0 govuk-!-margin-bottom-5"
+            >
+              <input
+                class="govuk-checkboxes__input"
+                data-testid="isMultipleOperatives"
+                id="isMultipleOperatives"
+                name="isMultipleOperatives"
+                type="checkbox"
+              />
+              <label
+                class="govuk-label govuk-checkboxes__label lbh-body-xs govuk-!-margin-0"
+                for="isMultipleOperatives"
+              >
+                Multiple operatives
+              </label>
+            </div>
+          </div>
+        </fieldset>
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="followOnTypeDescription-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="followOnTypeDescription"
+          >
+            Describe work required
+          </label>
+          <textarea
+            aria-describedby="followOnTypeDescription-hint followOnTypeDescription-error"
+            class="govuk-textarea lbh-textarea"
+            data-testid="followOnTypeDescription"
+            id="followOnTypeDescription"
+            name="followOnTypeDescription"
+            rows="4"
+          />
+        </div>
+        <fieldset>
+          <label
+            class="govuk-label govuk-label--m"
+          >
+            Materials
+          </label>
+          <div
+            class="govuk-checkboxes__item govuk-!-margin-0"
+          >
+            <input
+              class="govuk-checkboxes__input"
+              data-testid="stockItemsRequired"
+              id="stockItemsRequired"
+              name="stockItemsRequired"
+              type="checkbox"
+            />
+            <label
+              class="govuk-label govuk-checkboxes__label lbh-body-xs govuk-!-margin-0 govuk-!-margin-bottom-5"
+              for="stockItemsRequired"
+            >
+              Stock items required
+            </label>
+          </div>
+          <div
+            class="govuk-checkboxes__item govuk-!-margin-0"
+          >
+            <input
+              class="govuk-checkboxes__input"
+              data-testid="nonStockItemsRequired"
+              id="nonStockItemsRequired"
+              name="nonStockItemsRequired"
+              type="checkbox"
+            />
+            <label
+              class="govuk-label govuk-checkboxes__label lbh-body-xs govuk-!-margin-0 govuk-!-margin-bottom-5"
+              for="nonStockItemsRequired"
+            >
+              Non stock items required
+            </label>
+          </div>
+        </fieldset>
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="materialNotes-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="materialNotes"
+          >
+            Materials required
+          </label>
+          <textarea
+            aria-describedby="materialNotes-hint materialNotes-error"
+            class="govuk-textarea lbh-textarea"
+            data-testid="materialNotes"
+            id="materialNotes"
+            name="materialNotes"
+            rows="4"
+          />
+        </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+          id="additionalNotes-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="additionalNotes"
+          >
+            Additional notes
+          </label>
+          <textarea
+            aria-describedby="additionalNotes-hint additionalNotes-error"
+            class="govuk-textarea lbh-textarea"
+            data-testid="additionalNotes"
+            id="additionalNotes"
+            name="additionalNotes"
+            rows="4"
+          />
+        </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <button
+            class="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+          >
+            Close work order
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`MobileWorkingCloseWorkOrderForm component should render properly 1`] = `
 <DocumentFragment>
   <div

--- a/src/components/WorkOrders/__snapshots__/MobileWorkingCloseWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrders/__snapshots__/MobileWorkingCloseWorkOrderForm.test.js.snap
@@ -384,10 +384,6 @@ exports[`MobileWorkingCloseWorkOrderForm component should render properly 1`] = 
               </label>
             </div>
             <div
-              class="govuk-radios__conditional"
-              id="conditional-contact"
-            />
-            <div
               class="govuk-radios__item"
             >
               <input

--- a/src/pages/api/simple-feature-toggle/index.ts
+++ b/src/pages/api/simple-feature-toggle/index.ts
@@ -1,0 +1,11 @@
+import * as HttpStatus from 'http-status-codes'
+import { authoriseServiceAPIRequest } from '@/utils/serviceApiClient'
+
+export default authoriseServiceAPIRequest(async (req, res) => {
+  const data = {
+    followOnFunctionalityEnabled:
+      process.env.FOLLOW_ON_FUNCTIONALITY_ENABLED === 'true',
+  }
+
+  res.status(HttpStatus.StatusCodes.OK).json(data)
+})

--- a/src/utils/frontEndApiClient/requests.ts
+++ b/src/utils/frontEndApiClient/requests.ts
@@ -30,6 +30,15 @@ export const frontEndApiRequest = async ({
   return data
 }
 
+export const fetchSimpleFeatureToggles = async () => {
+  const featureToggleData = await frontEndApiRequest({
+    method: 'get',
+    path: '/api/simple-feature-toggle',
+  })
+
+  return featureToggleData
+}
+
 export const fetchFeatureToggles = async () => {
   try {
     const configurationData = await frontEndApiRequest({

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
@@ -13,7 +13,84 @@ describe('buildCloseWorkOrderData', () => {
         'A note',
         '00000001',
         'No Access',
-        'Payment type string'
+        'Payment type string',
+        false
+      )
+    ).toEqual({
+      workOrderReference: { id: '00000001', description: '', allocatedBy: '' },
+      jobStatusUpdates: [
+        {
+          typeCode: '70',
+          otherType: 'completed',
+          comments: 'Work order closed - A note',
+          eventTime: completionDate,
+          paymentType: 'Payment type string',
+          noteGeneratedOnFrontend: false,
+        },
+      ],
+    })
+  })
+
+  it('builds form with noteGeneratedOnFrontend set as false', () => {
+    expect(
+      buildCloseWorkOrderData(
+        completionDate,
+        'A note',
+        '00000001',
+        'Completed',
+        'Payment type string',
+        false
+      )
+    ).toEqual({
+      workOrderReference: { id: '00000001', description: '', allocatedBy: '' },
+      jobStatusUpdates: [
+        {
+          typeCode: '0',
+          otherType: 'completed',
+          comments: 'Work order closed - A note',
+          eventTime: completionDate,
+          paymentType: 'Payment type string',
+          noteGeneratedOnFrontend: false,
+        },
+      ],
+    })
+  })
+
+  it('has a typeCode of 0 when supplied a reason of "Work Order Completed"', () => {
+    const response = buildCloseWorkOrderData(
+      null,
+      null,
+      null,
+      'Work Order Completed',
+      false
+    )
+    expect(response.jobStatusUpdates[0].typeCode).toEqual('0')
+  })
+
+  it('has a typeCode of 70 when supplied a reason of "No Access"', () => {
+    const response = buildCloseWorkOrderData(
+      null,
+      null,
+      null,
+      'No Access',
+      false
+    )
+    expect(response.jobStatusUpdates[0].typeCode).toEqual('70')
+  })
+})
+
+describe('buildCloseWorkOrderData - when follow on feature toggle enabled', () => {
+  const completionDate = new Date()
+
+  it('builds form data with workOrderReference and jobStatusUpdate attributes', () => {
+    expect(
+      buildCloseWorkOrderData(
+        completionDate,
+        'A note',
+        '00000001',
+        'No Access',
+        'Payment type string',
+        true
       )
     ).toEqual({
       workOrderReference: { id: '00000001', description: '', allocatedBy: '' },
@@ -37,7 +114,8 @@ describe('buildCloseWorkOrderData', () => {
         'A note',
         '00000001',
         'Completed',
-        'Payment type string'
+        'Payment type string',
+        true
       )
     ).toEqual({
       workOrderReference: { id: '00000001', description: '', allocatedBy: '' },
@@ -59,13 +137,20 @@ describe('buildCloseWorkOrderData', () => {
       null,
       null,
       null,
-      'Work Order Completed'
+      'Work Order Completed',
+      true
     )
     expect(response.jobStatusUpdates[0].typeCode).toEqual('0')
   })
 
   it('has a typeCode of 70 when supplied a reason of "No Access"', () => {
-    const response = buildCloseWorkOrderData(null, null, null, 'No Access')
+    const response = buildCloseWorkOrderData(
+      null,
+      null,
+      null,
+      'No Access',
+      true
+    )
     expect(response.jobStatusUpdates[0].typeCode).toEqual('70')
   })
 })

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.test.js
@@ -10,7 +10,7 @@ describe('buildCloseWorkOrderData', () => {
     expect(
       buildCloseWorkOrderData(
         completionDate,
-        'A note',
+        'Work order closed - A note',
         '00000001',
         'No Access',
         'Payment type string',
@@ -35,7 +35,7 @@ describe('buildCloseWorkOrderData', () => {
     expect(
       buildCloseWorkOrderData(
         completionDate,
-        'A note',
+        'Work order closed - A note',
         '00000001',
         'Completed',
         'Payment type string',
@@ -86,7 +86,7 @@ describe('buildCloseWorkOrderData - when follow on feature toggle enabled', () =
     expect(
       buildCloseWorkOrderData(
         completionDate,
-        'A note',
+        'Work order closed - A note',
         '00000001',
         'No Access',
         'Payment type string',
@@ -98,7 +98,7 @@ describe('buildCloseWorkOrderData - when follow on feature toggle enabled', () =
         {
           typeCode: '70',
           otherType: 'completed',
-          comments: 'A note',
+          comments: 'Work order closed - A note',
           eventTime: completionDate,
           paymentType: 'Payment type string',
           noteGeneratedOnFrontend: false,

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.ts
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.ts
@@ -80,8 +80,6 @@ export const buildCloseWorkOrderData = (
     if (followOnRequest !== null) {
       dataObject['followOnRequest'] = followOnRequest
     }
-  } else if (reason != 'No Access') {
-    jobStatusUpdate.comments = `Work order closed - ${notes}`
   }
 
   return dataObject

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.ts
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.ts
@@ -80,7 +80,7 @@ export const buildCloseWorkOrderData = (
     if (followOnRequest !== null) {
       dataObject['followOnRequest'] = followOnRequest
     }
-  } else {
+  } else if (reason == 'No Access') {
     jobStatusUpdate.comments = `Work order closed - ${notes}`
   }
 

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.ts
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.ts
@@ -80,7 +80,7 @@ export const buildCloseWorkOrderData = (
     if (followOnRequest !== null) {
       dataObject['followOnRequest'] = followOnRequest
     }
-  } else if (reason == 'No Access') {
+  } else if (reason != 'No Access') {
     jobStatusUpdate.comments = `Work order closed - ${notes}`
   }
 

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.ts
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.ts
@@ -47,6 +47,7 @@ export const buildCloseWorkOrderData = (
   reference: string,
   reason: string,
   paymentType: string,
+  followOnFunctionalityEnabled: boolean,
   followOnRequest: followOnDataRequest = null
 ): closeWorkOrderDataRequest => {
   const typeCode = reason == 'No Access' ? '70' : '0'
@@ -60,11 +61,6 @@ export const buildCloseWorkOrderData = (
     noteGeneratedOnFrontend: false,
   }
 
-  if (typeCode === '0') {
-    // completed job note is generated on frontend
-    jobStatusUpdate.noteGeneratedOnFrontend = true
-  }
-
   const dataObject = {
     workOrderReference: {
       id: reference,
@@ -74,8 +70,18 @@ export const buildCloseWorkOrderData = (
     jobStatusUpdates: [jobStatusUpdate],
   }
 
-  if (followOnRequest !== null) {
-    dataObject['followOnRequest'] = followOnRequest
+  // feature toggle
+  if (followOnFunctionalityEnabled) {
+    if (typeCode === '0') {
+      // completed job note is generated on frontend
+      jobStatusUpdate.noteGeneratedOnFrontend = true
+    }
+
+    if (followOnRequest !== null) {
+      dataObject['followOnRequest'] = followOnRequest
+    }
+  } else {
+    jobStatusUpdate.comments = `Work order closed - ${notes}`
   }
 
   return dataObject


### PR DESCRIPTION
## Summary of Changes

Add feature toggle to disable follow-on functionality.

I wanted to clone the E2E tests so I can test when the FT was enabled and disabled. Using an enviornment variable made this impossible due to how NextJs works.

The solution was to add a featureToggle endpoint. The endpoint simply reads the environment variable. This made testing much easier as I can intercept the request to the feature toggle endpoint. 

I decided against using the configuration API because it was too confusing. Whereas setting up a new API endpoint in nextjs is increadibly simple.

### Additional changes

- I had to update a few components to typescript, as they were causing eslint to fail



note to self
```yml
      FOLLOW_ON_FUNCTIONALITY_ENABLED: ${ssm:/repairs-hub/${self:provider.stage}/repairs-hub-enable-followon-functionality}

```
