### PR TITLE
Add estimated duration radio buttons

### DIFF
--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -2857,7 +2857,9 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
         cy.contains('Please provide detail of the work required').should(
           'not.exist'
         )
-
+        // add estimated duration of work - error should disappear
+        cy.get('input[data-testid="estimatedDuration"]').first().check()
+        cy.contains('Select a duration').should('not.exist')
         // when one of the material options is selected, the description must not be empty
         cy.get('input[data-testid="stockItemsRequired"]').check()
         cy.get('[type="submit"]').contains('Close work order').click()
@@ -2891,7 +2893,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
       cy.contains('Summary of updates to work order')
     })
 
-    it('submits a request and shows summary page when user enters follow-on details', () => {
+    it.only('submits a request and shows summary page when user enters follow-on details', () => {
       cy.fixture('workOrders/workOrder.json').then((workOrder) => {
         workOrder.reference = 10000040
         workOrder.canAssignOperative = false
@@ -2922,6 +2924,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
         cy.get('textarea[data-testid="followOnTypeDescription"]').type(
           'follow on description'
         )
+        cy.get('input[data-testid="estimatedDuration"]').first().check()
         cy.get('input[data-testid="stockItemsRequired"]').check()
         cy.get('textarea[data-testid="materialNotes"]').type('material notes')
         cy.get('textarea[data-testid="additionalNotes"]').type(
@@ -2995,6 +2998,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
             nonStockItemsRequired: false,
             materialNotes: 'material notes',
             additionalNotes: 'Additional notes desc',
+            estimatedDuration: '30 mins',
             supervisorCalled: true,
           },
         })

--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -2893,7 +2893,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
       cy.contains('Summary of updates to work order')
     })
 
-    it.only('submits a request and shows summary page when user enters follow-on details', () => {
+    it('submits a request and shows summary page when user enters follow-on details', () => {
       cy.fixture('workOrders/workOrder.json').then((workOrder) => {
         workOrder.reference = 10000040
         workOrder.canAssignOperative = false

--- a/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
@@ -887,6 +887,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
     cy.get('textarea[data-testid="followOnTypeDescription"]').type(
       'follow on description'
     )
+    cy.get('input[data-testid="estimatedDuration"]').first().check()
     cy.get('input[data-testid="stockItemsRequired"]').check()
     cy.get('textarea[data-testid="materialNotes"]').type('material notes')
     cy.get('textarea[data-testid="additionalNotes"]').type(
@@ -934,6 +935,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
             materialNotes: 'material notes',
             additionalNotes: 'Additional notes desc',
             supervisorCalled: true,
+            estimatedDuration: '30 mins',
             otherTrade: 'Cheese Making',
           },
         })
@@ -1001,6 +1003,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
     cy.get('textarea[data-testid="followOnTypeDescription"]').type(
       'follow on description'
     )
+    cy.get('input[data-testid="estimatedDuration"]').first().check()
     cy.get('input[data-testid="stockItemsRequired"]').check()
     cy.get('textarea[data-testid="materialNotes"]').type('material notes')
     cy.get('textarea[data-testid="additionalNotes"]').type(

--- a/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
@@ -778,6 +778,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
       cy.get('textarea[data-testid="followOnTypeDescription"]').type(
         'follow on description'
       )
+      cy.get('input[data-testid="estimatedDuration"]').first().check()
       cy.get('input[data-testid="stockItemsRequired"]').check()
       cy.get('textarea[data-testid="materialNotes"]').type('material notes')
       cy.get('textarea[data-testid="additionalNotes"]').type(
@@ -825,6 +826,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
               materialNotes: 'material notes',
               additionalNotes: 'Additional notes desc',
               supervisorCalled: true,
+              estimatedDuration: '30 mins',
               otherTrade: 'Concrete Work',
             },
           })

--- a/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-with-followons-enabled.cy.js
@@ -441,6 +441,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
       cy.get('textarea[data-testid="followOnTypeDescription"]').type(
         'follow on description'
       )
+      cy.get('input[data-testid="estimatedDuration"]').first().check()
       cy.get('input[data-testid="stockItemsRequired"]').check()
       cy.get('textarea[data-testid="materialNotes"]').type('material notes')
       cy.get('textarea[data-testid="additionalNotes"]').type(
@@ -708,7 +709,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
       cy.contains('Please provide detail of the work required').should(
         'not.exist'
       )
-
+      cy.get('input[data-testid="estimatedDuration"]').first().check()
       // when one of the material options is selected, the description must not be empty
       cy.get('input[data-testid="stockItemsRequired"]').check()
       cy.get('[type="submit"]').contains('Close work order').click()

--- a/src/components/Form/Radios/index.tsx
+++ b/src/components/Form/Radios/index.tsx
@@ -40,6 +40,8 @@ const Radio = (props: Props) => {
     children,
     required,
     isRadiosInline = false,
+    isGrid,
+    labelHasGreyBackground,
     ...otherProps
   } = props
 
@@ -70,6 +72,7 @@ const Radio = (props: Props) => {
         className={cx('govuk-radios lbh-radios', {
           'govuk-radios--inline': isRadiosInline,
         })}
+        style={isGrid && { display: 'grid', gridTemplateColumns: '1fr 1fr' }}
       >
         {options.map((option) => {
           const { value, text, defaultChecked, hint } =
@@ -105,6 +108,13 @@ const Radio = (props: Props) => {
                 <label
                   className="govuk-label lbh-label govuk-radios__label"
                   htmlFor={`${name}_${value}`}
+                  style={
+                    labelHasGreyBackground && {
+                      background: '#F5F6F8',
+                      marginLeft: '1rem',
+                      borderRadius: '5px',
+                    }
+                  }
                 >
                   {text}
                 </label>

--- a/src/components/Form/Radios/index.tsx
+++ b/src/components/Form/Radios/index.tsx
@@ -71,14 +71,11 @@ const Radio = (props: Props) => {
       <div
         className={cx('govuk-radios lbh-radios', {
           'govuk-radios--inline': isRadiosInline,
-          'govuk-radios--maxWidthRemove': isGrid,
         })}
         style={
           isGrid && {
-            display: 'grid',
+            display: 'inline-grid',
             gridTemplateColumns: '1fr 1fr',
-            alignItems: 'start',
-            maxWidth: '90%',
           }
         }
       >

--- a/src/components/Form/Radios/index.tsx
+++ b/src/components/Form/Radios/index.tsx
@@ -24,6 +24,7 @@ interface Props {
   children?: JSX.Element
   required?: boolean
   isRadiosInline?: boolean
+  isGrid?: boolean
   [key: string]: any
 }
 
@@ -41,7 +42,6 @@ const Radio = (props: Props) => {
     required,
     isRadiosInline = false,
     isGrid,
-    labelHasGreyBackground,
     ...otherProps
   } = props
 
@@ -71,8 +71,16 @@ const Radio = (props: Props) => {
       <div
         className={cx('govuk-radios lbh-radios', {
           'govuk-radios--inline': isRadiosInline,
+          'govuk-radios--maxWidthRemove': isGrid,
         })}
-        style={isGrid && { display: 'grid', gridTemplateColumns: '1fr 1fr' }}
+        style={
+          isGrid && {
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            alignItems: 'start',
+            maxWidth: '90%',
+          }
+        }
       >
         {options.map((option) => {
           const { value, text, defaultChecked, hint } =
@@ -108,13 +116,6 @@ const Radio = (props: Props) => {
                 <label
                   className="govuk-label lbh-label govuk-radios__label"
                   htmlFor={`${name}_${value}`}
-                  style={
-                    labelHasGreyBackground && {
-                      background: '#F5F6F8',
-                      marginLeft: '1rem',
-                      borderRadius: '5px',
-                    }
-                  }
                 >
                   {text}
                 </label>

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -169,6 +169,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
         data.materialNotes,
         data.additionalNotes,
         data.supervisorCalled === 'Yes',
+        data.estimatedDuration,
         data.otherTrade
       )
     }

--- a/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.tsx
+++ b/src/components/WorkOrder/Notes/NoteContent/CompletedNoteContent/index.tsx
@@ -77,7 +77,20 @@ const CompletedNoteContent = ({ note, workOrder, setActiveTab }: Props) => {
                     </span>
                   </>
                 )}
+              {workOrder.followOnRequest.estimatedDuration && (
+                <>
+                  <br />
+                  <span>
+                    <strong>Estimated duration</strong>
+                    <br />
+                  </span>
 
+                  <span style={{ color: '#333' }}>
+                    {workOrder.followOnRequest.estimatedDuration}
+                  </span>
+                  <br />
+                </>
+              )}
               {(workOrder.followOnRequest.stockItemsRequired ||
                 workOrder.followOnRequest.nonStockItemsRequired ||
                 (workOrder.followOnRequest.materialNotes !== null &&

--- a/src/components/WorkOrder/Notes/types.ts
+++ b/src/components/WorkOrder/Notes/types.ts
@@ -32,5 +32,6 @@ export type FollowOnRequest = {
   nonStockItemsRequired: boolean
   materialNotes: string
   additionalNotes: string
+  estimatedDuration: string
   otherTrade?: string
 }

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -208,6 +208,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
         followOnData.materialNotes,
         followOnData.additionalNotes,
         followOnData.supervisorCalled,
+        followOnData.estimatedDuration,
         followOnData.otherTrade
       )
     }
@@ -271,6 +272,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
         materialNotes: formData.materialNotes,
         additionalNotes: formData.additionalNotes,
         supervisorCalled: formData.supervisorCalled === 'Yes',
+        estimatedDuration: formData.estimatedDuration,
         otherTrade: formData.otherTrade,
       }
 

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -113,13 +113,11 @@ const CloseWorkOrderForm = ({
         {showFurtherWorkFields && (
           <>
             <h1 className="lbh-heading-h2">Details of further work required</h1>
-
             <FollowOnRequestMaterialsSupervisorCalledForm
               register={register}
               errors={errors}
               followOnData={followOnData}
             />
-
             <FollowOnRequestTypeOfWorkForm
               errors={errors}
               register={register}
@@ -130,13 +128,31 @@ const CloseWorkOrderForm = ({
               followOnData={followOnData}
             />
 
+            <Radios
+              label="Estimated duration"
+              name="estimatedDuration"
+              labelSize="s"
+              options={[
+                '30 mins',
+                '1 hour',
+                '2-3 hours',
+                'Half day',
+                'Full day',
+                'More than a day',
+                'Unknown',
+              ]}
+              register={register({
+                required: 'Select estimated duration',
+              })}
+              error={errors && errors.estimatedDuration}
+            />
+
             <FollowOnRequestMaterialsForm
               register={register}
               getValues={getValues}
               errors={errors}
               followOnData={followOnData}
             />
-
             <TextArea
               name="additionalNotes"
               label="Additional notes"

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -136,15 +136,17 @@ const CloseWorkOrderForm = ({
                 '30 mins',
                 '1 hour',
                 '2-3 hours',
-                'Half day',
-                'Full day',
-                'More than a day',
+                'Half a day',
+                '1 day',
+                'More than 1 day',
                 'Unknown',
               ]}
               register={register({
                 required: 'Select estimated duration',
               })}
               error={errors && errors.estimatedDuration}
+              isGrid={true}
+              labelHasGreyBackground={true}
             />
 
             <FollowOnRequestMaterialsForm

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -146,7 +146,6 @@ const CloseWorkOrderForm = ({
               })}
               error={errors && errors.estimatedDuration}
               isGrid={true}
-              labelHasGreyBackground={true}
             />
 
             <FollowOnRequestMaterialsForm

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form'
 import BackButton from '../Layout/BackButton'
 import TextArea from '../Form/TextArea'
 import { PrimarySubmitButton } from '../Form'
+import Radios from '../Form/Radios'
 import { useState } from 'react'
 import FollowOnRequestTypeOfWorkForm from './CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm'
 import CloseWorkOrderFormReasonForClosing from './CloseWorkOrderFormComponents/CloseWorkOrderFormReasonForClosing'
@@ -159,6 +160,25 @@ const MobileWorkingCloseWorkOrderForm = ({
               setError={setError}
               clearErrors={clearErrors}
               watch={watch}
+            />
+
+            <Radios
+              label="Estimated duration"
+              name="estimatedDuration"
+              labelSize="s"
+              options={[
+                '30 mins',
+                '1 hour',
+                '2-3 hours',
+                'Half day',
+                'Full day',
+                'More than a day',
+                'Unknown',
+              ]}
+              register={register({
+                required: 'Select estimated duration',
+              })}
+              error={errors && errors.estimatedDuration}
             />
 
             <FollowOnRequestMaterialsForm

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
@@ -180,6 +180,7 @@ const MobileWorkingCloseWorkOrderForm = ({
               })}
               error={errors && errors.estimatedDuration}
               data-testid="estimatedDuration"
+              isGrid={true}
             />
 
             <FollowOnRequestMaterialsForm

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
@@ -179,6 +179,7 @@ const MobileWorkingCloseWorkOrderForm = ({
                 required: 'Select estimated duration',
               })}
               error={errors && errors.estimatedDuration}
+              data-testid="estimatedDuration"
             />
 
             <FollowOnRequestMaterialsForm

--- a/src/components/WorkOrders/SummaryCloseWorkOrder.js
+++ b/src/components/WorkOrders/SummaryCloseWorkOrder.js
@@ -123,7 +123,12 @@ const SummaryCloseWorkOrder = ({
                     </>
                   }
                 />
-
+                {followOnData.estimatedDuration && (
+                  <TableRow
+                    label="Estimated duration"
+                    value={followOnData.estimatedDuration}
+                  />
+                )}
                 {(followOnData.stockItemsRequired ||
                   followOnData.nonStockItemsRequired ||
                   followOnData.materialNotes !== '') && (

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -145,12 +145,6 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
   }
 }
 
-@media (max-width: 640px) {
-  .govuk-radios--maxWidthRemove {
-    max-width: none !important;
-  }
-}
-
 @media (max-width: 414px) {
   .govuk-radios__label[for^="estimatedDuration"] {
     font-size: 0.95rem !important;

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -144,3 +144,55 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
     }
   }
 }
+
+@media (max-width: 640px) {
+  .govuk-radios--maxWidthRemove {
+    max-width: none !important;
+  }
+}
+
+@media (max-width: 414px) {
+  .govuk-radios__label[for^="estimatedDuration"] {
+    font-size: 0.95rem !important;
+    padding: 8px 10px 5px;
+  }
+  .govuk-radios__label[for^="estimatedDuration"]::before {
+    width: 38px;
+    height: 38px;
+  }
+  .govuk-radios__label[for^="estimatedDuration"]::after {
+    top: 9px;
+    left: 9px;
+    border: 9px solid currentColor;
+  }
+}
+
+@media (max-width: 390px) {
+  .govuk-radios__label[for^="estimatedDuration"] {
+    font-size: 0.9rem !important;
+    padding: 5px 8px 5px;
+  }
+}
+
+@media (max-width: 362px) {
+  .govuk-radios__label[for^="estimatedDuration"] {
+    font-size: 0.8rem !important;
+    padding: 5px 8px 5px;
+  }
+  .govuk-radios__label[for^="estimatedDuration"]::before {
+    width: 35px;
+    height: 35px;
+  }
+  .govuk-radios__label[for^="estimatedDuration"]::after {
+    top: 10px;
+    left: 9.9px;
+    border: 8px solid currentColor;
+  }
+}
+
+@media (max-width: 337px) {
+  .govuk-radios__label[for^="estimatedDuration"] {
+    font-size: 0.75rem !important;
+    padding: 2px 5px 5px;
+  }
+}

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.ts
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.ts
@@ -14,6 +14,7 @@ export type followOnDataRequest = {
   materialNotes: string
   additionalNotes: string
   supervisorCalled: boolean
+  estimatedDuration: string
   otherTrade?: string
 }
 
@@ -98,7 +99,8 @@ export const buildFollowOnRequestData = (
   materialNotes: string,
   additionalNotes: string,
   supervisorCalled: boolean,
-  otherTrade?: string
+  estimatedDuration: string,
+  otherTrade?: string,
 ): followOnDataRequest => {
   return {
     isSameTrade,
@@ -111,6 +113,7 @@ export const buildFollowOnRequestData = (
     materialNotes,
     additionalNotes,
     supervisorCalled,
+    estimatedDuration,
     otherTrade,
   }
 }

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.ts
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.ts
@@ -100,7 +100,7 @@ export const buildFollowOnRequestData = (
   additionalNotes: string,
   supervisorCalled: boolean,
   estimatedDuration: string,
-  otherTrade?: string,
+  otherTrade?: string
 ): followOnDataRequest => {
   return {
     isSameTrade,


### PR DESCRIPTION
### Description of change

#### Context 

When designing the follow on solution it was initially decided that we didn’t want the operatives placing estimations on the form - this was signed off by the exec. Though since going live we have had feedback it would be helpful - especially from plumbing who provide the highest number of follow ons as it helps inform the SORs and also plan the work. 

#### Acceptance Criteria 

- Ability to add information on the estimated time needed to complete a task on the follow on form 

- After the ‘Describe work required’ input box but before the materials required 

- Mandatory if we have an unknown option if using the radio buttons 

#### Display: 

[Radio buttons or drop down - see rough design below]

Estimated time needed 

- 30 mins 

- 1 hour 

- 2-3 hours 

- Half a day 

- 1 day 

- More than 1 day 

- Unknown

No need to add in the duration notes (don’t include the free text field shown in pic below) 

#### Rough design: 

![image](https://github.com/user-attachments/assets/c6988285-900f-4347-b6fa-3ac24af6df46)

### Story Link

https://hackney.atlassian.net/jira/software/projects/HPT/boards/116?selectedIssue=HPT-630

### Automated test checklist

If a type of test isn't included, add note explaining why.

- [x] Integration tests (Cypress)

### Decisions

I chose to give the radio buttons slightly different text than in the designs. This is very easy to change if someone isn't completely happy with them.

Currently the radio buttons are vertical. If we want them more in a grid like structure this can be done. 

#### Current look: 

![image](https://github.com/user-attachments/assets/aeb03a32-0c61-454f-8384-0190d8b483ba)

