### PR TITLE
Try fix navigation error

### DIFF
--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -98,9 +98,10 @@ const Tabs = ({
           return (
             <li key={i} className="govuk-tabs__list-item">
               <a
-                onClick={() =>
+                onClick={(e) => {
+                  e.preventDefault()
                   setActiveTab(tabsList.find((elem) => elem === tab))
-                }
+                }}
                 className="govuk-tabs__tab"
                 href={`#${formatTabNameToId(tab)}`}
               >


### PR DESCRIPTION
### Description of change

The following error `Invariant: attempted to hard navigate to the same URL /work-orders/10411251 https://repairs-hub.hackney.gov.uk/work-orders/10411251#work-orders-history-tab` appears to be related to nextjs navigation.

https://stackoverflow.com/questions/74755177/nextjs-attempted-to-hard-navigate-to-the-same-url-error-while-passing-query-str

I cant replicate it on dev/staging, but this change should fix the issue.
