### PR TITLE
Quick fix for DLO contractor permissions

### DIFF
--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -45,7 +45,7 @@ export const buildUser = (
   const agentGroupRegex = new RegExp(AGENTS_GOOGLE_GROUPNAME_REGEX)
 
   const rolesFromGroups = (groupNames: string[]) => {
-    return groupNames.map((groupName) => {
+    const roles: string[] = groupNames.map((groupName) => {
       if (isAgentGroupName(groupName)) {
         return AGENT_ROLE
       }
@@ -84,6 +84,12 @@ export const buildUser = (
 
       console.warn(`User group name not recognised: ${groupName}`)
     })
+
+    if (roles.includes(DLO_CONTRACTOR_ROLE)) {
+      roles.push(CONTRACTOR_ROLE)
+    }
+
+    return roles
   }
 
   const isAgentGroupName = (groupName: string) =>


### PR DESCRIPTION
I recently added a new role for `DLO_CONTRACTORS` for follow ons. 

This change has introduced a bug. If the user has the DLO contractor permission, they would also have the contractor permission. But due to how the code was written, they only see dlo contractor. Resulting in some users having the wrong permissions.

![image](https://github.com/user-attachments/assets/3680f20d-4b8a-4ec2-8253-36583aa1b624)
