### PR TITLE
Remove google analytics noscript

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -22,19 +22,6 @@ class AppDocument extends Document {
           )}
         </Head>
         <body className="govuk-template__body">
-          {TAG_MANAGER_ID && (
-            <noscript>
-              <iframe
-                src={
-                  'https://www.googletagmanager.com/ns.html?id=' +
-                  TAG_MANAGER_ID
-                }
-                height="0"
-                width="0"
-                style={{ display: 'none', visibility: 'hidden' }}
-              ></iframe>
-            </noscript>
-          )}
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
This is to fix an issue where there's a white bar on the top of Repairs Hub.

This bar is caused by imported CSS that is to the effect of "add 1.5em margin top to any element on the page that has an element above it"

In this case the element above was a <noscript> on top of the main component. We don't really need the <noscript> so we may as well remove it and fix the display issue at the same time