### PR TITLE
Clear up null conditional rendering

### DIFF
--- a/src/components/BackOffice/ContractsDashboard/Contractor/ContractorView.tsx
+++ b/src/components/BackOffice/ContractsDashboard/Contractor/ContractorView.tsx
@@ -57,7 +57,7 @@ const ContractorView = ({
   )
 
   const descendingDateContractsWithSorCode = useMemo(
-    () => contractsWithSorCode && [...contractsWithSorCode].reverse(),
+    () => (contractsWithSorCode ? [...contractsWithSorCode].reverse() : null),
     [contractsWithSorCode]
   )
 

--- a/src/components/BackOffice/ContractsDashboard/SorSearch.tsx
+++ b/src/components/BackOffice/ContractsDashboard/SorSearch.tsx
@@ -66,14 +66,14 @@ const SorSearch = ({
           <Spinner />
         ) : (
           <>
-            {contracts?.length > 0 && (
+            {contracts !== null && contracts?.length > 0 && (
               <ContractListItems
                 contracts={contracts}
                 heading={`${sorCode} found in the following ${contractorName} contracts`}
                 page="sorSearch"
               />
             )}
-            {contracts?.length === 0 && (
+            {contracts !== null && contracts?.length === 0 && (
               <p className="lbh-body">
                 No contracts with{' '}
                 <span style={{ fontWeight: 600 }}>{sorCode}</span> SOR code{' '}


### PR DESCRIPTION
### Description of change

I want to make the conditional rendering in SorSearch clearer for when contracts isn't null
