### PR TITLE
fix bug in filter by trade 

### DIFF
--- a/src/components/Property/WorkOrdersHistory/WorkOrdersHistoryTable.js
+++ b/src/components/Property/WorkOrdersHistory/WorkOrdersHistoryTable.js
@@ -73,7 +73,7 @@ const WorkOrdersHistoryTable = ({
             PageNumber: 1,
             sort: 'dateraised:desc',
             TradeCodes: filterKey,
-            PageSize: 0,
+            PageSize: 0, //Fetch all
           },
         })
         setFilteredOrders(data)

--- a/src/components/Property/WorkOrdersHistory/WorkOrdersHistoryTable.js
+++ b/src/components/Property/WorkOrdersHistory/WorkOrdersHistoryTable.js
@@ -73,6 +73,7 @@ const WorkOrdersHistoryTable = ({
             PageNumber: 1,
             sort: 'dateraised:desc',
             TradeCodes: filterKey,
+            PageSize: 0,
           },
         })
         setFilteredOrders(data)


### PR DESCRIPTION
### Description of change

There was a bug that meant only 10 previous work orders were displayed. This has fixed that so there is no limit to the amount of work orders shown

### Automated test checklist

Tests to follow in different PR 
