### PR TITLE
Add tests to check for null tenure

### DIFF
--- a/cypress/e2e/work-order/create/create.cy.js
+++ b/cypress/e2e/work-order/create/create.cy.js
@@ -125,6 +125,28 @@ describe('Raise repair form', () => {
     cy.clock(now, ['Date'])
   })
 
+  it('Doesnt throw error when tenure is null', () => {
+    cy.loginWithAgentAndBudgetCodeOfficerRole()
+
+    cy.fixture('properties/property.json')
+      .then((property) => {
+        property.tenure = null
+
+        cy.intercept(
+          { method: 'GET', path: '/api/properties/00012345' },
+          { body: property }
+        )
+      })
+      .as('propertyRequest')
+
+    cy.visit('/properties/00012345/raise-repair/new')
+
+    cy.wait(['@propertyRequest', '@sorPrioritiesRequest', '@tradesRequest'])
+
+    cy.contains('New repair')
+    cy.contains('Dwelling: 16 Pitcairn House')
+  })
+
   it('Validates missing form inputs', () => {
     cy.loginWithAgentAndBudgetCodeOfficerRole()
 

--- a/cypress/e2e/work-order/edit.cy.js
+++ b/cypress/e2e/work-order/edit.cy.js
@@ -6,6 +6,33 @@ describe('Editing a work order description', () => {
       cy.loginWithAuthorisationManagerRole()
     })
 
+    describe('When tenure is null', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/workOrders/10000012' },
+          { fixture: 'workOrders/workOrder.json' }
+        ).as('workOrderRequest')
+
+        cy.fixture('properties/property.json')
+          .then((property) => {
+            property.tenure = null
+
+            cy.intercept(
+              { method: 'GET', path: '/api/properties/00012345' },
+              { body: property }
+            )
+          })
+          .as('property')
+      })
+
+      it('doesnt throw error', () => {
+        cy.visit('/work-orders/10000012/edit')
+
+        cy.contains('Edit work order: 10000012')
+        cy.contains('Edit description')
+      })
+    })
+
     describe(`When I don't trigger any errors`, () => {
       beforeEach(() => {
         cy.intercept(
@@ -236,6 +263,7 @@ describe('Editing a work order description', () => {
       })
     })
   })
+
   context('As an operative', () => {
     beforeEach(() => {
       cy.loginWithOperativeRole()
@@ -245,6 +273,7 @@ describe('Editing a work order description', () => {
       ).as('workOrder')
       cy.visit('/work-orders/10000012/edit')
     })
+
     it('I am restricted from accessing the correct page', () => {
       cy.contains(`Access denied`)
     })

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -665,7 +665,7 @@ describe('Show work order page', () => {
     cy.intercept(
       { method: 'GET', path: '/api/workOrders/10000088' },
       { fixture: 'workOrders/workOrder.json' }
-    ).as('workOrderRequest')
+    ).as('workOrderRequest-10000088')
 
     cy.intercept(
       { method: 'GET', path: '/api/workOrders/10000088/tasks' },
@@ -685,7 +685,7 @@ describe('Show work order page', () => {
 
     cy.visit('/work-orders/10000088')
 
-    cy.wait(['@workOrderRequest'])
+    cy.wait(['@workOrderRequest-10000088'])
 
     cy.contains('Work order: 10000088')
     cy.contains('This is an urgent repair description')

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -688,7 +688,7 @@ describe('Show work order page', () => {
     it('doesnt throw error', () => {
       cy.visit('/work-orders/10000012')
 
-      cy.wait(['@workOrderRequest', '@tasksRequest', '@locationAlerts'])
+      cy.wait(['@workOrderRequest', '@tasksRequest'])
 
       cy.contains('Work order: 10000012')
       cy.contains('This is an urgent repair description')

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -664,12 +664,12 @@ describe('Show work order page', () => {
     cy.loginWithContractorRole()
 
     cy.intercept(
-      { method: 'GET', path: '/api/workOrders/10000088' },
+      { method: 'GET', path: '/api/workOrders/10000012' },
       { fixture: 'workOrders/workOrder.json' }
-    ).as('workOrderRequest-10000088')
+    ).as('workOrderRequest-10000012')
 
     cy.intercept(
-      { method: 'GET', path: '/api/workOrders/10000088/tasks' },
+      { method: 'GET', path: '/api/workOrders/10000012/tasks' },
       { body: [] }
     ).as('tasksRequest')
 
@@ -684,11 +684,11 @@ describe('Show work order page', () => {
       })
       .as('property')
 
-    cy.visit('/work-orders/10000088')
+    cy.visit('/work-orders/10000012')
 
-    cy.wait(['@workOrderRequest-10000088'])
+    cy.wait(['@workOrderRequest-10000012'])
 
-    cy.contains('Work order: 10000088')
+    cy.contains('Work order: 10000012')
     cy.contains('This is an urgent repair description')
   })
 })

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -609,7 +609,6 @@ describe('Show work order page', () => {
           },
           { body: [] }
         ).as('workOrdersRequest')
-
       })
 
       it('contains a link to close the order', () => {

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -659,39 +659,35 @@ describe('Show work order page', () => {
     })
   })
 
-  describe('When tenure is null', () => {
-    beforeEach(() => {
-      cy.intercept(
-        { method: 'GET', path: '/api/workOrders/10000012' },
-        { fixture: 'workOrders/workOrder.json' }
-      ).as('workOrderRequest')
+  describe('When tenure is null doesnt throw error', () => {
+    cy.loginWithContractorRole()
 
-      cy.intercept(
-        { method: 'GET', path: '/api/workOrders/10000012/tasks' },
-        { body: [] }
-      ).as('tasksRequest')
+    cy.intercept(
+      { method: 'GET', path: '/api/workOrders/10000012' },
+      { fixture: 'workOrders/workOrder.json' }
+    ).as('workOrderRequest')
 
-      cy.loginWithContractorRole()
+    cy.intercept(
+      { method: 'GET', path: '/api/workOrders/10000012/tasks' },
+      { body: [] }
+    ).as('tasksRequest')
 
-      cy.fixture('properties/property.json')
-        .then((property) => {
-          property.tenure = null
+    cy.fixture('properties/property.json')
+      .then((property) => {
+        property.tenure = null
 
-          cy.intercept(
-            { method: 'GET', path: '/api/properties/00012345' },
-            { body: property }
-          )
-        })
-        .as('property')
-    })
+        cy.intercept(
+          { method: 'GET', path: '/api/properties/00012345' },
+          { body: property }
+        )
+      })
+      .as('property')
 
-    it('doesnt throw error', () => {
-      cy.visit('/work-orders/10000012')
+    cy.visit('/work-orders/10000012')
 
-      cy.wait(['@workOrderRequest', '@tasksRequest'])
+    cy.wait(['@workOrderRequest'])
 
-      cy.contains('Work order: 10000012')
-      cy.contains('This is an urgent repair description')
-    })
+    cy.contains('Work order: 10000012')
+    cy.contains('This is an urgent repair description')
   })
 })

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -83,10 +83,6 @@ describe('Show work order page', () => {
         },
         { body: [] }
       ).as('workOrdersRequest')
-      cy.intercept(
-        { method: 'GET', path: '/api/simple-feature-toggle' },
-        { body: {} }
-      ).as('featureToggle')
     })
 
     it('Shows various details about the work order, property and assigned contractor', () => {
@@ -613,10 +609,7 @@ describe('Show work order page', () => {
           },
           { body: [] }
         ).as('workOrdersRequest')
-        cy.intercept(
-          { method: 'GET', path: '/api/simple-feature-toggle' },
-          { body: {} }
-        ).as('featureToggle')
+
       })
 
       it('contains a link to close the order', () => {
@@ -663,7 +656,7 @@ describe('Show work order page', () => {
     cy.loginWithContractorRole()
 
     cy.intercept(
-      { method: 'GET', path: '/api/workOrders/10000088' },
+      { method: 'GET', path: '/api/workOrders/10000088/new' },
       { fixture: 'workOrders/workOrder.json' }
     ).as('workOrderRequest-10000088')
 

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -658,4 +658,45 @@ describe('Show work order page', () => {
       })
     })
   })
+
+  describe('When tenure is null', () => {
+    beforeEach(() => {
+      cy.intercept(
+        { method: 'GET', path: '/api/workOrders/10000012' },
+        { fixture: 'workOrders/workOrder.json' }
+      ).as('workOrderRequest')
+
+      cy.intercept(
+        { method: 'GET', path: '/api/workOrders/10000012/tasks' },
+        { body: [] }
+      ).as('tasksRequest')
+
+      cy.loginWithContractorRole()
+
+      cy.fixture('properties/property.json')
+        .then((property) => {
+          property.tenure = null
+
+          cy.intercept(
+            { method: 'GET', path: '/api/properties/00012345' },
+            { body: property }
+          )
+        })
+        .as('property')
+    })
+
+    it('doesnt throw error', () => {
+      cy.visit('/work-orders/10000012')
+
+      cy.wait([
+        '@workOrderRequest',
+        '@tasksRequest',
+        '@locationAlerts',
+        '@personAlerts',
+      ])
+
+      cy.contains('Work order: 10000012')
+      cy.contains('This is an urgent repair description')
+    })
+  })
 })

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -5,6 +5,15 @@ import 'cypress-audit/commands'
 describe('Show work order page', () => {
   beforeEach(() => {
     cy.intercept(
+      { method: 'GET', path: '/api/simple-feature-toggle' },
+      {
+        body: {
+          enableNewAppointmentEndpoint: false,
+        },
+      }
+    ).as('featureToggle')
+
+    cy.intercept(
       { method: 'GET', path: '/api/properties/00012345' },
       { fixture: 'properties/property.json' }
     ).as('property')
@@ -655,7 +664,7 @@ describe('Show work order page', () => {
     cy.loginWithContractorRole()
 
     cy.intercept(
-      { method: 'GET', path: '/api/workOrders/10000088/new' },
+      { method: 'GET', path: '/api/workOrders/10000088' },
       { fixture: 'workOrders/workOrder.json' }
     ).as('workOrderRequest-10000088')
 

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -659,16 +659,16 @@ describe('Show work order page', () => {
     })
   })
 
-  describe('When tenure is null doesnt throw error', () => {
+  it('When tenure is null doesnt throw error', () => {
     cy.loginWithContractorRole()
 
     cy.intercept(
-      { method: 'GET', path: '/api/workOrders/10000012' },
+      { method: 'GET', path: '/api/workOrders/10000088' },
       { fixture: 'workOrders/workOrder.json' }
     ).as('workOrderRequest')
 
     cy.intercept(
-      { method: 'GET', path: '/api/workOrders/10000012/tasks' },
+      { method: 'GET', path: '/api/workOrders/10000088/tasks' },
       { body: [] }
     ).as('tasksRequest')
 
@@ -683,11 +683,11 @@ describe('Show work order page', () => {
       })
       .as('property')
 
-    cy.visit('/work-orders/10000012')
+    cy.visit('/work-orders/10000088')
 
     cy.wait(['@workOrderRequest'])
 
-    cy.contains('Work order: 10000012')
+    cy.contains('Work order: 10000088')
     cy.contains('This is an urgent repair description')
   })
 })

--- a/cypress/e2e/work-order/show/show.cy.js
+++ b/cypress/e2e/work-order/show/show.cy.js
@@ -688,12 +688,7 @@ describe('Show work order page', () => {
     it('doesnt throw error', () => {
       cy.visit('/work-orders/10000012')
 
-      cy.wait([
-        '@workOrderRequest',
-        '@tasksRequest',
-        '@locationAlerts',
-        '@personAlerts',
-      ])
+      cy.wait(['@workOrderRequest', '@tasksRequest', '@locationAlerts'])
 
       cy.contains('Work order: 10000012')
       cy.contains('This is an urgent repair description')


### PR DESCRIPTION
From ticket:

```
We’ve had a couple issues with the prod release due to tenures being null on some properties. This wasnt picked up due to different data on prod vs staging and dev.

 

To help mitigate the issue, we should add tests to handle this usecase for each page where tenure data is used.
```