### PR TITLE
Fix permissions for viewing related work orders tab

### DIFF
--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -130,6 +130,15 @@ export const buildUser = (
 
   const hasRole = (r: string) => roles.includes(r)
 
+  const hasExternalContractorPermissions = () => {
+    if (hasRole(DLO_CONTRACTOR_ROLE)) {
+      // internal contractor
+      return false
+    }
+
+    return hasRole(CONTRACTOR_ROLE)
+  }
+
   return {
     name: name,
     email: email,
@@ -138,6 +147,7 @@ export const buildUser = (
     hasAgentPermissions: hasRole(AGENT_ROLE),
     hasContractorPermissions: hasRole(CONTRACTOR_ROLE),
     hasDLOContractorPermissions: hasRole(DLO_CONTRACTOR_ROLE),
+    hasExternalContractorPermissions: hasExternalContractorPermissions(),
     hasContractManagerPermissions: hasRole(CONTRACT_MANAGER_ROLE),
     hasAuthorisationManagerPermissions: hasRole(AUTHORISATION_MANAGER_ROLE),
     hasOperativePermissions: hasRole(OPERATIVE_ROLE),

--- a/src/utils/userPermissions.test.js
+++ b/src/utils/userPermissions.test.js
@@ -71,24 +71,20 @@ describe('canSeeAppointmentDetailsInfo', () => {
 })
 
 describe('canRaiseAFollowOn', () => {
-  it('returns true when user is not a contractor', () => {
+  it('returns true when user is not an external contractor', () => {
     const user = {
       name: 'Test Testerston',
       email: 'test@test.com',
-      hasAgentPermissions: true,
-      hasContractorPermissions: false,
-      hasContractManagerPermissions: true,
+      hasExternalContractorPermissions: false,
     }
     expect(canRaiseAFollowOn(user)).toBe(true)
   })
 
-  it('returns false when user is a contractor', () => {
+  it('returns false when user is an external contractor', () => {
     const user = {
       name: 'Test Testerston',
       email: 'test@test.com',
-      hasAgentPermissions: false,
-      hasContractorPermissions: true,
-      hasContractManagerPermissions: false,
+      hasExternalContractorPermissions: true,
     }
     expect(canRaiseAFollowOn(user)).toBe(false)
   })

--- a/src/utils/userPermissions.ts
+++ b/src/utils/userPermissions.ts
@@ -44,19 +44,7 @@ export const canAccessWorkOrder = (user) => {
 }
 
 export const canRaiseAFollowOn = (user) => {
-  // contractors cannot raise a follow on
-  // but the contractor permission includes the DLO contractor group
-  // so if they are a dlo contractor, they can raise a follow on
-
-  if (user.hasDLOContractorPermissions) {
-    return true
-  }
-
-  if (user.hasContractorPermissions) {
-    return false
-  }
-
-  return true
+  return !user.hasExternalContractorPermissions
 }
 
 export const canSeeWorkOrders = (user) => {
@@ -68,7 +56,7 @@ export const canSeeWorkOrders = (user) => {
 }
 
 export const canSeeRelatedWorkOrdersTab = (user) => {
-  return !user.hasContractorPermissions
+  return !user.hasExternalContractorPermissions
 }
 
 export const canSeeOperativeWorkOrders = (user) => {

--- a/src/utils/userPermissions.ts
+++ b/src/utils/userPermissions.ts
@@ -44,6 +44,7 @@ export const canAccessWorkOrder = (user) => {
 }
 
 export const canRaiseAFollowOn = (user) => {
+  // everyone except external contractors
   return !user.hasExternalContractorPermissions
 }
 
@@ -56,6 +57,7 @@ export const canSeeWorkOrders = (user) => {
 }
 
 export const canSeeRelatedWorkOrdersTab = (user) => {
+  // everyone except external contractors
   return !user.hasExternalContractorPermissions
 }
 


### PR DESCRIPTION
After enabling DLO contractors to raise follow ons, I noticed that they still cant see the releated work orders tab. 

Its the same permission, so I have now moved the logic into `user.ts`.