### PR TITLE
Add option for isEmergency to follow on request form

### DIFF
--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -2916,7 +2916,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // populate follow-on fields
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
-        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('false')
         cy.get('input[data-testid="followon-trades-plumbing"]').check()
         cy.get('textarea[data-testid="followOnTypeDescription"]').type(
           'follow on description'
@@ -2984,6 +2984,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
             },
           ],
           followOnRequest: {
+            isEmergency: false,
             isMultipleOperatives: true,
             requiredFollowOnTrades: ['Plumbing'],
             followOnTypeDescription: 'follow on description',
@@ -3089,6 +3090,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
             },
           ],
           followOnRequest: {
+            isEmergency: true,
             isMultipleOperatives: false,
             requiredFollowOnTrades: ['Plumbing'],
             followOnTypeDescription: 'follow on description',

--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -2814,6 +2814,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
             cy.contains('label', 'Further work required').click()
           })
 
+        cy.wait('@feature-toggle')
         // assert error messages arent visible yet
         cy.contains(
           'Please confirm whether you have contacted your supervisor'

--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -10,6 +10,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
       },
       {
         body: {
+          enableFollowOnIsEmergencyField: true,
           followOnFunctionalityEnabled: true,
           fetchAppointmentsFromDrs: false,
         },

--- a/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy-with-followons-enabled.cy.js
@@ -2833,6 +2833,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // select an option - error should disappear
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
         cy.contains(
           'Please confirm whether you have contacted your supervisor'
         ).should('not.exist')
@@ -2915,6 +2916,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // populate follow-on fields
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
         cy.get('input[data-testid="followon-trades-plumbing"]').check()
         cy.get('textarea[data-testid="followOnTypeDescription"]').type(
           'follow on description'
@@ -3019,6 +3021,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // populate follow-on fields
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
         cy.get('input[data-testid="followon-trades-plumbing"]').check()
         cy.get('textarea[data-testid="followOnTypeDescription"]').type(
           'follow on description'

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -54,6 +54,18 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
       { method: 'POST', path: '/api/jobStatusUpdate' },
       { body: '' }
     ).as('jobStatusUpdateRequest')
+
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/simple-feature-toggle',
+      },
+      {
+        body: {
+          enableFollowOnIsEmergencyField: true,
+        },
+      }
+    ).as('feature-toggle')
   })
 
   describe('When logged in as a contractor', () => {

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -2903,7 +2903,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // populate follow-on fields
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
-        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('false')
         cy.get('input[data-testid="followon-trades-plumbing"]').check()
         cy.get('[data-testid="isMultipleOperatives"]').check('true')
         cy.get('textarea[data-testid="followOnTypeDescription"]').type(
@@ -2972,6 +2972,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
             },
           ],
           followOnRequest: {
+            isEmergency: false,
             isMultipleOperatives: true,
             requiredFollowOnTrades: ['Plumbing'],
             followOnTypeDescription: 'follow on description',
@@ -3078,6 +3079,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
             },
           ],
           followOnRequest: {
+            isEmergency: true,
             isMultipleOperatives: false,
             requiredFollowOnTrades: ['Plumbing'],
             followOnTypeDescription: 'follow on description',

--- a/cypress/e2e/work-order/attend/close-by-proxy.cy.js
+++ b/cypress/e2e/work-order/attend/close-by-proxy.cy.js
@@ -2820,6 +2820,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // select an option - error should disappear
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
         cy.contains(
           'Please confirm whether you have contacted your supervisor'
         ).should('not.exist')
@@ -2902,6 +2903,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // populate follow-on fields
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
         cy.get('input[data-testid="followon-trades-plumbing"]').check()
         cy.get('[data-testid="isMultipleOperatives"]').check('true')
         cy.get('textarea[data-testid="followOnTypeDescription"]').type(
@@ -3007,6 +3009,7 @@ describe('Closing a work order on behalf of an operative - When follow-ons are e
 
         // populate follow-on fields
         cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+        cy.get('input[data-testid="followonRequestUrgency"]').check('true')
         cy.get('input[data-testid="followon-trades-plumbing"]').check()
         cy.get('[data-testid="isMultipleOperatives"]').check('false')
         cy.get('textarea[data-testid="followOnTypeDescription"]').type(

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -422,6 +422,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
 
       // populate follow-on fields
       cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+      cy.get('input[data-testid="followonRequestUrgency"]').check('true')
       cy.get('input[data-testid="followon-trades-plumbing"]').check()
       cy.get('[data-testid="isMultipleOperatives"]').check('true')
       cy.get('textarea[data-testid="followOnTypeDescription"]').type(
@@ -627,7 +628,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
       cy.contains('Please confirm if further work is required')
     })
 
-    it('shows validation when user enters follow-on details', () => {
+    it.only('shows validation when user enters follow-on details', () => {
       cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
 
       cy.wait([
@@ -671,6 +672,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
 
       // select option
       cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+      cy.get('input[data-testid="followonRequestUrgency"]').check('true')
       cy.contains(
         'Please confirm whether you have contacted your supervisor'
       ).should('not.exist')
@@ -751,6 +753,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
 
       // populate follow-on fields
       cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+      cy.get('input[data-testid="followonRequestUrgency"]').check('true')
       cy.intercept(
         { method: 'GET', path: '/api/filter/WorkOrder' },
         { fixture: 'filter/trades.json' }
@@ -856,6 +859,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
 
     // populate follow-on fields
     cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+    cy.get('input[data-testid="followonRequestUrgency"]').check('true')
     cy.intercept(
       { method: 'GET', path: '/api/filter/WorkOrder' },
       { fixture: 'filter/trades.json' }
@@ -960,6 +964,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
 
     // populate follow-on fields
     cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+    cy.get('input[data-testid="followonRequestUrgency"]').check('true')
     cy.intercept(
       { method: 'GET', path: '/api/filter/WorkOrder' },
       { fixture: 'filter/trades.json' }
@@ -1064,6 +1069,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
 
     // populate follow-on fields
     cy.get('input[data-testid="supervisorCalled"]').check('Yes')
+    cy.get('input[data-testid="followonRequestUrgency"]').check('true')
     cy.intercept(
       { method: 'GET', path: '/api/filter/WorkOrder' },
       { fixture: 'filter/trades.json' }

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -628,7 +628,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
       cy.contains('Please confirm if further work is required')
     })
 
-    it.only('shows validation when user enters follow-on details', () => {
+    it('shows validation when user enters follow-on details', () => {
       cy.visit(`/operatives/1/work-orders/${workOrderReference}`)
 
       cy.wait([

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -803,6 +803,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
               },
             ],
             followOnRequest: {
+              isEmergency: true,
               isMultipleOperatives: true,
               requiredFollowOnTrades: ['Plumbing', 'Other'],
               followOnTypeDescription: 'follow on description',
@@ -909,6 +910,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
             },
           ],
           followOnRequest: {
+            isEmergency: true,
             isMultipleOperatives: false,
             requiredFollowOnTrades: ['Plumbing', 'Other'],
             followOnTypeDescription: 'follow on description',
@@ -964,7 +966,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
 
     // populate follow-on fields
     cy.get('input[data-testid="supervisorCalled"]').check('Yes')
-    cy.get('input[data-testid="followonRequestUrgency"]').check('true')
+    cy.get('input[data-testid="followonRequestUrgency"]').check('false')
     cy.intercept(
       { method: 'GET', path: '/api/filter/WorkOrder' },
       { fixture: 'filter/trades.json' }
@@ -1014,6 +1016,7 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
             },
           ],
           followOnRequest: {
+            isEmergency: false,
             isMultipleOperatives: true,
             requiredFollowOnTrades: ['Plumbing', 'Other'],
             followOnTypeDescription: 'follow on description',

--- a/cypress/e2e/work-order/attend/close.cy.js
+++ b/cypress/e2e/work-order/attend/close.cy.js
@@ -84,6 +84,18 @@ describe('Closing my own work order - When follow-ons are enabled', () => {
       { body: [] }
     )
 
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/simple-feature-toggle',
+      },
+      {
+        body: {
+          enableFollowOnIsEmergencyField: true,
+        },
+      }
+    ).as('feature-toggle')
+
     cy.loginWithOperativeRole()
   })
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -76,6 +76,7 @@ functions:
       SENTRY_ENVIRONMENT: ${self:provider.stage}
       SENTRY_RELEASE: ${env:CIRCLE_SHA1}
       NEW_APPOINTMENT_ENDPOINT_ENABLED: ${ssm:/repairs-hub/${self:provider.stage}/enable-new-appointments-endpoint}
+      FOLLOW_ON_IS_EMERGENCY_FIELD_ENABLED: ${self:custom.follow-on-is-emergency-field-enabled.${self:provider.stage}}
       TAG_MANAGER_ID: ${self:custom.tag-manager-id.${self:provider.stage}}
 
 resources:
@@ -160,3 +161,7 @@ custom:
     development: ""
     staging: ""
     production: GTM-MLCLBXH2
+  follow-on-is-emergency-field-enabled:
+    development: true
+    staging: false
+    production: false

--- a/src/components/Form/Radios/index.tsx
+++ b/src/components/Form/Radios/index.tsx
@@ -14,7 +14,7 @@ interface Props {
     | string[]
     | {
         text: string
-        value: string
+        value: string | boolean
         defaultChecked?: boolean
         hint?: string
         children?: JSX.Element

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -167,6 +167,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
       })
 
       followOnRequest = buildFollowOnRequestData(
+        data.isEmergency === 'true',
         data.isMultipleOperatives === 'true',
         requiredFollowOnTrades,
         data.followOnTypeDescription,
@@ -267,7 +268,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
           isNoAccess ? 'closed with no access' : 'closed'
         }`
       )
-      router.push('/')
+      // router.push('/')
     } catch (e) {
       console.error(e)
       setError(

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -310,6 +310,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
         <MobileWorkingCloseWorkOrderForm
           onSubmit={onWorkOrderCompleteSubmit}
           isLoading={loadingStatus !== null}
+          featureToggles={featureToggles}
         />
       )}
 

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -8,7 +8,6 @@ import {
 import { WorkOrder } from '@/models/workOrder'
 import { sortObjectsByDateKey } from '@/utils/date'
 import MobileWorkingWorkOrder from './MobileWorkingWorkOrder'
-import router from 'next/router'
 import {
   buildCloseWorkOrderData,
   buildFollowOnRequestData,

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -310,7 +310,6 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
         <MobileWorkingCloseWorkOrderForm
           onSubmit={onWorkOrderCompleteSubmit}
           isLoading={loadingStatus !== null}
-          featureToggles={featureToggles}
         />
       )}
 

--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.js
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.js
@@ -8,6 +8,7 @@ import {
 import { WorkOrder } from '@/models/workOrder'
 import { sortObjectsByDateKey } from '@/utils/date'
 import MobileWorkingWorkOrder from './MobileWorkingWorkOrder'
+import router from 'next/router'
 import {
   buildCloseWorkOrderData,
   buildFollowOnRequestData,
@@ -267,7 +268,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }) => {
           isNoAccess ? 'closed with no access' : 'closed'
         }`
       )
-      // router.push('/')
+      router.push('/')
     } catch (e) {
       console.error(e)
       setError(

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -198,6 +198,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
       }
 
       followOnDataRequest = buildFollowOnRequestData(
+        followOnData.isEmergency,
         followOnData.isMultipleOperatives,
         requiredFollowOnTrades,
         followOnData.followOnTypeDescription,
@@ -256,6 +257,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
       })
 
       const followOnData = {
+        isEmergency: formData.isEmergency === 'true',
         isMultipleOperatives: formData.isMultipleOperatives === 'true',
         requiredFollowOnTrades: requiredFollowOnTrades,
         followOnTypeDescription: formData.followOnTypeDescription,

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -73,6 +73,7 @@ const FollowOnRequestTypeOfWorkForm = (
       >
         <div style={{ marginBottom: '3rem' }}>
           <Radio
+            data-testid="followonRequestUrgency"
             labelSize="s"
             label="Is this an emergency?"
             name="isEmergency"

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -39,12 +39,12 @@ const FollowOnRequestTypeOfWorkForm = (
 
   const URGENCY_OPTIONS = [
     {
-      value: 'true',
-      text: 'Yes',
+      value: true,
+      text: 'Yes, this is an emergency',
       defaultChecked: followOnData?.isEmergency === true,
     },
     {
-      value: 'false',
+      value: false,
       text: 'No',
       defaultChecked: followOnData?.isEmergency === false,
     },
@@ -52,13 +52,13 @@ const FollowOnRequestTypeOfWorkForm = (
 
   const MULTIPLE_OPERATIVES_REQUIRED_OPTIONS = [
     {
-      value: 'true',
+      value: true,
       text: 'Yes',
       hint: null,
       defaultChecked: followOnData?.isMultipleOperatives === true,
     },
     {
-      value: 'false',
+      value: false,
       text: 'No',
       hint: null,
       defaultChecked: followOnData?.isMultipleOperatives === false,

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -20,6 +20,7 @@ interface FollowOnRequestTypeOfWorkFormProps {
   followOnData?: Partial<followOnDataRequest>
   hasWhiteBackground?: boolean
   isGrid?: boolean
+  featureToggles?: Record<string, boolean>
 }
 
 const FollowOnRequestTypeOfWorkForm = (
@@ -35,6 +36,7 @@ const FollowOnRequestTypeOfWorkForm = (
     followOnData,
     hasWhiteBackground,
     isGrid,
+    featureToggles,
   } = props
 
   const URGENCY_OPTIONS = [
@@ -71,20 +73,22 @@ const FollowOnRequestTypeOfWorkForm = (
         className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2 lbh-fieldset"
         style={{ marginTop: 0 }}
       >
-        <div style={{ marginBottom: '3rem' }}>
-          <Radio
-            data-testid="followonRequestUrgency"
-            labelSize="s"
-            label="Is this an emergency?"
-            name="isEmergency"
-            options={URGENCY_OPTIONS}
-            register={register({
-              required: 'Please confirm if this is an emergency',
-            })}
-            error={errors && errors.isEmergency}
-            hasWhiteBackground={hasWhiteBackground}
-          />
-        </div>
+        {featureToggles?.enableFollowOnIsEmergencyField && (
+          <div style={{ marginBottom: '3rem' }}>
+            <Radio
+              data-testid="followonRequestUrgency"
+              labelSize="s"
+              label="Is this an emergency?"
+              name="isEmergency"
+              options={URGENCY_OPTIONS}
+              register={register({
+                required: 'Please confirm if this is an emergency',
+              })}
+              error={errors && errors.isEmergency}
+              hasWhiteBackground={hasWhiteBackground}
+            />
+          </div>
+        )}
 
         <div
           className={classNames('lbh-form-group', {

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -54,7 +54,7 @@ const FollowOnRequestTypeOfWorkForm = (
   const URGENCY_OPTIONS = [
     {
       value: true,
-      text: 'Yes, this is an emergency',
+      text: 'Yes',
       defaultChecked: followOnData?.isEmergency === true,
     },
     {

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -23,7 +23,6 @@ interface FollowOnRequestTypeOfWorkFormProps {
   followOnData?: Partial<followOnDataRequest>
   hasWhiteBackground?: boolean
   isGrid?: boolean
-  featureToggles?: SimpleFeatureToggleResponse
 }
 
 const FollowOnRequestTypeOfWorkForm = (
@@ -39,21 +38,17 @@ const FollowOnRequestTypeOfWorkForm = (
     followOnData,
     hasWhiteBackground,
     isGrid,
-    featureToggles,
   } = props
 
   const [
     simpleFeatureToggles,
     setSimpleFeatureToggles,
-  ] = useState<SimpleFeatureToggleResponse>(featureToggles)
+  ] = useState<SimpleFeatureToggleResponse>()
 
   useEffect(() => {
-    // Handle case of user directly navigating to this page
-    if (!featureToggles) {
-      fetchSimpleFeatureToggles().then((fetchedFeatureToggles) => {
-        setSimpleFeatureToggles(fetchedFeatureToggles)
-      })
-    }
+    fetchSimpleFeatureToggles().then((fetchedFeatureToggles) => {
+      setSimpleFeatureToggles(fetchedFeatureToggles)
+    })
   }, [])
 
   const URGENCY_OPTIONS = [

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -9,6 +9,9 @@ import {
   UseFormMethods,
 } from 'react-hook-form'
 import { followOnDataRequest } from '@/root/src/utils/hact/workOrderComplete/closeWorkOrder'
+import { useEffect, useState } from 'react'
+import { fetchSimpleFeatureToggles } from '@/root/src/utils/frontEndApiClient/requests'
+import { SimpleFeatureToggleResponse } from '@/root/src/pages/api/simple-feature-toggle'
 
 interface FollowOnRequestTypeOfWorkFormProps {
   errors: DeepMap<FieldValues, FieldError>
@@ -20,7 +23,7 @@ interface FollowOnRequestTypeOfWorkFormProps {
   followOnData?: Partial<followOnDataRequest>
   hasWhiteBackground?: boolean
   isGrid?: boolean
-  featureToggles?: Record<string, boolean>
+  featureToggles?: SimpleFeatureToggleResponse
 }
 
 const FollowOnRequestTypeOfWorkForm = (
@@ -38,6 +41,20 @@ const FollowOnRequestTypeOfWorkForm = (
     isGrid,
     featureToggles,
   } = props
+
+  const [
+    simpleFeatureToggles,
+    setSimpleFeatureToggles,
+  ] = useState<SimpleFeatureToggleResponse>(featureToggles)
+
+  useEffect(() => {
+    // Handle case of user directly navigating to this page
+    if (!featureToggles) {
+      fetchSimpleFeatureToggles().then((fetchedFeatureToggles) => {
+        setSimpleFeatureToggles(fetchedFeatureToggles)
+      })
+    }
+  }, [])
 
   const URGENCY_OPTIONS = [
     {
@@ -73,7 +90,10 @@ const FollowOnRequestTypeOfWorkForm = (
         className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2 lbh-fieldset"
         style={{ marginTop: 0 }}
       >
-        {featureToggles?.enableFollowOnIsEmergencyField && (
+        {!simpleFeatureToggles?.enableFollowOnIsEmergencyField && (
+          <h1>IsEmergency is off: {JSON.stringify(simpleFeatureToggles)}</h1>
+        )}
+        {simpleFeatureToggles?.enableFollowOnIsEmergencyField && (
           <div style={{ marginBottom: '3rem' }}>
             <Radio
               data-testid="followonRequestUrgency"

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -85,9 +85,6 @@ const FollowOnRequestTypeOfWorkForm = (
         className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2 lbh-fieldset"
         style={{ marginTop: 0 }}
       >
-        {!simpleFeatureToggles?.enableFollowOnIsEmergencyField && (
-          <h1>IsEmergency is off: {JSON.stringify(simpleFeatureToggles)}</h1>
-        )}
         {simpleFeatureToggles?.enableFollowOnIsEmergencyField && (
           <div style={{ marginBottom: '3rem' }}>
             <Radio

--- a/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderFormComponents/FollowOnRequestTypeOfWorkForm.tsx
@@ -2,10 +2,29 @@ import classNames from 'classnames'
 import { Radio, TextArea } from '../../Form'
 import ErrorMessage from '../../Errors/ErrorMessage'
 import FollowOnRequestDifferentTradesForm from './FollowOnRequestDifferentTradesForm'
-import { FOLLOW_ON_REQUEST_AVAILABLE_TRADES } from '@/utils/statusCodes'
-import { useEffect, useState } from 'react'
+import {
+  DeepMap,
+  FieldError,
+  FieldValues,
+  UseFormMethods,
+} from 'react-hook-form'
+import { followOnDataRequest } from '@/root/src/utils/hact/workOrderComplete/closeWorkOrder'
 
-const FollowOnRequestTypeOfWorkForm = (props) => {
+interface FollowOnRequestTypeOfWorkFormProps {
+  errors: DeepMap<FieldValues, FieldError>
+  register: UseFormMethods['register']
+  getValues: (payload?: string | string[]) => unknown
+  setError: (name: string, error: FieldError) => void
+  clearErrors: (name?: string | string[]) => void
+  watch: CallableFunction
+  followOnData?: Partial<followOnDataRequest>
+  hasWhiteBackground?: boolean
+  isGrid?: boolean
+}
+
+const FollowOnRequestTypeOfWorkForm = (
+  props: FollowOnRequestTypeOfWorkFormProps
+): JSX.Element => {
   const {
     errors,
     register,
@@ -18,15 +37,28 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
     isGrid,
   } = props
 
+  const URGENCY_OPTIONS = [
+    {
+      value: 'true',
+      text: 'Yes',
+      defaultChecked: followOnData?.isEmergency === true,
+    },
+    {
+      value: 'false',
+      text: 'No',
+      defaultChecked: followOnData?.isEmergency === false,
+    },
+  ]
+
   const MULTIPLE_OPERATIVES_REQUIRED_OPTIONS = [
     {
-      value: true,
+      value: 'true',
       text: 'Yes',
       hint: null,
       defaultChecked: followOnData?.isMultipleOperatives === true,
     },
     {
-      value: false,
+      value: 'false',
       text: 'No',
       hint: null,
       defaultChecked: followOnData?.isMultipleOperatives === false,
@@ -39,6 +71,20 @@ const FollowOnRequestTypeOfWorkForm = (props) => {
         className="govuk-fieldset govuk-!-margin-bottom-2 govuk-!-padding-2 lbh-fieldset"
         style={{ marginTop: 0 }}
       >
+        <div style={{ marginBottom: '3rem' }}>
+          <Radio
+            labelSize="s"
+            label="Is this an emergency?"
+            name="isEmergency"
+            options={URGENCY_OPTIONS}
+            register={register({
+              required: 'Please confirm if this is an emergency',
+            })}
+            error={errors && errors.isEmergency}
+            hasWhiteBackground={hasWhiteBackground}
+          />
+        </div>
+
         <div
           className={classNames('lbh-form-group', {
             'govuk-form-group--error': errors.typeOfWork,

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
@@ -30,13 +30,11 @@ interface MobileWorkingCloseWorkOrderFormProps {
     followOnFiles: File[]
   ) => void
   isLoading: boolean
-  featureToggles?: SimpleFeatureToggleResponse
 }
 
 const MobileWorkingCloseWorkOrderForm = ({
   onSubmit,
   isLoading,
-  featureToggles,
 }: MobileWorkingCloseWorkOrderFormProps) => {
   const {
     handleSubmit,
@@ -172,9 +170,7 @@ const MobileWorkingCloseWorkOrderForm = ({
               setError={setError}
               clearErrors={clearErrors}
               watch={watch}
-              featureToggles={featureToggles}
             />
-
             <FollowOnRequestMaterialsForm
               register={register}
               getValues={getValues}

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
@@ -22,7 +22,21 @@ const FIELD_NAMES_ON_FIRST_PAGE = new Set<string>([
   'workOrderFileUpload',
 ])
 
-const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
+interface MobileWorkingCloseWorkOrderFormProps {
+  onSubmit: (
+    data: Record<string, any>,
+    workOrderFiles: File[],
+    followOnFiles: File[]
+  ) => void
+  isLoading: boolean
+  featureToggles?: Record<string, boolean>
+}
+
+const MobileWorkingCloseWorkOrderForm = ({
+  onSubmit,
+  isLoading,
+  featureToggles,
+}: MobileWorkingCloseWorkOrderFormProps) => {
   const {
     handleSubmit,
     register,
@@ -60,8 +74,6 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
 
   const [workOrderFiles, setWorkOrderFiles] = useState([])
   const [followOnFiles, setFollowOnFiles] = useState([])
-
-  // const [workOrderFiles, setFiles] = useState([])
 
   return (
     <div className="mobile-working-close-work-order-form">
@@ -159,6 +171,7 @@ const MobileWorkingCloseWorkOrderForm = ({ onSubmit, isLoading }) => {
               setError={setError}
               clearErrors={clearErrors}
               watch={watch}
+              featureToggles={featureToggles}
             />
 
             <FollowOnRequestMaterialsForm

--- a/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
+++ b/src/components/WorkOrders/MobileWorkingCloseWorkOrderForm.tsx
@@ -10,6 +10,7 @@ import validateFileUpload from '../WorkOrder/Photos/hooks/validateFileUpload'
 import ControlledFileInput from '../WorkOrder/Photos/ControlledFileInput'
 import FollowOnRequestMaterialsSupervisorCalledForm from './CloseWorkOrderFormComponents/FollowOnRequestMaterialsSupervisorCalledForm'
 import FollowOnRequestMaterialsForm from './CloseWorkOrderFormComponents/FollowOnRequestMaterialsForm'
+import { SimpleFeatureToggleResponse } from '../../pages/api/simple-feature-toggle'
 
 const PAGES = {
   WORK_ORDER_STATUS: '1',
@@ -29,7 +30,7 @@ interface MobileWorkingCloseWorkOrderFormProps {
     followOnFiles: File[]
   ) => void
   isLoading: boolean
-  featureToggles?: Record<string, boolean>
+  featureToggles?: SimpleFeatureToggleResponse
 }
 
 const MobileWorkingCloseWorkOrderForm = ({

--- a/src/pages/api/simple-feature-toggle/index.ts
+++ b/src/pages/api/simple-feature-toggle/index.ts
@@ -4,6 +4,7 @@ import { authoriseServiceAPIRequest } from '@/utils/serviceApiClient'
 export interface SimpleFeatureToggleResponse {
   googleTagManagerEnabled: boolean
   enableNewAppointmentEndpoint: boolean
+  enableFollowOnIsEmergencyField: boolean
 }
 
 export default authoriseServiceAPIRequest(async (req, res) => {
@@ -12,6 +13,9 @@ export default authoriseServiceAPIRequest(async (req, res) => {
 
     enableNewAppointmentEndpoint:
       process.env.NEW_APPOINTMENT_ENDPOINT_ENABLED === 'true',
+
+    enableFollowOnIsEmergencyField:
+      process.env.FOLLOW_ON_IS_EMERGENCY_FIELD_ENABLED === 'true',
   }
 
   res.status(HttpStatus.StatusCodes.OK).json(data)

--- a/src/utils/hact/workOrderComplete/closeWorkOrder.ts
+++ b/src/utils/hact/workOrderComplete/closeWorkOrder.ts
@@ -4,6 +4,7 @@ import {
 } from '../../paymentTypes'
 
 export type followOnDataRequest = {
+  isEmergency: boolean
   isMultipleOperatives: boolean
   requiredFollowOnTrades: string[]
   followOnTypeDescription: string
@@ -82,6 +83,7 @@ export const buildCloseWorkOrderData = (
 }
 
 export const buildFollowOnRequestData = (
+  isEmergency: boolean,
   isMultipleOperatives: boolean,
   requiredFollowOnTrades: string[],
   followOnTypeDescription: string,
@@ -93,6 +95,7 @@ export const buildFollowOnRequestData = (
   otherTrade?: string
 ): followOnDataRequest => {
   return {
+    isEmergency,
     isMultipleOperatives,
     requiredFollowOnTrades,
     followOnTypeDescription,


### PR DESCRIPTION
[HPT-738](https://hackney.atlassian.net/browse/HPT-738) Add in urgency label into the follow on form 

Add an "Is this an emergency?" field to the follow on request form. If the yes option is selected, this sets `isEmergency: true` to the `followOnRequest` part of the work order close request.

Right now this will do nothing, but the Repairs API will be updated to use this to mark certain follow-ons as emergencies in the emails.

A feature toggle has been added for this field to hide it on staging and prod, pending review on development. Currently when the feature is toggled off, it will send `isEmergency: false` in the API response, and the plan is that the API will only mark emergencies differently, and leave the rest of the emails as-is, e.g. with an [Emergency] tag in the email title.

This way the frontend can be safely released independently from the API.

![image](https://github.com/user-attachments/assets/2dec1ad0-4ff7-446e-8fad-0e484264f48d)


[HPT-738]: https://hackney.atlassian.net/browse/HPT-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ