### PR TITLE
Extract getWorkOrder logic into a single method

### DIFF
--- a/cypress/e2e/search/search.cy.js
+++ b/cypress/e2e/search/search.cy.js
@@ -152,7 +152,7 @@ describe('Search', () => {
           cy.wait(['@repairs_with_error', '@workOrderTasksRequest'])
         })
 
-        it('Displays an error message', () => {
+        it.only('Displays an error message', () => {
           cy.get('.govuk-error-message').contains(
             'Could not find a work order with reference 00000000'
           )

--- a/cypress/e2e/search/search.cy.js
+++ b/cypress/e2e/search/search.cy.js
@@ -152,7 +152,7 @@ describe('Search', () => {
           cy.wait(['@repairs_with_error', '@workOrderTasksRequest'])
         })
 
-        it.only('Displays an error message', () => {
+        it('Displays an error message', () => {
           cy.get('.govuk-error-message').contains(
             'Could not find a work order with reference 00000000'
           )

--- a/src/components/Operatives/NewTaskForm.js
+++ b/src/components/Operatives/NewTaskForm.js
@@ -8,6 +8,7 @@ import RateScheduleItem from '../WorkElement/RateScheduleItem'
 import Spinner from '../Spinner'
 import ErrorMessage from '../Errors/ErrorMessage'
 import { buildVariationFormData } from '@/utils/hact/jobStatusUpdate/variation'
+import { getWorkOrder } from '../../utils/requests/workOrders'
 
 const NewTaskForm = ({ workOrderReference }) => {
   const [loading, setLoading] = useState(false)
@@ -22,10 +23,13 @@ const NewTaskForm = ({ workOrderReference }) => {
     setError(null)
 
     try {
-      const workOrder = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${reference}`,
-      })
+      const workOrderResponse = await getWorkOrder(reference)
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       const sorCodes = await frontEndApiRequest({
         path: '/api/schedule-of-rates/codes',

--- a/src/components/Operatives/NewTaskForm.js
+++ b/src/components/Operatives/NewTaskForm.js
@@ -9,6 +9,7 @@ import Spinner from '../Spinner'
 import ErrorMessage from '../Errors/ErrorMessage'
 import { buildVariationFormData } from '@/utils/hact/jobStatusUpdate/variation'
 import { getWorkOrder } from '../../utils/requests/workOrders'
+import { APIResponseError } from '../../types/requests/types'
 
 const NewTaskForm = ({ workOrderReference }) => {
   const [loading, setLoading] = useState(false)
@@ -59,11 +60,16 @@ const NewTaskForm = ({ workOrderReference }) => {
       setExistingTasks(tasksAndSors)
     } catch (e) {
       setSorCodes([])
-      setError(
-        `Oops an error occurred with error status: ${
-          e.response?.status
-        } with message: ${JSON.stringify(e.response?.data?.message)}`
-      )
+
+      if (e instanceof APIResponseError) {
+        setError(e.message)
+      } else {
+        setError(
+          `Oops an error occurred with error status: ${
+            e.response?.status
+          } with message: ${JSON.stringify(e.response?.data?.message)}`
+        )
+      }
     }
 
     setLoading(false)

--- a/src/components/Operatives/OperativeFormView.js
+++ b/src/components/Operatives/OperativeFormView.js
@@ -8,6 +8,7 @@ import { buildOperativeAssignmentFormData } from '@/utils/hact/jobStatusUpdate/a
 import { WorkOrder } from '@/models/workOrder'
 import OperativeForm from './OperativeForm'
 import { sortOperativesWithPayrollFirst } from '@/utils/helpers/operatives'
+import { getWorkOrder } from '../../utils/requests/workOrders'
 
 const OperativeFormView = ({ workOrderReference }) => {
   const router = useRouter()
@@ -59,12 +60,15 @@ const OperativeFormView = ({ workOrderReference }) => {
 
       setCurrentUser(currentUser)
 
-      const workOrder = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${workOrderReference}`,
-      })
+      const workOrderResponse = await getWorkOrder(workOrderReference)
 
-      setWorkOrder(new WorkOrder(workOrder))
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
+
+      setWorkOrder(workOrder)
 
       const sortedOperatives = sortOperativesWithPayrollFirst(
         workOrder.operatives,

--- a/src/components/Operatives/OperativeFormView.js
+++ b/src/components/Operatives/OperativeFormView.js
@@ -9,6 +9,7 @@ import { WorkOrder } from '@/models/workOrder'
 import OperativeForm from './OperativeForm'
 import { sortOperativesWithPayrollFirst } from '@/utils/helpers/operatives'
 import { getWorkOrder } from '../../utils/requests/workOrders'
+import { APIResponseError } from '../../types/requests/types'
 
 const OperativeFormView = ({ workOrderReference }) => {
   const router = useRouter()
@@ -90,16 +91,20 @@ const OperativeFormView = ({ workOrderReference }) => {
       setAvailableOperatives([])
       console.error('An error has occured:', e.response)
 
-      if (e.response?.status === 404) {
-        setError(
-          `Could not find a work order with reference ${workOrderReference}`
-        )
+      if (e instanceof APIResponseError) {
+        setError(e.message)
       } else {
-        setError(
-          `Oops an error occurred with error status: ${
-            e.response?.status
-          } with message: ${JSON.stringify(e.response?.data?.message)}`
-        )
+        if (e.response?.status === 404) {
+          setError(
+            `Could not find a work order with reference ${workOrderReference}`
+          )
+        } else {
+          setError(
+            `Oops an error occurred with error status: ${
+              e.response?.status
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+          )
+        }
       }
     }
 

--- a/src/components/WorkOrder/Appointment/AppointmentView.js
+++ b/src/components/WorkOrder/Appointment/AppointmentView.js
@@ -14,6 +14,7 @@ import NoAvailableAppointments from './NoAvailableAppointments'
 import { WorkOrder } from '@/models/workOrder'
 import { toISODate } from '../../../utils/date'
 import { createWOLinks } from '@/utils/successPageLinks'
+import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
 
 const AppointmentView = ({ workOrderReference, successText }) => {
   const [property, setProperty] = useState({})
@@ -35,11 +36,13 @@ const AppointmentView = ({ workOrderReference, successText }) => {
     setError(null)
 
     try {
-      const workOrderData = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${workOrderReference}`,
-      })
-      const workOrder = new WorkOrder(workOrderData)
+      const workOrderResponse = await getWorkOrder(workOrderReference)
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       if (!workOrder.statusAllowsScheduling()) {
         setError(

--- a/src/components/WorkOrder/Appointment/AppointmentView.js
+++ b/src/components/WorkOrder/Appointment/AppointmentView.js
@@ -15,6 +15,7 @@ import { WorkOrder } from '@/models/workOrder'
 import { toISODate } from '../../../utils/date'
 import { createWOLinks } from '@/utils/successPageLinks'
 import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
+import { APIResponseError } from '@/root/src/types/requests/types'
 
 const AppointmentView = ({ workOrderReference, successText }) => {
   const [property, setProperty] = useState({})
@@ -86,11 +87,16 @@ const AppointmentView = ({ workOrderReference, successText }) => {
       setTenure(null)
       setAvailableAppointments(null)
       console.error('An error has occured:', e.response)
-      setError(
-        `Oops an error occurred with error status: ${
-          e.response?.status
-        } with message: ${JSON.stringify(e.response?.data?.message)}`
-      )
+
+      if (e instanceof APIResponseError) {
+        setError(e.message)
+      } else {
+        setError(
+          `Oops an error occurred with error status: ${
+            e.response?.status
+          } with message: ${JSON.stringify(e.response?.data?.message)}`
+        )
+      }
     } finally {
       setLoading(false)
     }

--- a/src/components/WorkOrder/Authorisation/AuthorisationView.js
+++ b/src/components/WorkOrder/Authorisation/AuthorisationView.js
@@ -22,6 +22,7 @@ import {
   authorisationApprovedLinks,
   cancelWorkOrderLinks,
 } from '@/utils/successPageLinks'
+import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
 
 const AuthorisationView = ({ workOrderReference }) => {
   const [error, setError] = useState()
@@ -80,11 +81,13 @@ const AuthorisationView = ({ workOrderReference }) => {
     setError(null)
 
     try {
-      const workOrderData = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${workOrderReference}`,
-      })
-      const workOrder = new WorkOrder(workOrderData)
+      const workOrderResponse = await getWorkOrder(workOrderReference)
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       const tasksAndSors = await frontEndApiRequest({
         method: 'get',

--- a/src/components/WorkOrder/Authorisation/AuthorisationView.js
+++ b/src/components/WorkOrder/Authorisation/AuthorisationView.js
@@ -23,6 +23,7 @@ import {
   cancelWorkOrderLinks,
 } from '@/utils/successPageLinks'
 import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
+import { APIResponseError } from '@/root/src/types/requests/types'
 
 const AuthorisationView = ({ workOrderReference }) => {
   const [error, setError] = useState()
@@ -114,9 +115,14 @@ const AuthorisationView = ({ workOrderReference }) => {
       }
     } catch (e) {
       console.error('An error has occured:', e.response)
-      setError(
-        `Oops an error occurred with error status: ${e.response?.status}`
-      )
+
+      if (e instanceof APIResponseError) {
+        setError(e.message)
+      } else {
+        setError(
+          `Oops an error occurred with error status: ${e.response?.status}`
+        )
+      }
     }
 
     setLoading(false)

--- a/src/components/WorkOrder/Authorisation/VariationAuthorisationView.tsx
+++ b/src/components/WorkOrder/Authorisation/VariationAuthorisationView.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../../types/variations/types'
 import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
 import { WorkOrder } from '@/root/src/models/workOrder'
+import { APIResponseError } from '@/root/src/types/requests/types'
 
 const APPROVE_REQUEST = 'Approve request'
 const REJECT_REQUEST = 'Reject request'
@@ -94,16 +95,21 @@ const VariationAuthorisationView = ({ workOrderReference }: Props) => {
     } catch (e) {
       setVariation(null)
       console.error('An error has occured:', e.response)
-      if (e.response?.status === 404) {
-        setError(
-          `Could not find a work order with reference ${workOrderReference}`
-        )
+
+      if (e instanceof APIResponseError) {
+        setError(e.message)
       } else {
-        setError(
-          `Oops an error occurred with error status: ${
-            e.response?.status
-          } with message: ${JSON.stringify(e.response?.data?.message)}`
-        )
+        if (e.response?.status === 404) {
+          setError(
+            `Could not find a work order with reference ${workOrderReference}`
+          )
+        } else {
+          setError(
+            `Oops an error occurred with error status: ${
+              e.response?.status
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+          )
+        }
       }
     }
 

--- a/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderView.js
+++ b/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderView.js
@@ -45,7 +45,7 @@ const CancelWorkOrderView = ({ workOrderReference }) => {
 
     if (!workOrderResponse.success) {
       setWorkOrder(null)
-      setError(workOrderResponse.error)
+      setError(workOrderResponse.error.message)
     } else {
       setWorkOrder(workOrderResponse.response)
     }

--- a/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderView.js
+++ b/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderView.js
@@ -8,6 +8,7 @@ import { WorkOrder } from '@/models/workOrder'
 import SuccessPage from '../../SuccessPage/index'
 import { cancelWorkOrderLinks } from '@/utils/successPageLinks'
 import Panel from '@/components/Template/Panel'
+import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
 
 const CancelWorkOrderView = ({ workOrderReference }) => {
   const [workOrder, setWorkOrder] = useState({})
@@ -40,21 +41,13 @@ const CancelWorkOrderView = ({ workOrderReference }) => {
   const getCancelWorkOrderView = async () => {
     setError(null)
 
-    try {
-      const workOrder = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${workOrderReference}`,
-      })
+    const workOrderResponse = await getWorkOrder(workOrderReference)
 
-      setWorkOrder(new WorkOrder(workOrder))
-    } catch (e) {
+    if (!workOrderResponse.success) {
       setWorkOrder(null)
-      console.error('An error has occured:', e.response)
-      setError(
-        `Oops an error occurred with error status: ${
-          e.response?.status
-        } with message: ${JSON.stringify(e.response?.data?.message)}`
-      )
+      setError(workOrderResponse.error)
+    } else {
+      setWorkOrder(workOrderResponse.response)
     }
 
     setLoading(false)

--- a/src/components/WorkOrder/EditWorkOrder.tsx
+++ b/src/components/WorkOrder/EditWorkOrder.tsx
@@ -46,7 +46,7 @@ const EditWorkOrder = ({ workOrderReference }: EditWorkOrderProps) => {
     setLoading(true)
     const { response, error } = await getWorkOrder(workOrderReference)
     setWorkOrder(response)
-    setError(error)
+    setError(error.message)
     setLoading(false)
   }
 
@@ -60,14 +60,14 @@ const EditWorkOrder = ({ workOrderReference }: EditWorkOrderProps) => {
       data.editRepairDescription
     )
     if (!editWorkOrderResponse.success) {
-      setError(editWorkOrderResponse.error)
+      setError(editWorkOrderResponse.error.message)
       return
     }
 
     const postNoteResponse = await postNote(noteData)
 
     if (!postNoteResponse.success) {
-      setError(postNoteResponse.error)
+      setError(postNoteResponse.error.message)
       return
     }
     router.push(`/work-orders/${workOrder.reference}`)

--- a/src/components/WorkOrder/EditWorkOrder.tsx
+++ b/src/components/WorkOrder/EditWorkOrder.tsx
@@ -44,9 +44,14 @@ const EditWorkOrder = ({ workOrderReference }: EditWorkOrderProps) => {
 
   const fetchWorkOrder = async () => {
     setLoading(true)
-    const { response, error } = await getWorkOrder(workOrderReference)
-    setWorkOrder(response)
-    setError(error.message)
+    const workOrderResponse = await getWorkOrder(workOrderReference)
+
+    if (!workOrderResponse.success) {
+      setError(workOrderResponse.error.message)
+    } else {
+      setWorkOrder(workOrderResponse.response)
+    }
+
     setLoading(false)
   }
 

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -23,6 +23,7 @@ import { workOrderNoteFragmentForPaymentType } from '../../utils/paymentTypes'
 import SpinnerWithLabel from '../SpinnerWithLabel'
 import fileUploadStatusLogger from './Photos/hooks/uploadFiles/fileUploadStatusLogger'
 import { emitTagManagerEvent } from '@/utils/tagManager'
+import { getWorkOrder } from '../../utils/requests/workOrders'
 
 const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
   const { setModalFlashMessage } = useContext(FlashMessageContext)
@@ -47,10 +48,13 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
     setError(null)
 
     try {
-      const workOrder = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${workOrderReference}`,
-      })
+      const workOrderResponse = await getWorkOrder(workOrderReference)
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       const featureToggleData = await fetchSimpleFeatureToggles()
 

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -24,6 +24,7 @@ import SpinnerWithLabel from '../SpinnerWithLabel'
 import fileUploadStatusLogger from './Photos/hooks/uploadFiles/fileUploadStatusLogger'
 import { emitTagManagerEvent } from '@/utils/tagManager'
 import { getWorkOrder } from '../../utils/requests/workOrders'
+import { APIResponseError } from '../../types/requests/types'
 
 const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
   const { setModalFlashMessage } = useContext(FlashMessageContext)
@@ -95,16 +96,20 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
       setPhotos(null)
       console.error('An error has occured:', e.response)
 
-      if (e.response?.status === 404) {
-        setError(
-          `Could not find a work order with reference ${workOrderReference}`
-        )
+      if (e instanceof APIResponseError) {
+        setError(e.message)
       } else {
-        setError(
-          `Oops an error occurred with error status: ${
-            e.response?.status
-          } with message: ${JSON.stringify(e.response?.data?.message)}`
-        )
+        if (e.response?.status === 404) {
+          setError(
+            `Could not find a work order with reference ${workOrderReference}`
+          )
+        } else {
+          setError(
+            `Oops an error occurred with error status: ${
+              e.response?.status
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+          )
+        }
       }
     }
 

--- a/src/components/WorkOrder/TasksAndSors/EditTaskForm.js
+++ b/src/components/WorkOrder/TasksAndSors/EditTaskForm.js
@@ -9,6 +9,7 @@ import { buildVariationFormData } from '@/utils/hact/jobStatusUpdate/variation'
 import { useRouter } from 'next/router'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import AppointmentHeader from '../AppointmentHeader'
+import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
 
 const EditTaskForm = ({ workOrderReference, taskId }) => {
   const [tasks, setTasks] = useState({})
@@ -63,10 +64,13 @@ const EditTaskForm = ({ workOrderReference, taskId }) => {
     setError(null)
 
     try {
-      const workOrder = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${workOrderReference}`,
-      })
+      const workOrderResponse = await getWorkOrder(workOrderReference)
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       const currentUser = await frontEndApiRequest({
         method: 'get',

--- a/src/components/WorkOrder/TasksAndSors/EditTaskForm.js
+++ b/src/components/WorkOrder/TasksAndSors/EditTaskForm.js
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import AppointmentHeader from '../AppointmentHeader'
 import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
+import { APIResponseError } from '@/root/src/types/requests/types'
 
 const EditTaskForm = ({ workOrderReference, taskId }) => {
   const [tasks, setTasks] = useState({})
@@ -98,11 +99,15 @@ const EditTaskForm = ({ workOrderReference, taskId }) => {
     } catch (e) {
       console.error('An error has occured:', e.response)
 
-      setError(
-        `Oops an error occurred with error status: ${
-          e.response?.status
-        } with message: ${JSON.stringify(e.response?.data?.message)}`
-      )
+      if (e instanceof APIResponseError) {
+        setError(e.message)
+      } else {
+        setError(
+          `Oops an error occurred with error status: ${
+            e.response?.status
+          } with message: ${JSON.stringify(e.response?.data?.message)}`
+        )
+      }
     }
 
     setLoading(false)

--- a/src/components/WorkOrder/Update/index.js
+++ b/src/components/WorkOrder/Update/index.js
@@ -16,6 +16,7 @@ import SuccessPage from '../../SuccessPage/index'
 import { updateWorkOrderLinks, generalLinks } from '@/utils/successPageLinks'
 import PageAnnouncement from '@/components/Template/PageAnnouncement'
 import AddMultipleSORs from '@/components/Property/RaiseWorkOrder/AddMultipleSORs'
+import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
 
 const WorkOrderUpdateView = ({ reference }) => {
   const [loading, setLoading] = useState(false)
@@ -140,10 +141,13 @@ const WorkOrderUpdateView = ({ reference }) => {
         path: '/api/hub-user',
       })
 
-      const workOrder = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${reference}`,
-      })
+      const workOrderResponse = await getWorkOrder(reference)
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       const tasks = await frontEndApiRequest({
         method: 'get',

--- a/src/components/WorkOrder/Update/index.js
+++ b/src/components/WorkOrder/Update/index.js
@@ -17,6 +17,7 @@ import { updateWorkOrderLinks, generalLinks } from '@/utils/successPageLinks'
 import PageAnnouncement from '@/components/Template/PageAnnouncement'
 import AddMultipleSORs from '@/components/Property/RaiseWorkOrder/AddMultipleSORs'
 import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
+import { APIResponseError } from '@/root/src/types/requests/types'
 
 const WorkOrderUpdateView = ({ reference }) => {
   const [loading, setLoading] = useState(false)
@@ -184,11 +185,16 @@ const WorkOrderUpdateView = ({ reference }) => {
       setCurrentUser(null)
       setSorCodeArrays([[]])
       setTasks(null)
-      setError(
-        `Oops an error occurred with error status: ${
-          e.response?.status
-        } with message: ${JSON.stringify(e.response?.data?.message)}`
-      )
+
+      if (e instanceof APIResponseError) {
+        setError(e.message)
+      } else {
+        setError(
+          `Oops an error occurred with error status: ${
+            e.response?.status
+          } with message: ${JSON.stringify(e.response?.data?.message)}`
+        )
+      }
     }
 
     setLoading(false)

--- a/src/components/WorkOrder/WorkOrderView.tsx
+++ b/src/components/WorkOrder/WorkOrderView.tsx
@@ -10,6 +10,7 @@ import PrintJobTicketDetails from './PrintJobTicketDetails'
 import WorkOrderViewTabs from '../Tabs/Views/WorkOrderViewTabs'
 import { CautionaryAlert } from '../../models/cautionaryAlerts'
 import { Tenure } from '../../models/tenure'
+import { getWorkOrder } from '../../utils/requests/workOrders'
 
 const { NEXT_PUBLIC_STATIC_IMAGES_BUCKET_URL } = process.env
 
@@ -43,17 +44,20 @@ const WorkOrderView = ({ workOrderReference }) => {
     setError(null)
 
     try {
-      const workOrderPromise = frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${workOrderReference}`,
-      })
+      const workOrderPromise = getWorkOrder(workOrderReference)
 
       const tasksAndSorsPromise = frontEndApiRequest({
         method: 'get',
         path: `/api/workOrders/${workOrderReference}/tasks`,
       })
 
-      const workOrder = await workOrderPromise
+      const workOrderResponse = await workOrderPromise
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       const propertyPromise = frontEndApiRequest({
         method: 'get',

--- a/src/components/WorkOrder/WorkOrderView.tsx
+++ b/src/components/WorkOrder/WorkOrderView.tsx
@@ -11,6 +11,8 @@ import WorkOrderViewTabs from '../Tabs/Views/WorkOrderViewTabs'
 import { CautionaryAlert } from '../../models/cautionaryAlerts'
 import { Tenure } from '../../models/tenure'
 import { getWorkOrder } from '../../utils/requests/workOrders'
+import { ApiError } from 'next/dist/server/api-utils'
+import { APIResponseError } from '../../types/requests/types'
 
 const { NEXT_PUBLIC_STATIC_IMAGES_BUCKET_URL } = process.env
 
@@ -81,16 +83,20 @@ const WorkOrderView = ({ workOrderReference }) => {
       setProperty(null)
       console.error('An error has occured:', e.response)
 
-      if (e.response?.status === 404) {
-        setError(
-          `Could not find a work order with reference ${workOrderReference}`
-        )
+      if (e instanceof APIResponseError) {
+        setError(e.message)
       } else {
-        setError(
-          `Oops an error occurred with error status: ${
-            e.response?.status
-          } with message: ${JSON.stringify(e.response?.data?.message)}`
-        )
+        if (e.response?.status === 404) {
+          setError(
+            `Could not find a work order with reference ${workOrderReference}`
+          )
+        } else {
+          setError(
+            `Oops an error occurred with error status: ${
+              e.response?.status
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+          )
+        }
       }
     }
 

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -3,7 +3,6 @@ import CloseWorkOrderForm from './CloseWorkOrderForm'
 import { useState, useEffect } from 'react'
 import { convertToDateFormat } from '@/utils/date'
 import SummaryCloseWorkOrder from './SummaryCloseWorkOrder'
-import Spinner from '../Spinner'
 import ErrorMessage from '../Errors/ErrorMessage'
 import {
   buildCloseWorkOrderData,
@@ -23,6 +22,7 @@ import uploadFiles from '../WorkOrder/Photos/hooks/uploadFiles'
 import { buildWorkOrderCompleteNotes } from '../../utils/hact/workOrderComplete/closeWorkOrder'
 import SpinnerWithLabel from '../SpinnerWithLabel'
 import fileUploadStatusLogger from '../WorkOrder/Photos/hooks/uploadFiles/fileUploadStatusLogger'
+import { getWorkOrder } from '../../utils/requests/workOrders'
 
 // Named this way because this component exists to allow supervisors
 // to close work orders on behalf of (i.e. a proxy for) an operative.
@@ -137,14 +137,16 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     setError(null)
 
     try {
-      const workOrder = await frontEndApiRequest({
-        method: 'get',
-        path: `/api/workOrders/${reference}`,
-      })
-
       const featureToggleData = await fetchSimpleFeatureToggles()
-
       setFeatureToggles(featureToggleData)
+
+      const workOrderResponse = await getWorkOrder(reference)
+
+      if (!workOrderResponse.success) {
+        throw workOrderResponse.error
+      }
+
+      const workOrder = workOrderResponse.response
 
       setWorkOrder(new WorkOrder(workOrder))
 

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -23,6 +23,7 @@ import { buildWorkOrderCompleteNotes } from '../../utils/hact/workOrderComplete/
 import SpinnerWithLabel from '../SpinnerWithLabel'
 import fileUploadStatusLogger from '../WorkOrder/Photos/hooks/uploadFiles/fileUploadStatusLogger'
 import { getWorkOrder } from '../../utils/requests/workOrders'
+import { APIResponseError } from '../../types/requests/types'
 
 // Named this way because this component exists to allow supervisors
 // to close work orders on behalf of (i.e. a proxy for) an operative.
@@ -167,11 +168,15 @@ const CloseWorkOrderByProxy = ({ reference }) => {
 
       console.error('An error has occured:', e.response)
 
-      setError(
-        `Oops an error occurred with error status: ${
-          e.response?.status
-        } with message: ${JSON.stringify(e.response?.data?.message)}`
-      )
+      if (e instanceof APIResponseError) {
+        setError(e.message)
+      } else {
+        setError(
+          `Oops an error occurred with error status: ${
+            e.response?.status
+          } with message: ${JSON.stringify(e.response?.data?.message)}`
+        )
+      }
     }
     setLoadingStatus(null)
   }

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestDifferentTradesForm.js
@@ -46,7 +46,7 @@ const FollowOnRequestDifferentTradesForm = (props) => {
   const fetchTrades = async () => {
     const tradesResponse = await getTrades()
     if (!tradesResponse.success) {
-      setError(tradesResponse.error)
+      setError(tradesResponse.error.message)
       return
     }
     setTrades(tradesResponse.response)

--- a/src/components/WorkOrders/ConfirmCloseWorkOrderView/index.tsx
+++ b/src/components/WorkOrders/ConfirmCloseWorkOrderView/index.tsx
@@ -5,6 +5,7 @@ import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
 import { useRouter } from 'next/router'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import SpinnerWithLabel from '../../SpinnerWithLabel'
+import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
 
 interface Props {
   workOrderId: string
@@ -26,22 +27,18 @@ const ConfirmCloseWorkOrderView = (props: Props) => {
     loadWorkOrder()
   }, [])
 
-  const loadWorkOrder = () => {
+  const loadWorkOrder = async () => {
     setLoadingStatus('Fetching work order data')
 
-    frontEndApiRequest({
-      method: 'get',
-      path: `/api/workOrders/${workOrderId}`,
-    })
-      .then((res) => {
-        setWorkOrder(res)
-      })
-      .catch((err) => {
-        setRequestError(err.message)
-      })
-      .finally(() => {
-        setLoadingStatus(null)
-      })
+    const workOrderResponse = await getWorkOrder(workOrderId)
+
+    if (workOrderResponse.success) {
+      setWorkOrder(workOrderResponse.response)
+    } else {
+      setRequestError(workOrderResponse.error)
+    }
+
+    setLoadingStatus(null)
   }
 
   const handleSkip = () => {

--- a/src/components/WorkOrders/ConfirmCloseWorkOrderView/index.tsx
+++ b/src/components/WorkOrders/ConfirmCloseWorkOrderView/index.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/router'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import SpinnerWithLabel from '../../SpinnerWithLabel'
 import { getWorkOrder } from '@/root/src/utils/requests/workOrders'
+import { ApiResponseType } from '@/root/src/types/requests/types'
+import { WorkOrder } from '@/root/src/models/workOrder'
 
 interface Props {
   workOrderId: string
@@ -30,12 +32,14 @@ const ConfirmCloseWorkOrderView = (props: Props) => {
   const loadWorkOrder = async () => {
     setLoadingStatus('Fetching work order data')
 
-    const workOrderResponse = await getWorkOrder(workOrderId)
+    const workOrderResponse: ApiResponseType<WorkOrder> = await getWorkOrder(
+      workOrderId
+    )
 
     if (workOrderResponse.success) {
-      setWorkOrder(workOrderResponse.response)
+      setWorkOrder(workOrderResponse?.response)
     } else {
-      setRequestError(workOrderResponse.error)
+      setRequestError(workOrderResponse.error.message)
     }
 
     setLoadingStatus(null)

--- a/src/models/workOrder.ts
+++ b/src/models/workOrder.ts
@@ -34,6 +34,8 @@ export class WorkOrder {
   callerName: string
   callerNumber: string
   plannerComments: string
+  propertyReference: string
+  property: string
 
   constructor(workOrderData) {
     Object.assign(this, workOrderData)

--- a/src/types/requests/types.ts
+++ b/src/types/requests/types.ts
@@ -1,7 +1,16 @@
+export class APIResponseError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'APIResponseError'
+
+    Object.setPrototypeOf(this, APIResponseError.prototype)
+  }
+}
+
 export type ApiResponseType<T> = {
   success: boolean
   response: T | null
-  error: string | null
+  error: APIResponseError | null
 }
 
 export type NoteDataType = {

--- a/src/utils/requests/trades.ts
+++ b/src/utils/requests/trades.ts
@@ -1,4 +1,4 @@
-import { ApiResponseType } from '../../types/requests/types'
+import { APIResponseError, ApiResponseType } from '../../types/requests/types'
 import { frontEndApiRequest } from '../frontEndApiClient/requests'
 
 export type Trades = {
@@ -23,12 +23,13 @@ export const getTrades = async (): Promise<ApiResponseType<Trades[]>> => {
     return {
       success: false,
       response: null,
-      error:
+      error: new APIResponseError(
         e.response?.status === 400
           ? `Invalid request data`
           : `Oops, an error occurred: ${
               e.response?.status
-            } with message: ${JSON.stringify(e.response?.data?.message)}`,
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+      ),
     }
   }
 }

--- a/src/utils/requests/workOrders.ts
+++ b/src/utils/requests/workOrders.ts
@@ -1,6 +1,6 @@
 import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
 import { WorkOrder } from '@/models/workOrder'
-import { ApiResponseType } from '../../types/requests/types'
+import { APIResponseError, ApiResponseType } from '../../types/requests/types'
 import { NoteDataType } from '../../types/requests/types'
 
 export const getWorkOrder = async (
@@ -23,12 +23,13 @@ export const getWorkOrder = async (
     return {
       success: false,
       response: null,
-      error:
+      error: new APIResponseError(
         e.response?.status === 404
           ? `Could not find a work order with reference ${workOrderReference}`
           : `Oops, an error occurred: ${
               e.response?.status
-            } with message: ${JSON.stringify(e.response?.data?.message)}`,
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+      ),
     }
   }
 }
@@ -58,12 +59,13 @@ export const editWorkOrder = async (
     return {
       success: false,
       response: null,
-      error:
+      error: new APIResponseError(
         e.response?.status === 400
           ? 'Invalid request data'
           : `Oops, an error occurred: ${
               e.response?.status
-            } with message: ${JSON.stringify(e.response?.data?.message)}`,
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+      ),
     }
   }
 }
@@ -89,12 +91,13 @@ export const postNote = async (
     return {
       success: false,
       response: null,
-      error:
+      error: new APIResponseError(
         e.response?.status === 400
           ? `Invalid request data`
           : `Oops, an error occurred: ${
               e.response?.status
-            } with message: ${JSON.stringify(e.response?.data?.message)}`,
+            } with message: ${JSON.stringify(e.response?.data?.message)}`
+      ),
     }
   }
 }

--- a/src/utils/successPageLinks.js
+++ b/src/utils/successPageLinks.js
@@ -5,20 +5,11 @@ import { getWorkOrder } from './requests/workOrders'
 const onWindowFocusCallback = async (workOrderReference) => {
   // fetch workOrder page to trigger manual sync
   // (calling this endpoint will fetch latest appointment from DRS)
-  try {
-    const getWorkOrderResponse = await getWorkOrder(workOrderReference)
 
-    if (!getWorkOrderResponse.success) {
-      console.error(getWorkOrderResponse.error.message)
-      return
-    }
+  const getWorkOrderResponse = await getWorkOrder(workOrderReference)
 
-    await frontEndApiRequest({
-      method: 'get',
-      path: `/api/workOrders/${workOrderReference}`,
-    })
-  } catch (e) {
-    console.error(e)
+  if (!getWorkOrderResponse.success) {
+    console.error(getWorkOrderResponse.error.message)
   }
 }
 

--- a/src/utils/successPageLinks.js
+++ b/src/utils/successPageLinks.js
@@ -1,9 +1,18 @@
 import { buildDataFromScheduleAppointment } from '@/utils/hact/jobStatusUpdate/notesForm'
 import { frontEndApiRequest } from '@/utils/frontEndApiClient/requests'
+import { getWorkOrder } from './requests/workOrders'
 
 const onWindowFocusCallback = async (workOrderReference) => {
   // fetch workOrder page to trigger manual sync
+  // (calling this endpoint will fetch latest appointment from DRS)
   try {
+    const getWorkOrderResponse = await getWorkOrder(workOrderReference)
+
+    if (!getWorkOrderResponse.success) {
+      console.error(getWorkOrderResponse.error)
+      return
+    }
+
     await frontEndApiRequest({
       method: 'get',
       path: `/api/workOrders/${workOrderReference}`,

--- a/src/utils/successPageLinks.js
+++ b/src/utils/successPageLinks.js
@@ -9,7 +9,7 @@ const onWindowFocusCallback = async (workOrderReference) => {
     const getWorkOrderResponse = await getWorkOrder(workOrderReference)
 
     if (!getWorkOrderResponse.success) {
-      console.error(getWorkOrderResponse.error)
+      console.error(getWorkOrderResponse.error.message)
       return
     }
 


### PR DESCRIPTION
I'm currently trying to separate fetching appointment details from fetching work order details. This will enable more resilience when DRS goes down.

However, the PR became very large. The risk of it breaking something became too high.

This PR extracts all the getWorkOrder logic into a single method. In future iterations, it will allow more control and easier feature toggling when updating this feature.

## Key changes

The GetWorkOrder method returns a response object, rather than throwing errors directly. 

![image](https://github.com/user-attachments/assets/94fb05e0-ec92-4838-8c32-b8025de8b88d)

To integrate well with preexisting error handling, I've introduced the error class `APIResponseError`. This custom error behaves identically to the base Error class and allows checking for that type of error.

![image](https://github.com/user-attachments/assets/99414fd3-c0b9-4260-b60a-96f61042b73f)

As more requests are refactored with this approach, this type check could be removed.
