### PR TITLE
Allow-operatives-to-see-past-work-orders-pr-changes

### DIFF
--- a/src/components/PastWorkOrders/MobileWorkingPastWorkOrdersView/MobileWorkingPastWorkOrdersView.tsx
+++ b/src/components/PastWorkOrders/MobileWorkingPastWorkOrdersView/MobileWorkingPastWorkOrdersView.tsx
@@ -34,7 +34,7 @@ const MobileWorkingPastWorkOrdersView = ({ currentUser }) => {
     try {
       const data = await frontEndApiRequest({
         method: 'get',
-        path: `/api/operatives/016062/workOrdersNew?date=${targetDate}`,
+        path: `/api/operatives/${currentUser.operativePayrollNumber}/workOrdersNew?date=${targetDate}`,
       })
 
       const workOrders: WorkOrdersType = data.map(

--- a/src/components/PastWorkOrders/MobileWorkingPastWorkOrdersView/MobileWorkingPastWorkOrdersView.tsx
+++ b/src/components/PastWorkOrders/MobileWorkingPastWorkOrdersView/MobileWorkingPastWorkOrdersView.tsx
@@ -24,15 +24,17 @@ const MobileWorkingPastWorkOrdersView = ({ currentUser }) => {
   const [selectedDate, setSelectedDate] = useState<Date>(yesterday)
   const targetDate = selectedDate.toISOString().split('T')[0]
 
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
   const lastFiveWorkingDays = getWorkingDaysBeforeDate(currentDate, 7)
 
   const getOperativeWorkOrderView = async () => {
     setError(null)
-
+    setIsLoading(true)
     try {
       const data = await frontEndApiRequest({
         method: 'get',
-        path: `/api/operatives/${currentUser.operativePayrollNumber}/workOrdersNew?date=${targetDate}`,
+        path: `/api/operatives/016062/workOrdersNew?date=${targetDate}`,
       })
 
       const workOrders: WorkOrdersType = data.map(
@@ -49,6 +51,7 @@ const MobileWorkingPastWorkOrdersView = ({ currentUser }) => {
         `Request failed with status code: ${e.response?.status} with message: ${e.response?.data?.message}`
       )
     }
+    setIsLoading(false)
   }
 
   useEffect(() => {
@@ -67,9 +70,11 @@ const MobileWorkingPastWorkOrdersView = ({ currentUser }) => {
   }
 
   const handleDateChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setIsLoading(true)
     const selectedDate = event.target.value
     setSelectedDate(new Date(selectedDate))
   }
+
   return (
     <>
       <Meta title="Manage past work orders" />
@@ -78,27 +83,23 @@ const MobileWorkingPastWorkOrdersView = ({ currentUser }) => {
           handleChange={handleDateChange}
           lastFiveWorkingDays={lastFiveWorkingDays}
         />
-        {sortedWorkOrders === null && !error ? (
+        {isLoading ? (
           <Spinner />
+        ) : error ? (
+          <ErrorMessage label={error} />
+        ) : sortedWorkOrders?.length ? (
+          <ol className="lbh-list mobile-working-work-order-list">
+            <MobileWorkingPastWorkOrderListItems
+              workOrders={sortedWorkOrders}
+              currentUser={currentUser}
+            />
+          </ol>
         ) : (
-          <>
-            {sortedWorkOrders?.length ? (
-              <ol className="lbh-list mobile-working-work-order-list">
-                <MobileWorkingPastWorkOrderListItems
-                  workOrders={[...sortedWorkOrders]}
-                  currentUser={currentUser}
-                />
-              </ol>
-            ) : !error ? (
-              <WarningInfoBox
-                header="No work orders displayed"
-                text="Please contact your supervisor"
-                name="No jobs warning"
-              />
-            ) : (
-              <ErrorMessage label={error} />
-            )}
-          </>
+          <WarningInfoBox
+            header="No work orders displayed"
+            text="Please contact your supervisor"
+            name="No jobs warning"
+          />
         )}
       </div>
     </>

--- a/src/components/PastWorkOrdersDatePicker/Index.tsx
+++ b/src/components/PastWorkOrdersDatePicker/Index.tsx
@@ -1,5 +1,4 @@
 import { format } from 'date-fns'
-import { getWorkingDaysBeforeDate } from '@/utils/time'
 
 interface PastWorkOrdersDatePickerProps {
   handleChange: (e: React.ChangeEvent<HTMLSelectElement>) => void

--- a/src/components/PastWorkOrdersDatePicker/Index.tsx
+++ b/src/components/PastWorkOrdersDatePicker/Index.tsx
@@ -16,7 +16,7 @@ const PastWorkOrdersDatePicker = ({
       </label>
       <select id="date-picker" name="date-picker" onChange={handleChange}>
         {lastFiveWorkingDays.map((day, index) => {
-          const formattedDate = format(day, 'MMM dd')
+          const formattedDate = format(day, 'EEE d MMM')
           return (
             <option data-testid={`date-option`} value={day} key={index}>
               {formattedDate}

--- a/src/components/PastWorkOrdersDatePicker/PastWorkOrdersDatePicker.test.js
+++ b/src/components/PastWorkOrdersDatePicker/PastWorkOrdersDatePicker.test.js
@@ -52,7 +52,7 @@ describe('PastWorkOrdersDatePicker Component', () => {
     options.forEach((option, index) => {
       const expectedDate = lastFiveWorkingDays[index]
       // Check the text content matches the expected day display
-      const formattedDate = format(expectedDate, 'MMM dd')
+      const formattedDate = format(expectedDate, 'EEE d MMM')
 
       expect(option.textContent).toContain(formattedDate)
     })
@@ -76,7 +76,7 @@ describe('PastWorkOrdersDatePicker Component', () => {
       const expectedDate = lastFiveWorkingDays[index]
 
       // Check the text content matches the expected day display
-      const formattedDate = format(expectedDate, 'MMM dd')
+      const formattedDate = format(expectedDate, 'EEE d MMM')
       expect(option.textContent).toContain(formattedDate)
     })
     expect(asFragment()).toMatchSnapshot()
@@ -98,7 +98,7 @@ describe('PastWorkOrdersDatePicker Component', () => {
       const expectedDate = lastFiveWorkingDays[index]
 
       // Check the text content matches the expected day display
-      const formattedDate = format(expectedDate.d, 'MMM dd')
+      const formattedDate = format(expectedDate.d, 'EEE d MMM')
       expect(option.textContent).toContain(formattedDate)
     })
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/PastWorkOrdersDatePicker/__snapshots__/PastWorkOrdersDatePicker.test.js.snap
+++ b/src/components/PastWorkOrdersDatePicker/__snapshots__/PastWorkOrdersDatePicker.test.js.snap
@@ -19,31 +19,31 @@ exports[`PastWorkOrdersDatePicker Component should be populated with the previou
         data-testid="date-option"
         value="1723161600000"
       >
-        Aug 09
+        Fri 9 Aug
       </option>
       <option
         data-testid="date-option"
         value="1723075200000"
       >
-        Aug 08
+        Thu 8 Aug
       </option>
       <option
         data-testid="date-option"
         value="1722988800000"
       >
-        Aug 07
+        Wed 7 Aug
       </option>
       <option
         data-testid="date-option"
         value="1722902400000"
       >
-        Aug 06
+        Tue 6 Aug
       </option>
       <option
         data-testid="date-option"
         value="1722816000000"
       >
-        Aug 05
+        Mon 5 Aug
       </option>
     </select>
   </div>
@@ -69,31 +69,31 @@ exports[`PastWorkOrdersDatePicker Component should be populated with the previou
         data-testid="date-option"
         value="1712793600000"
       >
-        Apr 11
+        Thu 11 Apr
       </option>
       <option
         data-testid="date-option"
         value="1712707200000"
       >
-        Apr 10
+        Wed 10 Apr
       </option>
       <option
         data-testid="date-option"
         value="1712620800000"
       >
-        Apr 09
+        Tue 9 Apr
       </option>
       <option
         data-testid="date-option"
         value="1712534400000"
       >
-        Apr 08
+        Mon 8 Apr
       </option>
       <option
         data-testid="date-option"
         value="1712275200000"
       >
-        Apr 05
+        Fri 5 Apr
       </option>
     </select>
   </div>
@@ -119,31 +119,31 @@ exports[`PastWorkOrdersDatePicker Component should be populated with the previou
         data-testid="date-option"
         value="1704067200000"
       >
-        Jan 01
+        Mon 1 Jan
       </option>
       <option
         data-testid="date-option"
         value="1703808000000"
       >
-        Dec 29
+        Fri 29 Dec
       </option>
       <option
         data-testid="date-option"
         value="1703721600000"
       >
-        Dec 28
+        Thu 28 Dec
       </option>
       <option
         data-testid="date-option"
         value="1703635200000"
       >
-        Dec 27
+        Wed 27 Dec
       </option>
       <option
         data-testid="date-option"
         value="1703548800000"
       >
-        Dec 26
+        Tue 26 Dec
       </option>
     </select>
   </div>

--- a/src/styles/components/mobile-working/mobile-work-order-container.scss
+++ b/src/styles/components/mobile-working/mobile-work-order-container.scss
@@ -1,4 +1,5 @@
 .mobile-work-order-container {
     border: 2px solid #d8d9da;
     padding: 2rem 1rem;
+    margin-top: 0 !important; 
 }

--- a/src/styles/components/tabs-version-two.scss
+++ b/src/styles/components/tabs-version-two.scss
@@ -2,7 +2,6 @@
         display: flex;
         justify-content: flex-start;
         gap: 2px;
-        margin: 0 0 10px 0 !important;
         border: none !important; 
         }
         .v2-govuk-tabs__list-item {
@@ -40,7 +39,7 @@
                 display: flex;
                 justify-content: flex-start;
                 gap: 2px;
-                margin: 0 0 10px 0;
+                margin-bottom: 0 !important;
                 }
                 .v2-govuk-tabs__list-item {
                   display: block;


### PR DESCRIPTION
### Description of change

Addressing comments made on the initial PR:
- Add loading spinner when retrieving previous jobs
- Add day name to date picker
- Make tabs more like [Figma](https://www.figma.com/design/Tww5QypeA3WDg8UvzdbSLb/Repairs-Hub-Mockups?node-id=25-164&node-type=canvas&t=6KuguDH0X8xs5m6Y-0)

![image](https://github.com/user-attachments/assets/9eff3078-9ef2-4a7c-a195-eef896629095)
