### PR TITLE
Remove explicit serverless version from config

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,7 +1,5 @@
 service: repairs-hub-frontend
 
-frameworkVersion: '2'
-
 provider:
   name: aws
   runtime: nodejs20.x


### PR DESCRIPTION
Serverless is only invoked through CI. Upgrading to v4 failed because we needed to update in two places (the npm install and serverless.yml frameworkVersion attribute.

Other repositories don't set this explicitly, and as we don't run serverless locally we don't need this to enforce consistency. ;

