### PR TITLE
Increase provisioned concurrency to 14

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -157,6 +157,6 @@ custom:
       - subnet-0beb266003a56ca82
       - subnet-06a697d86a9b6ed01
   provisionedConcurrency:
-    development: 1
-    staging: 1
-    production: 6
+    development: 0
+    staging: 0
+    production: 14


### PR DESCRIPTION
Increase capasity to 90% of highest usage. This should make it clear if cold starts are effecting 500 errors