### PR TITLE
Fix link on related work order view page

### DIFF
--- a/src/components/WorkOrders/RelatedWorkOrdersView/RelatedWorkOrderViewList.tsx
+++ b/src/components/WorkOrders/RelatedWorkOrdersView/RelatedWorkOrderViewList.tsx
@@ -35,9 +35,9 @@ const RelatedWorkOrderViewList = ({ hierarchy }: Props) => {
             </div>
             <div className="wo-hierarchy-link-and-trade">
               <span className="wo-hierarchy-link">
-                <Link href={`/work-orders/${workOrder.reference}`}>
+                <a href={`/work-orders/${workOrder.reference}`}>
                   {workOrder.reference}
-                </Link>
+                </a>
               </span>
 
               <div style={{ marginTop: 0 }}>{workOrder.tradeDescription}</div>


### PR DESCRIPTION
## Summary of Changes

The links don't work on the related work orders tab. I suspect it's related to how tabs are rendered and is interfering with next/router.

For now, the simplest solution is to use an anchor tag.

![image](https://github.com/user-attachments/assets/26f0ed9a-23a9-4011-ac2d-ac3d56b2d07b)
