### PR TITLE
Make follow on look nicer

### DIFF
--- a/src/components/Form/Checkbox/index.js
+++ b/src/components/Form/Checkbox/index.js
@@ -11,6 +11,7 @@ const Checkbox = ({
   hidden,
   labelClassName,
   hintText,
+  hasWhiteBackground,
   children,
   showChildren,
 }) => (
@@ -31,7 +32,11 @@ const Checkbox = ({
       {...(checked && { defaultChecked: checked })}
     />
     <label
-      className={cx('govuk-label govuk-checkboxes__label', labelClassName)}
+      className={cx(
+        'govuk-label govuk-checkboxes__label',
+        hasWhiteBackground && 'white-background',
+        labelClassName
+      )}
       htmlFor={name}
     >
       {label}

--- a/src/components/Form/Radios/index.tsx
+++ b/src/components/Form/Radios/index.tsx
@@ -42,6 +42,7 @@ const Radio = (props: Props) => {
     required,
     isRadiosInline = false,
     isGrid,
+    hasWhiteBackground,
     ...otherProps
   } = props
 
@@ -111,7 +112,12 @@ const Radio = (props: Props) => {
                 />
 
                 <label
-                  className="govuk-label lbh-label govuk-radios__label"
+                  className={cx(
+                    'govuk-label',
+                    'lbh-label',
+                    'govuk-radios__label',
+                    hasWhiteBackground && 'white-background'
+                  )}
                   htmlFor={`${name}_${value}`}
                 >
                   {text}

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -119,6 +119,7 @@ const CloseWorkOrderForm = ({
               backgroundColor: '#f3f3f3',
               padding: '2rem',
               display: 'flex',
+              flexDirection: 'column',
               flexWrap: 'wrap',
               marginBottom: '10px',
             }}
@@ -128,126 +129,113 @@ const CloseWorkOrderForm = ({
                 Details of further work required
               </h1>
             </div>
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                width: '100%',
-              }}
-            >
-              <div style={{ gridColumn: '1' }}>
-                <FollowOnRequestMaterialsSupervisorCalledForm
-                  register={register}
-                  errors={errors}
-                  followOnData={followOnData}
-                  hasWhiteBackground={true}
-                />
-              </div>
-              <div style={{ gridColumn: '1', marginTop: '0' }}>
-                <FollowOnRequestTypeOfWorkForm
-                  errors={errors}
-                  register={register}
-                  getValues={getValues}
-                  setError={setError}
-                  clearErrors={clearErrors}
-                  watch={watch}
-                  followOnData={followOnData}
-                  hasWhiteBackground={true}
-                />
-              </div>
-              <div style={{ gridColumn: '1 / -1', marginTop: '0' }}>
-                <label style={{ fontSize: '25px' }}>Radio or Dropdown?</label>
-                <div style={{ display: 'flex', gap: '10px' }}>
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault()
-                      setIsDropdown(false)
-                      setIsRadio(true)
-                    }}
-                    style={{ cursor: 'pointer', borderRadius: '5px' }}
-                    data-testid="radioButton"
-                  >
-                    Radio
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault()
-                      setIsRadio(false)
-                      setIsDropdown(true)
-                    }}
-                    style={{
-                      cursor: 'pointer',
-                      marginTop: '0',
-                      borderRadius: '5px',
-                    }}
-                    data-testid="dropdownButton"
-                  >
-                    Dropdown
-                  </button>
-                </div>
-                {isRadio && (
-                  <Radios
-                    label="Estimated duration"
-                    name="estimatedDuration"
-                    labelSize="s"
-                    options={[
-                      '30 mins',
-                      '1 hour',
-                      '2-3 hours',
-                      'Half a day',
-                      '1 day',
-                      'More than 1 day',
-                      'Unknown',
-                    ]}
-                    register={register({
-                      required: 'Select estimated duration',
-                    })}
-                    error={errors && errors.estimatedDuration}
-                    isGrid={true}
-                    hasWhiteBackground={true}
-                  />
-                )}
-                {isDropdown && (
-                  <Select
-                    label="Estimated duration"
-                    name="estimatedDuration"
-                    options={[
-                      '30 mins',
-                      '1 hour',
-                      '2-3 hours',
-                      'Half a day',
-                      '1 day',
-                      'More than 1 day',
-                      'Unknown',
-                    ]}
-                    register={register({
-                      required: 'Select estimated duration',
-                    })}
-                    error={errors && errors.estimatedDuration}
-                    widthClass="govuk-!-width-one-half"
-                  />
-                )}
-              </div>
 
-              <div style={{ gridColumn: '2', gridRow: '1', marginTop: '0' }}>
-                <FollowOnRequestMaterialsForm
-                  register={register}
-                  getValues={getValues}
-                  errors={errors}
-                  followOnData={followOnData}
-                  hasWhiteBackground={true}
-                />
-              </div>
-              <div style={{ gridColumn: '2', gridRow: '2', marginTop: '0' }}>
-                <TextArea
-                  name="additionalNotes"
-                  label="Additional notes"
-                  register={register}
-                  error={errors && errors.additionalNotes}
-                  defaultValue={followOnData?.additionalNotes ?? ''}
-                />
-              </div>
+            <FollowOnRequestMaterialsSupervisorCalledForm
+              register={register}
+              errors={errors}
+              followOnData={followOnData}
+              hasWhiteBackground={true}
+            />
+
+            <FollowOnRequestTypeOfWorkForm
+              errors={errors}
+              register={register}
+              getValues={getValues}
+              setError={setError}
+              clearErrors={clearErrors}
+              watch={watch}
+              followOnData={followOnData}
+              hasWhiteBackground={true}
+              isGrid={true}
+            />
+
+            <label style={{ fontSize: '25px' }}>Radio or Dropdown?</label>
+            <div style={{ display: 'flex', gap: '10px' }}>
+              <button
+                onClick={(e) => {
+                  e.preventDefault()
+                  setIsDropdown(false)
+                  setIsRadio(true)
+                }}
+                style={{ cursor: 'pointer', borderRadius: '5px' }}
+                data-testid="radioButton"
+              >
+                Radio
+              </button>
+              <button
+                onClick={(e) => {
+                  e.preventDefault()
+                  setIsRadio(false)
+                  setIsDropdown(true)
+                }}
+                style={{
+                  cursor: 'pointer',
+                  marginTop: '0',
+                  borderRadius: '5px',
+                }}
+                data-testid="dropdownButton"
+              >
+                Dropdown
+              </button>
             </div>
+            {isRadio && (
+              <Radios
+                label="Estimated duration"
+                name="estimatedDuration"
+                labelSize="s"
+                options={[
+                  '30 mins',
+                  '1 hour',
+                  '2-3 hours',
+                  'Half a day',
+                  '1 day',
+                  'More than 1 day',
+                  'Unknown',
+                ]}
+                register={register({
+                  required: 'Select estimated duration',
+                })}
+                error={errors && errors.estimatedDuration}
+                isGrid={true}
+                hasWhiteBackground={true}
+              />
+            )}
+            {isDropdown && (
+              <Select
+                label="Estimated duration"
+                name="estimatedDuration"
+                options={[
+                  '30 mins',
+                  '1 hour',
+                  '2-3 hours',
+                  'Half a day',
+                  '1 day',
+                  'More than 1 day',
+                  'Unknown',
+                ]}
+                register={register({
+                  required: 'Select estimated duration',
+                })}
+                error={errors && errors.estimatedDuration}
+                widthClass="govuk-!-width-one-half"
+              />
+            )}
+
+            <FollowOnRequestMaterialsForm
+              register={register}
+              getValues={getValues}
+              errors={errors}
+              followOnData={followOnData}
+              hasWhiteBackground={true}
+            />
+
+            <TextArea
+              name="additionalNotes"
+              label="Additional notes"
+              register={register}
+              error={errors && errors.additionalNotes}
+              defaultValue={followOnData?.additionalNotes ?? ''}
+            />
           </div>
         )}
 

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -140,6 +140,7 @@ const CloseWorkOrderForm = ({
                   register={register}
                   errors={errors}
                   followOnData={followOnData}
+                  hasWhiteBackground={true}
                 />
               </div>
               <div style={{ gridColumn: '1', marginTop: '0' }}>
@@ -151,6 +152,7 @@ const CloseWorkOrderForm = ({
                   clearErrors={clearErrors}
                   watch={watch}
                   followOnData={followOnData}
+                  hasWhiteBackground={true}
                 />
               </div>
               <div style={{ gridColumn: '1 / -1', marginTop: '0' }}>
@@ -202,6 +204,7 @@ const CloseWorkOrderForm = ({
                     })}
                     error={errors && errors.estimatedDuration}
                     isGrid={true}
+                    hasWhiteBackground={true}
                   />
                 )}
                 {isDropdown && (
@@ -232,6 +235,7 @@ const CloseWorkOrderForm = ({
                   getValues={getValues}
                   errors={errors}
                   followOnData={followOnData}
+                  hasWhiteBackground={true}
                 />
               </div>
               <div style={{ gridColumn: '2', gridRow: '2', marginTop: '0' }}>

--- a/src/components/WorkOrders/CloseWorkOrderForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderForm.js
@@ -114,109 +114,137 @@ const CloseWorkOrderForm = ({
         />
 
         {showFurtherWorkFields && (
-          <>
-            <h1 className="lbh-heading-h2">Details of further work required</h1>
-            <FollowOnRequestMaterialsSupervisorCalledForm
-              register={register}
-              errors={errors}
-              followOnData={followOnData}
-            />
-            <FollowOnRequestTypeOfWorkForm
-              errors={errors}
-              register={register}
-              getValues={getValues}
-              setError={setError}
-              clearErrors={clearErrors}
-              watch={watch}
-              followOnData={followOnData}
-            />
-
-            <label style={{ fontSize: '25px' }}>Radio or Dropdown?</label>
-            <div style={{ display: 'flex', gap: '10px' }}>
-              <button
-                onClick={(e) => {
-                  e.preventDefault()
-                  setIsDropdown(false)
-                  setIsRadio(true)
-                }}
-                style={{ cursor: 'pointer', borderRadius: '5px' }}
-                data-testid="radioButton"
-              >
-                Radio
-              </button>
-              <button
-                onClick={(e) => {
-                  e.preventDefault()
-                  setIsRadio(false)
-                  setIsDropdown(true)
-                }}
-                style={{
-                  cursor: 'pointer',
-                  marginTop: '0',
-                  borderRadius: '5px',
-                }}
-                data-testid="dropdownButton"
-              >
-                Dropdown
-              </button>
+          <div
+            style={{
+              backgroundColor: '#f3f3f3',
+              padding: '2rem',
+              display: 'flex',
+              flexWrap: 'wrap',
+              marginBottom: '10px',
+            }}
+          >
+            <div style={{ flexBasis: '100%' }}>
+              <h1 className="lbh-heading-h2">
+                Details of further work required
+              </h1>
             </div>
-            {isRadio && (
-              <Radios
-                label="Estimated duration"
-                name="estimatedDuration"
-                labelSize="s"
-                options={[
-                  '30 mins',
-                  '1 hour',
-                  '2-3 hours',
-                  'Half a day',
-                  '1 day',
-                  'More than 1 day',
-                  'Unknown',
-                ]}
-                register={register({
-                  required: 'Select estimated duration',
-                })}
-                error={errors && errors.estimatedDuration}
-                isGrid={true}
-              />
-            )}
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                width: '100%',
+              }}
+            >
+              <div style={{ gridColumn: '1' }}>
+                <FollowOnRequestMaterialsSupervisorCalledForm
+                  register={register}
+                  errors={errors}
+                  followOnData={followOnData}
+                />
+              </div>
+              <div style={{ gridColumn: '1', marginTop: '0' }}>
+                <FollowOnRequestTypeOfWorkForm
+                  errors={errors}
+                  register={register}
+                  getValues={getValues}
+                  setError={setError}
+                  clearErrors={clearErrors}
+                  watch={watch}
+                  followOnData={followOnData}
+                />
+              </div>
+              <div style={{ gridColumn: '1 / -1', marginTop: '0' }}>
+                <label style={{ fontSize: '25px' }}>Radio or Dropdown?</label>
+                <div style={{ display: 'flex', gap: '10px' }}>
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setIsDropdown(false)
+                      setIsRadio(true)
+                    }}
+                    style={{ cursor: 'pointer', borderRadius: '5px' }}
+                    data-testid="radioButton"
+                  >
+                    Radio
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setIsRadio(false)
+                      setIsDropdown(true)
+                    }}
+                    style={{
+                      cursor: 'pointer',
+                      marginTop: '0',
+                      borderRadius: '5px',
+                    }}
+                    data-testid="dropdownButton"
+                  >
+                    Dropdown
+                  </button>
+                </div>
+                {isRadio && (
+                  <Radios
+                    label="Estimated duration"
+                    name="estimatedDuration"
+                    labelSize="s"
+                    options={[
+                      '30 mins',
+                      '1 hour',
+                      '2-3 hours',
+                      'Half a day',
+                      '1 day',
+                      'More than 1 day',
+                      'Unknown',
+                    ]}
+                    register={register({
+                      required: 'Select estimated duration',
+                    })}
+                    error={errors && errors.estimatedDuration}
+                    isGrid={true}
+                  />
+                )}
+                {isDropdown && (
+                  <Select
+                    label="Estimated duration"
+                    name="estimatedDuration"
+                    options={[
+                      '30 mins',
+                      '1 hour',
+                      '2-3 hours',
+                      'Half a day',
+                      '1 day',
+                      'More than 1 day',
+                      'Unknown',
+                    ]}
+                    register={register({
+                      required: 'Select estimated duration',
+                    })}
+                    error={errors && errors.estimatedDuration}
+                    widthClass="govuk-!-width-one-half"
+                  />
+                )}
+              </div>
 
-            {isDropdown && (
-              <Select
-                label="Estimated duration"
-                name="estimatedDuration"
-                options={[
-                  '30 mins',
-                  '1 hour',
-                  '2-3 hours',
-                  'Half a day',
-                  '1 day',
-                  'More than 1 day',
-                  'Unknown',
-                ]}
-                register={register({
-                  required: 'Select estimated duration',
-                })}
-                error={errors && errors.estimatedDuration}
-                widthClass="govuk-!-width-one-half"
-              />
-            )}
-
-            <FollowOnRequestMaterialsForm
-              register={register}
-              getValues={getValues}
-              errors={errors}
-              followOnData={followOnData}
-            />
-            <TextArea
-              name="additionalNotes"
-              label="Additional notes"
-              register={register}
-              error={errors && errors.additionalNotes}
-              defaultValue={followOnData?.additionalNotes ?? ''}
-            />
-          </>
+              <div style={{ gridColumn: '2', gridRow: '1', marginTop: '0' }}>
+                <FollowOnRequestMaterialsForm
+                  register={register}
+                  getValues={getValues}
+                  errors={errors}
+                  followOnData={followOnData}
+                />
+              </div>
+              <div style={{ gridColumn: '2', gridRow: '2', marginTop: '0' }}>
+                <TextArea
+                  name="additionalNotes"
+                  label="Additional notes"
+                  register={register}
+                  error={errors && errors.additionalNotes}
+                  defaultValue={followOnData?.additionalNotes ?? ''}
+                />
+              </div>
+            </div>
+          </div>
         )}
 
         <div className="govuk-form-group lbh-form-group">

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
@@ -22,7 +22,13 @@ const codesToFilter = new Set(
 )
 
 const FollowOnRequestDifferentTradesForm = (props) => {
-  const { register, requiredFollowOnTrades, watch, errors } = props
+  const {
+    register,
+    requiredFollowOnTrades,
+    watch,
+    errors,
+    hasWhiteBackground,
+  } = props
 
   const [trades, setTrades] = useState([])
   const [error, setError] = useState(null)
@@ -59,6 +65,7 @@ const FollowOnRequestDifferentTradesForm = (props) => {
             label={label}
             register={register}
             checked={selectedTrades.has(name)}
+            hasWhiteBackground={hasWhiteBackground}
           />
         </li>
       ))}

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
@@ -28,6 +28,7 @@ const FollowOnRequestDifferentTradesForm = (props) => {
     watch,
     errors,
     hasWhiteBackground,
+    isGrid,
   } = props
 
   const [trades, setTrades] = useState([])
@@ -54,9 +55,20 @@ const FollowOnRequestDifferentTradesForm = (props) => {
   const filteredTrades = trades.filter((trade) => !codesToFilter.has(trade.key))
 
   return (
-    <ul>
+    <ul
+      style={
+        isGrid && {
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          rowGap: '1rem',
+        }
+      }
+    >
       {FOLLOW_ON_REQUEST_AVAILABLE_TRADES.map(({ name, label }) => (
-        <li style={{ display: 'flex' }} key={name}>
+        <li
+          style={{ ...(isGrid && { marginTop: '0' }), display: 'flex' }}
+          key={name}
+        >
           <Checkbox
             className="govuk-!-margin-0"
             labelClassName="lbh-body-xs govuk-!-margin-0"

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
@@ -66,7 +66,11 @@ const FollowOnRequestDifferentTradesForm = (props) => {
     >
       {FOLLOW_ON_REQUEST_AVAILABLE_TRADES.map(({ name, label }) => (
         <li
-          style={{ ...(isGrid && { marginTop: '0' }), display: 'flex' }}
+          style={{
+            ...(isGrid && { marginTop: '0' }),
+            ...(name === 'followon-trades-other' && { gridColumn: 'span 2' }),
+            display: 'flex',
+          }}
           key={name}
         >
           <Checkbox
@@ -79,27 +83,34 @@ const FollowOnRequestDifferentTradesForm = (props) => {
             checked={selectedTrades.has(name)}
             hasWhiteBackground={hasWhiteBackground}
           />
+          {name === 'followon-trades-other' && isDifferentTradesChecked && (
+            <div
+              style={
+                isGrid && {
+                  paddingLeft: '20px',
+                  borderLeft: `3px solid ${error ? '#be3a34' : '#b1b4b6'}`,
+                }
+              }
+            >
+              <DataList
+                label="Please specify"
+                name="otherTrade"
+                options={filteredTrades.map((trade) => trade.description)}
+                register={register}
+                hint="Select or type a trade"
+                widthClass="govuk-!-width-full"
+                error={errors.otherTrade}
+                maxLength={maxLength}
+                onChange={(e) =>
+                  setRemainingCharacterCount(maxLength - e.target.value.length)
+                }
+                remainingCharacterCount={remainingCharacterCount}
+              />
+              {error && <ErrorMessage label={error} />}
+            </div>
+          )}
         </li>
       ))}
-      {isDifferentTradesChecked && (
-        <>
-          <DataList
-            label="Please specify"
-            name="otherTrade"
-            options={filteredTrades.map((trade) => trade.description)}
-            register={register}
-            hint="Select or type a trade"
-            widthClass="govuk-!-width-full"
-            error={errors.otherTrade}
-            maxLength={maxLength}
-            onChange={(e) =>
-              setRemainingCharacterCount(maxLength - e.target.value.length)
-            }
-            remainingCharacterCount={remainingCharacterCount}
-          />
-          {error && <ErrorMessage label={error} />}
-        </>
-      )}
     </ul>
   )
 }

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestMaterialsForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestMaterialsForm.js
@@ -1,7 +1,13 @@
 import { Checkbox, TextArea } from '../../Form'
 
 const FollowOnRequestMaterialsForm = (props) => {
-  const { register, getValues, errors, followOnData } = props
+  const {
+    register,
+    getValues,
+    errors,
+    followOnData,
+    hasWhiteBackground,
+  } = props
 
   return (
     <>
@@ -15,6 +21,7 @@ const FollowOnRequestMaterialsForm = (props) => {
           label={'Stock items required'}
           register={register}
           checked={followOnData?.stockItemsRequired ?? false}
+          hasWhiteBackground={hasWhiteBackground}
         />
 
         <Checkbox
@@ -24,6 +31,7 @@ const FollowOnRequestMaterialsForm = (props) => {
           label={'Non stock items required'}
           register={register}
           checked={followOnData?.nonStockItemsRequired ?? false}
+          hasWhiteBackground={hasWhiteBackground}
         />
       </fieldset>
 

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestMaterialsSupervisorCalledForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestMaterialsSupervisorCalledForm.tsx
@@ -4,10 +4,11 @@ interface Props {
   register: any
   errors: { [key: string]: { message: string } }
   followOnData?: { supervisorCalled: boolean }
+  hasWhiteBackground?: boolean
 }
 
 const FollowOnRequestMaterialsSupervisorCalledForm = (props: Props) => {
-  const { register, errors, followOnData } = props
+  const { register, errors, followOnData, hasWhiteBackground } = props
 
   const options = [
     {
@@ -35,6 +36,7 @@ const FollowOnRequestMaterialsSupervisorCalledForm = (props: Props) => {
         required: 'Please confirm whether you have contacted your supervisor',
       })}
       error={errors && errors.supervisorCalled}
+      hasWhiteBackground={hasWhiteBackground}
     />
   )
 }

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.js
@@ -15,6 +15,7 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
     watch,
     followOnData,
     hasWhiteBackground,
+    isGrid,
   } = props
 
   const selectedFurtherWorkRequired =
@@ -136,6 +137,7 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
                   requiredFollowOnTrades={
                     followOnData?.requiredFollowOnTrades ?? []
                   }
+                  isGrid={isGrid}
                 />
               </>
             }

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.js
@@ -14,6 +14,7 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
     clearErrors,
     watch,
     followOnData,
+    hasWhiteBackground,
   } = props
 
   const selectedFurtherWorkRequired =
@@ -93,6 +94,7 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
               },
             })}
             checked={followOnData?.isSameTrade ?? false}
+            hasWhiteBackground={hasWhiteBackground}
           />
 
           <Checkbox
@@ -102,6 +104,7 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
             label={'Different trade(s)'}
             error={errors && errors?.isDifferentTrades}
             checked={followOnData?.isDifferentTrades ?? false}
+            hasWhiteBackground={hasWhiteBackground}
             register={register({
               validate: () => {
                 // doesnt validate itself - just running the validate function
@@ -129,6 +132,7 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
                   register={register}
                   errors={errors}
                   watch={watch}
+                  hasWhiteBackground={hasWhiteBackground}
                   requiredFollowOnTrades={
                     followOnData?.requiredFollowOnTrades ?? []
                   }
@@ -144,6 +148,7 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
             name={'isMultipleOperatives'}
             checked={followOnData?.isMultipleOperatives ?? false}
             label={'Multiple operatives'}
+            hasWhiteBackground={hasWhiteBackground}
             register={register({
               validate: () => {
                 // doesnt validate itself - just running the validate function

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -137,6 +137,10 @@ $govuk-font-family: 'GDS Transport', arial, sans-serif !important;
   }
 }
 
+.white-background::before {
+  background-color: white;
+}
+
 @media (min-width: 800px) {
   .latest-changes {
     img {


### PR DESCRIPTION
### Description of change

#### Context 

This is due to my misunderstanding of the desktop process to close a job, the different google groups and processes involved. 

When testing the follow on form on staging I was taken by how unattractive and unclear the UX is for the follow on form. Looking back to some original designs I think it would be beneficial to implement the format that was conceptualised: 

#### Acceptance 

Have everything as one list apart from the other trade checkboxes 

#### Initial design: 

![image](https://github.com/user-attachments/assets/0a1d9447-2d17-4003-842f-1c4cbbae8159)

**Grey background is a must and is only for desktop view**

### Story Link

https://hackney.atlassian.net/jira/software/projects/HPT/boards/116?selectedIssue=HPT-650

### How it looks

![image](https://github.com/user-attachments/assets/0bbb0729-bc3b-4f75-963a-4a949bc2e77a)

### With other not selected:

![image](https://github.com/user-attachments/assets/594448b5-7cb9-4ac0-b3a2-601388f5787f)

### With other selected: 

![image](https://github.com/user-attachments/assets/69f62ba4-2618-4439-93fe-7adde5476075)

#### With radio estimated duration selected: 

![image](https://github.com/user-attachments/assets/46ab8238-1ccc-4db5-81f4-c09c0889892f)

#### With dropdown estimated duration selected:

![image](https://github.com/user-attachments/assets/14c0b50f-c3c2-4968-8b16-1e1aacea0521)
