### PR TITLE
Add backoffice tool for managing DRS sync

### DIFF
--- a/src/components/BackOffice/BackOfficeDashboard/index.tsx
+++ b/src/components/BackOffice/BackOfficeDashboard/index.tsx
@@ -1,21 +1,26 @@
 import Link from 'next/link'
 
+const links = [
+  { description: 'Add SOR Codes', link: '/backoffice/add-sor-codes' },
+  {
+    description: 'Add SOR contracts to properties',
+    link: '/backoffice/sor-contracts',
+  },
+  {
+    description: 'Bulk-close workOrders',
+    link: '/backoffice/close-workorders',
+  },
+  {
+    description: 'Operative mobile work order view',
+    link: '/backoffice/mobile-view',
+  },
+  {
+    description: 'DRS Sync Retry',
+    link: '/backoffice/drs-sync',
+  },
+]
+
 const BackOfficeDashboard = () => {
-  const links = [
-    { description: 'Add SOR Codes', link: '/backoffice/add-sor-codes' },
-    {
-      description: 'Add SOR contracts to properties',
-      link: '/backoffice/sor-contracts',
-    },
-    {
-      description: 'Bulk-close workOrders',
-      link: '/backoffice/close-workorders',
-    },
-    {
-      description: 'Operative mobile work order view',
-      link: '/backoffice/mobile-view',
-    },
-  ]
   return (
     <>
       <h1 className="lbh-heading-h1">BackOffice</h1>

--- a/src/components/BackOffice/DrsSync/index.tsx
+++ b/src/components/BackOffice/DrsSync/index.tsx
@@ -1,0 +1,211 @@
+import { frontEndApiRequest } from '@/root/src/utils/frontEndApiClient/requests'
+import Layout from '../Layout'
+import { useEffect, useState } from 'react'
+import SpinnerWithLabel from '../../SpinnerWithLabel'
+
+interface WorkOrderResponse {
+  reference: number
+  dateRaised: string
+  lastUpdated: Date | null
+  priority: string
+  priorityCode: number
+  property: string
+  propertyPostCode: string
+  owner: string
+  description: string
+  propertyReference: string
+  tradeCode: string
+  tradeDescription: string
+  status: string
+}
+
+const DrsSyncView = () => {
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [workOrders, setWorkOrders] = useState<WorkOrderResponse[]>(null)
+
+  const fetchWorkOrdersThatDidntSync = () => {
+    if (isLoading) return
+    setIsLoading(true)
+
+    frontEndApiRequest({
+      method: 'get',
+      path: '/api/backoffice/work-orders-by-sync-status',
+    })
+      .then((res) => {
+        console.log({ res })
+
+        setWorkOrders(res)
+      })
+      .catch((err) => {
+        console.error(err)
+        //   setRequestError(err.message)
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }
+
+  const handleResendToDrs = (workOrderId: number) => {
+    if (isLoading) return
+
+    if (!confirm('Have you confirmed the order doesnt exist in DRS?')) return
+
+    setIsLoading(true)
+
+    frontEndApiRequest({
+      method: 'post',
+      path: '/api/backoffice/resend-order',
+      requestData: {
+        workOrderId,
+      },
+    })
+      .then((res) => {
+        console.log({ res })
+
+        // setWorkOrders(res)
+        //   setFormSuccess(true)
+        //   clearForm()
+      })
+      .catch((err) => {
+        console.error(err)
+        //   setRequestError(err.message)
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }
+
+  const handleClearStatus = (workOrderId: number) => {
+    if (isLoading) return
+
+    if (!confirm('Are you sure?')) return
+
+    setIsLoading(true)
+
+    frontEndApiRequest({
+      method: 'post',
+      path: '/api/backoffice/reset-sync-status',
+      requestData: {
+        workOrderId,
+      },
+    })
+      .then((res) => {
+        console.log({ res })
+
+        // setWorkOrders(res)
+        //   setFormSuccess(true)
+        //   clearForm()
+      })
+      .catch((err) => {
+        console.error(err)
+        //   setRequestError(err.message)
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    fetchWorkOrdersThatDidntSync()
+  }, [])
+
+  const groupedByStatus: { [key: string]: number } = {}
+
+  workOrders?.forEach((workOrder) => {
+    if (groupedByStatus.hasOwnProperty(workOrder.status)) {
+      groupedByStatus[workOrder.status]++
+    } else {
+      groupedByStatus[workOrder.status] = 1
+    }
+  })
+
+  const [selectedFilter, setSelectedFilter] = useState<string>(null)
+
+  const filteredWorkOrders =
+    selectedFilter === null
+      ? workOrders
+      : workOrders.filter((x) => x.status === selectedFilter)
+
+  if (isLoading) return <SpinnerWithLabel label="Fetching work orders" />
+
+  return (
+    <>
+      <Layout title="Drs Sync Retry">
+        <>
+          <h2>Work orders that timed out</h2>
+
+          <div>
+            <button onClick={() => fetchWorkOrdersThatDidntSync()}>
+              Refresh
+            </button>
+          </div>
+
+          <div>
+            <ul
+              style={{
+                display: 'flex',
+                background: '#ddd',
+                padding: '15px',
+                flexDirection: 'row',
+              }}
+            >
+              {Object.keys(groupedByStatus).map((key) => (
+                <li style={{ display: 'block', margin: '0 0 0 15px' }}>
+                  {key}: {groupedByStatus[key]}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <label htmlFor="">Filter by status</label>
+            <br />
+            <select
+              onChange={(e) => {
+                if (e.target.value === 'All') {
+                  setSelectedFilter(null)
+                } else {
+                  setSelectedFilter(e.target.value)
+                }
+              }}
+            >
+              <option value="All">All</option>
+              {Object.keys(groupedByStatus).map((key) => (
+                <option value={key}>{key}</option>
+              ))}
+            </select>
+          </div>
+
+          <ul style={{ display: 'flex', flexDirection: 'column' }}>
+            {filteredWorkOrders?.map((x) => {
+              return (
+                <li
+                  key={x.reference}
+                  style={{ display: 'block', background: '#eee' }}
+                >
+                  <p>
+                    <a href={`/work-orders/${x.reference}`}>View work order</a>
+                  </p>
+
+                  <div>
+                    <button onClick={() => handleResendToDrs(x.reference)}>
+                      Resend to DRS
+                    </button>
+                    <button onClick={() => handleClearStatus(x.reference)}>
+                      Reset status
+                    </button>
+                    <button disabled>WIP - Fetch reference from DRS (order found on DRS)</button>
+                  </div>
+
+                  <pre>{JSON.stringify(x, null, 2)}</pre>
+                </li>
+              )
+            })}
+          </ul>
+        </>
+      </Layout>
+    </>
+  )
+}
+
+export default DrsSyncView

--- a/src/components/BackOffice/DrsSync/index.tsx
+++ b/src/components/BackOffice/DrsSync/index.tsx
@@ -112,7 +112,9 @@ const DrsSyncView = () => {
   const groupedByStatus: { [key: string]: number } = {}
 
   workOrders?.forEach((workOrder) => {
-    if (groupedByStatus.hasOwnProperty(workOrder.status)) {
+    if (
+      Object.prototype.hasOwnProperty.call(groupedByStatus, workOrder.status)
+    ) {
       groupedByStatus[workOrder.status]++
     } else {
       groupedByStatus[workOrder.status] = 1
@@ -194,7 +196,9 @@ const DrsSyncView = () => {
                     <button onClick={() => handleClearStatus(x.reference)}>
                       Reset status
                     </button>
-                    <button disabled>WIP - Fetch reference from DRS (order found on DRS)</button>
+                    <button disabled>
+                      WIP - Fetch reference from DRS (order found on DRS)
+                    </button>
                   </div>
 
                   <pre>{JSON.stringify(x, null, 2)}</pre>

--- a/src/pages/backoffice/drs-sync.tsx
+++ b/src/pages/backoffice/drs-sync.tsx
@@ -1,0 +1,19 @@
+import DrsSyncView from '../../components/BackOffice/DrsSync'
+import Meta from '../../components/Meta'
+import { getQueryProps } from '../../utils/helpers/serverSideProps'
+import { DATA_ADMIN_ROLE } from '../../utils/user'
+
+const DrsSync = () => {
+  return (
+    <>
+      <Meta title="BackOffice" />
+      <DrsSyncView />
+    </>
+  )
+}
+
+export const getServerSideProps = getQueryProps
+
+DrsSync.permittedRoles = [DATA_ADMIN_ROLE]
+
+export default DrsSync


### PR DESCRIPTION
A very primative tool for managing DRS sync. The primary function is to list work orders that failed to sync, check them, and then apply a fix.

![image](https://github.com/user-attachments/assets/eaf4d596-4f05-413a-9dd5-d4409d52a53e)

The code quality is terrible, but this is a back office tool. Its not user facing. 

The long term goal is to add a reliable retry mechanism. But until that is possible, this makes it easier to track and fix work orders that failed to sync.
