### PR TITLE
Disable search button with single character

### DIFF
--- a/src/components/Search/Search.test.tsx
+++ b/src/components/Search/Search.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import UserContext from '../UserContext'
 import Search from './Search'
 import { agent } from 'factories/agent'
@@ -34,5 +34,28 @@ describe('Search component', () => {
     )
 
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('disables search button when input is empty or one character', async () => {
+    render(
+      <UserContext.Provider value={{ user: agent }}>
+        <Search />
+      </UserContext.Provider>
+    )
+
+    const searchButton = screen.getByRole('button', { name: 'Search' })
+    const searchInput = screen.getByTestId('input-search') as HTMLInputElement
+
+    // Enabled with two characters
+    fireEvent.change(searchInput, { target: { value: 'ab' } })
+    await waitFor(() => expect(searchButton).not.toBeDisabled())
+
+    // Disabled with one character
+    fireEvent.change(searchInput, { target: { value: 'a' } })
+    await waitFor(() => expect(searchButton).toBeDisabled())
+
+    // Disabled when empty
+    fireEvent.change(searchInput, { target: { value: '' } })
+    await waitFor(() => expect(searchButton).toBeDisabled())
   })
 })

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -72,7 +72,7 @@ const Search: React.FC<SearchProps> = ({ query }) => {
   }, [pageNumber])
 
   const searchForProperties = async (searchQuery, pageNumber) => {
-    if (!searchQuery || searchQuery.length <= 1) return
+    if (!searchQuery.trim() || searchQuery.trim().length <= 1) return
     setLoading(true)
     setError(null)
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -156,7 +156,7 @@ const Search: React.FC<SearchProps> = ({ query }) => {
               <PrimarySubmitButton
                 id="submit-search"
                 label="Search"
-                disabled={searchTextInput?.length <= 1}
+                disabled={!searchTextInput || searchTextInput.length <= 1}
                 onClick={handleSubmit}
               />
             </form>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -148,6 +148,7 @@ const Search: React.FC<SearchProps> = ({ query }) => {
               <input
                 className="govuk-input lbh-input govuk-input--width-10"
                 id="input-search"
+                data-testid="input-search"
                 name="search-name"
                 type="text"
                 value={searchTextInput}
@@ -156,7 +157,7 @@ const Search: React.FC<SearchProps> = ({ query }) => {
               <PrimarySubmitButton
                 id="submit-search"
                 label="Search"
-                disabled={!searchTextInput || searchTextInput.length <= 1}
+                disabled={!searchTextInput.trim() || searchTextInput.trim().length <= 1}
                 onClick={handleSubmit}
               />
             </form>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -72,6 +72,7 @@ const Search: React.FC<SearchProps> = ({ query }) => {
   }, [pageNumber])
 
   const searchForProperties = async (searchQuery, pageNumber) => {
+    if (!searchQuery || searchQuery.length <= 1) return
     setLoading(true)
     setError(null)
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -157,7 +157,9 @@ const Search: React.FC<SearchProps> = ({ query }) => {
               <PrimarySubmitButton
                 id="submit-search"
                 label="Search"
-                disabled={!searchTextInput.trim() || searchTextInput.trim().length <= 1}
+                disabled={
+                  !searchTextInput.trim() || searchTextInput.trim().length <= 1
+                }
                 onClick={handleSubmit}
               />
             </form>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -156,6 +156,7 @@ const Search: React.FC<SearchProps> = ({ query }) => {
               <PrimarySubmitButton
                 id="submit-search"
                 label="Search"
+                disabled={searchTextInput?.length <= 1}
                 onClick={handleSubmit}
               />
             </form>

--- a/src/components/Search/__snapshots__/Search.test.tsx.snap
+++ b/src/components/Search/__snapshots__/Search.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`Search component renders a search form 1`] = `
             <button
               class="govuk-button lbh-button"
               data-module="govuk-button"
+              disabled=""
               id="submit-search"
               type="submit"
             >

--- a/src/components/Search/__snapshots__/Search.test.tsx.snap
+++ b/src/components/Search/__snapshots__/Search.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Search component renders a search form 1`] = `
           </label>
           <input
             class="govuk-input lbh-input govuk-input--width-10"
+            data-testid="input-search"
             id="input-search"
             name="search-name"
             type="text"


### PR DESCRIPTION
Resolve [sentry issue 6072543441](https://london-borough-of-hackney.sentry.io/issues/6072543441) - the search endpoint returns 502 when searching for a single character

To prevent this issue, this disables the search button until more than one character is entered in search

Issue in prod: https://repairs-hub.hackney.gov.uk/search?searchText=a

![image](https://github.com/user-attachments/assets/2fe7dd02-cf1d-4fbb-8c9e-b64c5ffef41a)

