### PR TITLE
Add Surveyor Inspection follow-ons

### DIFF
--- a/src/utils/statusCodes.js
+++ b/src/utils/statusCodes.js
@@ -85,6 +85,11 @@ export const FOLLOW_ON_REQUEST_AVAILABLE_TRADES = [
   },
   { name: 'followon-trades-UPVC', label: 'UPVC', value: 'UPVC' },
   {
+    name: 'followon-trades-surveyor-inspection',
+    label: 'Surveyors Inspection',
+    value: 'SurveyorsInspection',
+  },
+  {
     name: 'followon-trades-other',
     label: 'Other (please specify in the text box below)',
     value: 'Other',


### PR DESCRIPTION
We have a request to allow specifying Surveyor Inspection to avoid having that go to reactive repairs.

Tested and this works on dev

![image](https://github.com/user-attachments/assets/248f9e92-2dea-4941-80af-6ee8bc83b3da)
