### PR TITLE
Last-min-fixes

### DIFF
--- a/src/components/PastWorkOrders/MobileWorkingPastWorkOrdersView/MobileWorkingPastWorkOrdersView.tsx
+++ b/src/components/PastWorkOrders/MobileWorkingPastWorkOrdersView/MobileWorkingPastWorkOrdersView.tsx
@@ -105,7 +105,6 @@ const MobileWorkingPastWorkOrdersView = ({ currentUser }) => {
         ) : (
           <WarningInfoBox
             header="No work orders displayed"
-            text="Please contact your supervisor"
             name="No jobs warning"
           />
         )}

--- a/src/components/Property/WorkOrdersHistory/__snapshots__/WorkOrdersHistoryTable.test.js.snap
+++ b/src/components/Property/WorkOrdersHistory/__snapshots__/WorkOrdersHistoryTable.test.js.snap
@@ -19,7 +19,7 @@ exports[`WorkOrdersHistoryTable component when logged in as a contract manager s
     <a
       class="lbh-link lbh-body-xs"
       href="#work-orders-history-tab"
-      style="padding: 10px;"
+      style="padding: 10px; margin-left: 0.7rem;"
     >
       Clear filters
     </a>
@@ -180,7 +180,7 @@ exports[`WorkOrdersHistoryTable component when logged in as an agent should rend
     <a
       class="lbh-link lbh-body-xs"
       href="#work-orders-history-tab"
-      style="padding: 10px;"
+      style="padding: 10px; margin-left: 0.7rem;"
     >
       Clear filters
     </a>
@@ -341,7 +341,7 @@ exports[`WorkOrdersHistoryTable component when logged in as an authorisation man
     <a
       class="lbh-link lbh-body-xs"
       href="#work-orders-history-tab"
-      style="padding: 10px;"
+      style="padding: 10px; margin-left: 0.7rem;"
     >
       Clear filters
     </a>

--- a/src/components/Property/WorkOrdersHistoryFilter/Index.tsx
+++ b/src/components/Property/WorkOrdersHistoryFilter/Index.tsx
@@ -68,7 +68,7 @@ const WorkOrdersHistoryFilter = ({
       )}
       <a
         className="lbh-link lbh-body-xs"
-        style={{ padding: '10px' }}
+        style={{ padding: '10px', marginLeft: '0.7rem' }}
         href="#work-orders-history-tab"
         onClick={handleClearFilters}
       >

--- a/src/components/Template/WarningInfoBox.js
+++ b/src/components/Template/WarningInfoBox.js
@@ -24,7 +24,7 @@ const WarningInfoBox = ({ header, text, name }) => {
 
 WarningInfoBox.propTypes = {
   header: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   name: PropTypes.string.isRequired,
 }
 


### PR DESCRIPTION
## Description of change

### Removed the text from the warning box for Past Work Orders when operative has no orders on a specific day.

#### Before: 

![image](https://github.com/user-attachments/assets/1be67279-3754-4489-852c-456c055a60ac)

#### After: 

![image](https://github.com/user-attachments/assets/f4046cd7-9fd2-467d-b921-2168e37268ac)

### Moved the clear filter link further away from the Select By Trade dropdown in Work Orders History.

#### Before: 

![image](https://github.com/user-attachments/assets/aceee283-5c0a-4a13-b29e-0290c24a606e)

#### After:

![image](https://github.com/user-attachments/assets/ce9dbf69-b14a-415f-b02e-14b8f5f571d8)
