### PR TITLE
Group sentry logging by status code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,57 +233,58 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
-      - tests:
-          requires:
-            - install-dependencies
-      - e2e:
-          requires:
-            - install-dependencies
+      # - tests:
+      #     requires:
+      #       - install-dependencies
+      # - e2e:
+      #     requires:
+      #       - install-dependencies
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
-            - tests
-            - e2e
-          filters:
-            branches:
-              only: develop
+            # - tests
+            # - e2e
+            - install-dependencies
+          # filters:
+          #   branches:
+          #     only: develop
       - build-deploy-development:
           requires:
             - assume-role-development
-          filters:
-            branches:
-              only: develop
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          requires:
-            - tests
-            - e2e
-          filters:
-            branches:
-              only: main
-      - build-deploy-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: main
-      - permit-deploy-production:
-          type: approval
-          requires:
-            - build-deploy-staging
-          filters:
-            branches:
-              only: main
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          requires:
-            - permit-deploy-production
-          filters:
-            branches:
-              only: main
-      - build-deploy-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: develop
+      # - assume-role-staging:
+      #     context: api-assume-role-staging-context
+      #     requires:
+      #       - tests
+      #       - e2e
+      #     filters:
+      #       branches:
+      #         only: main
+      # - build-deploy-staging:
+      #     requires:
+      #       - assume-role-staging
+      #     filters:
+      #       branches:
+      #         only: main
+      # - permit-deploy-production:
+      #     type: approval
+      #     requires:
+      #       - build-deploy-staging
+      #     filters:
+      #       branches:
+      #         only: main
+      # - assume-role-production:
+      #     context: api-assume-role-housing-production-context
+      #     requires:
+      #       - permit-deploy-production
+      #     filters:
+      #       branches:
+      #         only: main
+      # - build-deploy-production:
+      #     requires:
+      #       - assume-role-production
+      #     filters:
+      #       branches:
+      #         only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,58 +233,57 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
-      # - tests:
-      #     requires:
-      #       - install-dependencies
-      # - e2e:
-      #     requires:
-      #       - install-dependencies
+      - tests:
+          requires:
+            - install-dependencies
+      - e2e:
+          requires:
+            - install-dependencies
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
-            # - tests
-            # - e2e
-            - install-dependencies
-          # filters:
-          #   branches:
-          #     only: develop
+            - tests
+            - e2e
+          filters:
+            branches:
+              only: develop
       - build-deploy-development:
           requires:
             - assume-role-development
-          # filters:
-          #   branches:
-          #     only: develop
-      # - assume-role-staging:
-      #     context: api-assume-role-staging-context
-      #     requires:
-      #       - tests
-      #       - e2e
-      #     filters:
-      #       branches:
-      #         only: main
-      # - build-deploy-staging:
-      #     requires:
-      #       - assume-role-staging
-      #     filters:
-      #       branches:
-      #         only: main
-      # - permit-deploy-production:
-      #     type: approval
-      #     requires:
-      #       - build-deploy-staging
-      #     filters:
-      #       branches:
-      #         only: main
-      # - assume-role-production:
-      #     context: api-assume-role-housing-production-context
-      #     requires:
-      #       - permit-deploy-production
-      #     filters:
-      #       branches:
-      #         only: main
-      # - build-deploy-production:
-      #     requires:
-      #       - assume-role-production
-      #     filters:
-      #       branches:
-      #         only: main
+          filters:
+            branches:
+              only: develop
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          requires:
+            - tests
+            - e2e
+          filters:
+            branches:
+              only: main
+      - build-deploy-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: main
+      - permit-deploy-production:
+          type: approval
+          requires:
+            - build-deploy-staging
+          filters:
+            branches:
+              only: main
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+            - permit-deploy-production
+          filters:
+            branches:
+              only: main
+      - build-deploy-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: main

--- a/src/utils/serviceApiClient.js
+++ b/src/utils/serviceApiClient.js
@@ -234,24 +234,20 @@ export const authoriseServiceAPIRequest = (callBack) => {
     } catch (error) {
       const errorResponse = error.response
 
-      // Helper function to categorize errors
       const categorizeError = (error) => {
         if (errorResponse?.status) {
-          // API Errors
           return {
             category: 'api_error',
             statusCode: errorResponse.status,
             type: HttpStatus.getStatusText(errorResponse.status),
           }
         } else if (error.request) {
-          // Network Errors
           return {
             category: 'network_error',
             statusCode: 0,
             type: 'CONNECTION_FAILURE',
           }
         } else {
-          // Client Setup Errors
           return {
             category: 'setup_error',
             statusCode: -1,
@@ -262,28 +258,24 @@ export const authoriseServiceAPIRequest = (callBack) => {
 
       const errorCategory = categorizeError(error)
 
-      // Configure Sentry context for this error
       Sentry.configureScope((scope) => {
         // Add error metadata
         scope.setTag('error.category', errorCategory.category)
         scope.setTag('error.status_code', errorCategory.statusCode)
         scope.setTag('error.type', errorCategory.type)
 
-        // Add request context
         scope.setContext('request', {
           path: req.path,
           method: req.method,
           query: req.query,
         })
 
-        // Set fingerprint to group similar errors
         scope.setFingerprint([
           errorCategory.category,
           errorCategory.statusCode.toString(),
           errorCategory.type,
         ])
 
-        // Add extra context for API errors
         if (errorResponse) {
           scope.setContext('api_response', {
             status: errorResponse.status,
@@ -293,12 +285,10 @@ export const authoriseServiceAPIRequest = (callBack) => {
         }
       })
 
-      // Capture the exception with enhanced context
       Sentry.captureException(error, {
         level: errorResponse?.status >= 500 ? 'error' : 'warning',
       })
 
-      // Log error details
       if (errorResponse) {
         logger.error(
           'Service API response',

--- a/src/utils/serviceApiClient.js
+++ b/src/utils/serviceApiClient.js
@@ -213,6 +213,7 @@ export const authoriseServiceAPIRequest = (callBack) => {
         Sentry.setUser({ name: user.name, email: user.email })
       }
 
+      // Configure cookie removal in Sentry scope
       Sentry.configureScope((scope) => {
         scope.addEventProcessor((event) => {
           if (event.request?.cookies[GSSO_TOKEN_NAME]) {
@@ -231,11 +232,74 @@ export const authoriseServiceAPIRequest = (callBack) => {
       // Call the function defined in the API route
       return await callBack(req, res, user)
     } catch (error) {
-      Sentry.captureException(error)
-
       const errorResponse = error.response
+
+      // Helper function to categorize errors
+      const categorizeError = (error) => {
+        if (errorResponse?.status) {
+          // API Errors
+          return {
+            category: 'api_error',
+            statusCode: errorResponse.status,
+            type: HttpStatus.getStatusText(errorResponse.status),
+          }
+        } else if (error.request) {
+          // Network Errors
+          return {
+            category: 'network_error',
+            statusCode: 0,
+            type: 'CONNECTION_FAILURE',
+          }
+        } else {
+          // Client Setup Errors
+          return {
+            category: 'setup_error',
+            statusCode: -1,
+            type: 'CLIENT_SETUP_ERROR',
+          }
+        }
+      }
+
+      const errorCategory = categorizeError(error)
+
+      // Configure Sentry context for this error
+      Sentry.configureScope((scope) => {
+        // Add error metadata
+        scope.setTag('error.category', errorCategory.category)
+        scope.setTag('error.status_code', errorCategory.statusCode)
+        scope.setTag('error.type', errorCategory.type)
+
+        // Add request context
+        scope.setContext('request', {
+          path: req.path,
+          method: req.method,
+          query: req.query,
+        })
+
+        // Set fingerprint to group similar errors
+        scope.setFingerprint([
+          errorCategory.category,
+          errorCategory.statusCode.toString(),
+          errorCategory.type,
+        ])
+
+        // Add extra context for API errors
+        if (errorResponse) {
+          scope.setContext('api_response', {
+            status: errorResponse.status,
+            statusText: errorResponse.statusText,
+            data: errorResponse.data,
+          })
+        }
+      })
+
+      // Capture the exception with enhanced context
+      Sentry.captureException(error, {
+        level: errorResponse?.status >= 500 ? 'error' : 'warning',
+      })
+
+      // Log error details
       if (errorResponse) {
-        // The request was made and the server responded with a non-200 status
         logger.error(
           'Service API response',
           JSON.stringify({
@@ -245,28 +309,22 @@ export const authoriseServiceAPIRequest = (callBack) => {
           })
         )
 
-        // When we get a 404 from the service API
         if (errorResponse?.status === HttpStatus.NOT_FOUND) {
           res
             .status(HttpStatus.NOT_FOUND)
             .json({ message: errorResponse?.data || 'Resource not found' })
         } else {
-          // Return the actual error status and message from the service API
           res
             .status(errorResponse?.status)
             .json({ message: errorResponse?.data || 'Service API error' })
         }
       } else if (error.request) {
-        // The request was made but no response was received
         logger.error('Cannot connect to Service API')
-
         res
           .status(HttpStatus.INTERNAL_SERVER_ERROR)
           .json({ message: 'No response received from Service API' })
       } else {
-        // Something happened in setting up the request that triggered an Error
         logger.error('API Client could not setup request', error.message)
-
         res
           .status(HttpStatus.INTERNAL_SERVER_ERROR)
           .json({ message: 'API Client request setup error' })


### PR DESCRIPTION
### Description of change

Due to how we're capturing errors, Sentry is clumping them all together. This makes it much more difficult to analyse.

![image](https://github.com/user-attachments/assets/b7aa70a4-f2f9-4633-8471-d36626abfee6)

Sentry after this change
![image](https://github.com/user-attachments/assets/9e46743a-d115-4248-a48c-5a37ea30b625)

The code is 100% written by a human
