### PR TITLE
Show/filter operatives by ref numbers in RH Backoffice

### DIFF
--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -142,7 +142,7 @@ const OperativeMobileView = () => {
                       value={x.operativePayrollNumber}
                       style={{ whiteSpace: 'pre'}}
                     >
-                      {x.name} ({x.payrollNumber}) - {x.id?.toString().padStart(3, " ")}
+                      {x.name} ({x.payrollNumber}) - {x.id}
                     </option>
                   ))}
                 </select>

--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -19,8 +19,9 @@ const OperativeMobileView = () => {
         path: '/api/operatives',
       })
         .then((res) => {
-          const sortedOperatives = res
-            .sort((a, b) => a.name.localeCompare(b.name))
+          const sortedOperatives = res.sort((a, b) =>
+            a.name.localeCompare(b.name)
+          )
           setOperatives(sortedOperatives)
         })
         .finally(() => {
@@ -28,7 +29,6 @@ const OperativeMobileView = () => {
           resolve()
         })
     })
-
 
   const refresh = () => {
     // hacky implementation? yes! but idc, this is backoffice
@@ -140,7 +140,7 @@ const OperativeMobileView = () => {
                     <option
                       key={x.operativePayrollNumber}
                       value={x.operativePayrollNumber}
-                      style={{ whiteSpace: 'pre'}}
+                      style={{ whiteSpace: 'pre' }}
                     >
                       {x.name} ({x.payrollNumber}) - {x.id}
                     </option>

--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -21,8 +21,6 @@ const OperativeMobileView = () => {
         .then((res) => {
           const sortedOperatives = res
             .sort((a, b) => a.name.localeCompare(b.name))
-            .map(mapOperativeToHubUser)
-
           setOperatives(sortedOperatives)
         })
         .finally(() => {
@@ -31,20 +29,6 @@ const OperativeMobileView = () => {
         })
     })
 
-  const mapOperativeToHubUser = (operative) => {
-    return {
-      sub: 'placeholder',
-      name: operative.name,
-      email: 'placeholder',
-      varyLimit: 'placeholder',
-      raiseLimit: 'placeholder',
-      contractors: [],
-      operativePayrollNumber: operative.payrollNumber,
-      isOneJobAtATime: operative.isOnejobatatime,
-    }
-  }
-
-  // const refresh =
 
   const refresh = () => {
     // hacky implementation? yes! but idc, this is backoffice
@@ -156,8 +140,9 @@ const OperativeMobileView = () => {
                     <option
                       key={x.operativePayrollNumber}
                       value={x.operativePayrollNumber}
+                      style={{ whiteSpace: 'pre'}}
                     >
-                      {x.name}
+                      {x.name} ({x.payrollNumber}) - {x.id?.toString().padStart(3, " ")}
                     </option>
                   ))}
                 </select>

--- a/src/components/BackOffice/OperativeMobileView/index.js
+++ b/src/components/BackOffice/OperativeMobileView/index.js
@@ -19,9 +19,9 @@ const OperativeMobileView = () => {
         path: '/api/operatives',
       })
         .then((res) => {
-          const sortedOperatives = res.sort((a, b) =>
-            a.name.localeCompare(b.name)
-          )
+          const sortedOperatives = res
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(mapOperativeToHubUser)
           setOperatives(sortedOperatives)
         })
         .finally(() => {
@@ -29,6 +29,20 @@ const OperativeMobileView = () => {
           resolve()
         })
     })
+
+  const mapOperativeToHubUser = (operative) => {
+    return {
+      id: operative.id,
+      sub: 'placeholder',
+      name: operative.name,
+      email: 'placeholder',
+      varyLimit: 'placeholder',
+      raiseLimit: 'placeholder',
+      contractors: [],
+      operativePayrollNumber: operative.payrollNumber,
+      isOneJobAtATime: operative.isOnejobatatime,
+    }
+  }
 
   const refresh = () => {
     // hacky implementation? yes! but idc, this is backoffice
@@ -142,7 +156,7 @@ const OperativeMobileView = () => {
                       value={x.operativePayrollNumber}
                       style={{ whiteSpace: 'pre' }}
                     >
-                      {x.name} ({x.payrollNumber}) - {x.id}
+                      {x.name} ({x.operativePayrollNumber}) - {x.id}
                     </option>
                   ))}
                 </select>

--- a/src/components/BackOffice/OperativeMobileView/utils.js
+++ b/src/components/BackOffice/OperativeMobileView/utils.js
@@ -1,6 +1,6 @@
 export const filterOperatives = (operatives, operativeFilter) => {
   if (!operativeFilter) return operatives;
-
+  operativeFilter = operativeFilter.toLowerCase();
   return operatives.filter((x) =>
     x.id?.toString().includes(operativeFilter) ||
     x.name?.toLowerCase().includes(operativeFilter) ||

--- a/src/components/BackOffice/OperativeMobileView/utils.js
+++ b/src/components/BackOffice/OperativeMobileView/utils.js
@@ -5,6 +5,6 @@ export const filterOperatives = (operatives, operativeFilter) => {
     (x) =>
       x.id?.toString().includes(operativeFilter) ||
       x.name?.toLowerCase().includes(operativeFilter) ||
-      x.payrollNumber?.toLowerCase().includes(operativeFilter)
+      x.operativePayrollNumber?.toLowerCase().includes(operativeFilter)
   )
 }

--- a/src/components/BackOffice/OperativeMobileView/utils.js
+++ b/src/components/BackOffice/OperativeMobileView/utils.js
@@ -1,9 +1,10 @@
 export const filterOperatives = (operatives, operativeFilter) => {
-  if (!operativeFilter) return operatives;
-  operativeFilter = operativeFilter.toLowerCase();
-  return operatives.filter((x) =>
-    x.id?.toString().includes(operativeFilter) ||
-    x.name?.toLowerCase().includes(operativeFilter) ||
-    x.payrollNumber?.toLowerCase().includes(operativeFilter)
-  );
+  if (!operativeFilter) return operatives
+  operativeFilter = operativeFilter.toLowerCase()
+  return operatives.filter(
+    (x) =>
+      x.id?.toString().includes(operativeFilter) ||
+      x.name?.toLowerCase().includes(operativeFilter) ||
+      x.payrollNumber?.toLowerCase().includes(operativeFilter)
+  )
 }

--- a/src/components/BackOffice/OperativeMobileView/utils.js
+++ b/src/components/BackOffice/OperativeMobileView/utils.js
@@ -1,17 +1,9 @@
 export const filterOperatives = (operatives, operativeFilter) => {
-  let filteredOperativeList = operatives
+  if (!operativeFilter) return operatives;
 
-  if (operativeFilter !== '') {
-    filteredOperativeList = filteredOperativeList.filter((x) =>
-      x.name.toLowerCase().includes(operativeFilter.toLowerCase())
-    )
-  }
-
-  // if (showOnlyOJAT) {
-  //   filteredOperativeList = filteredOperativeList.filter(
-  //     (x) => x.isOneJobAtATime
-  //   )
-  // }
-
-  return filteredOperativeList
+  return operatives.filter((x) =>
+    x.id?.toString().includes(operativeFilter) ||
+    x.name?.toLowerCase().includes(operativeFilter) ||
+    x.payrollNumber?.toLowerCase().includes(operativeFilter)
+  );
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cf52c29b-8a0c-4846-9141-49f6c639e80b)

Logs typically refer to operatives through their IDs or payroll refs  - this makes it easier to cross reference them