### PR TITLE
Update messaging for DRS status badge

### DIFF
--- a/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
+++ b/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
@@ -1,3 +1,5 @@
+import WarningInfoBox from '../Template/WarningInfoBox'
+
 interface Props {
   bookingLifeCycleStatus: string
 }
@@ -10,22 +12,31 @@ export const DrsBookingLifeCycleStatusBadge = ({
   }
 
   return (
-    <p
-      className="lbh-body-s"
-      style={{
-        color: '#f9fafb',
-        background: '#4b5563',
-        display: 'inline-block',
-        padding: '2px 6px',
-        marginBottom: '15px',
-        marginTop: '5px',
-        borderRadius: '2px',
-        fontWeight: 'normal',
-        letterSpacing: '2px',
-        fontSize: '13px',
-      }}
-    >
-      {bookingLifeCycleStatus}
-    </p>
+    <>
+      <p
+        className="lbh-body-s"
+        style={{
+          color: '#f9fafb',
+          background: '#4b5563',
+          display: 'inline-block',
+          padding: '2px 6px',
+          marginBottom: '15px',
+          marginTop: '5px',
+          borderRadius: '2px',
+          fontWeight: 'normal',
+          letterSpacing: '2px',
+          fontSize: '13px',
+        }}
+      >
+        {bookingLifeCycleStatus}
+      </p>
+
+      <WarningInfoBox
+        className="variant-warning govuk-!-margin-bottom-4"
+        header="Work order cannot be cancelled"
+        name="despatched-warning"
+        text="The work order is locked after being dispatched to the operative. If you need to cancel the job, please contact a planner to unlock the job in DRS."
+      />
+    </>
   )
 }

--- a/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
+++ b/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
@@ -1,6 +1,5 @@
+import { LOCKED_DRS_STATUS_CODES } from '../../utils/statusCodes'
 import WarningInfoBox from '../Template/WarningInfoBox'
-
-const DESPATCHED_BOOKING_STATUS = 'DESPATCHED'
 
 interface Props {
   bookingLifeCycleStatus: string
@@ -33,14 +32,24 @@ export const DrsBookingLifeCycleStatusBadge = ({
         {bookingLifeCycleStatus}
       </p>
 
-      {bookingLifeCycleStatus === DESPATCHED_BOOKING_STATUS && (
-        <WarningInfoBox
-          className="variant-warning govuk-!-margin-bottom-4"
-          header="Work order cannot be cancelled"
-          name="despatched-warning"
-          text="The work order is locked after being dispatched to the operative. If you need to cancel the job, please contact a planner to unlock the job in DRS."
-        />
-      )}
+      <CannotCancelJobWarningBox
+        bookingLifeCycleStatus={bookingLifeCycleStatus}
+      />
     </>
+  )
+}
+
+export const CannotCancelJobWarningBox = ({
+  bookingLifeCycleStatus,
+}: Props) => {
+  if (!LOCKED_DRS_STATUS_CODES.has(bookingLifeCycleStatus)) return null
+
+  return (
+    <WarningInfoBox
+      className="variant-warning govuk-!-margin-bottom-4"
+      header="Work order cannot be cancelled"
+      name="despatched-warning"
+      text="An operative has commenced work on this order. If you need to cancel the job, please contact a planner to unlock the job in DRS."
+    />
   )
 }

--- a/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
+++ b/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
@@ -11,6 +11,7 @@ export const DrsBookingLifeCycleStatusBadge = ({
 
   return (
     <p
+      className="lbh-body-s"
       style={{
         color: '#f9fafb',
         background: '#4b5563',

--- a/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
+++ b/src/components/DrsBookingLifeCycleStatusBadge/index.tsx
@@ -1,5 +1,7 @@
 import WarningInfoBox from '../Template/WarningInfoBox'
 
+const DESPATCHED_BOOKING_STATUS = 'DESPATCHED'
+
 interface Props {
   bookingLifeCycleStatus: string
 }
@@ -31,12 +33,14 @@ export const DrsBookingLifeCycleStatusBadge = ({
         {bookingLifeCycleStatus}
       </p>
 
-      <WarningInfoBox
-        className="variant-warning govuk-!-margin-bottom-4"
-        header="Work order cannot be cancelled"
-        name="despatched-warning"
-        text="The work order is locked after being dispatched to the operative. If you need to cancel the job, please contact a planner to unlock the job in DRS."
-      />
+      {bookingLifeCycleStatus === DESPATCHED_BOOKING_STATUS && (
+        <WarningInfoBox
+          className="variant-warning govuk-!-margin-bottom-4"
+          header="Work order cannot be cancelled"
+          name="despatched-warning"
+          text="The work order is locked after being dispatched to the operative. If you need to cancel the job, please contact a planner to unlock the job in DRS."
+        />
+      )}
     </>
   )
 }

--- a/src/components/WorkOrder/AppointmentDetails.tsx
+++ b/src/components/WorkOrder/AppointmentDetails.tsx
@@ -1,6 +1,11 @@
 import { useContext } from 'react'
 import UserContext from '../UserContext'
-import { STATUS_CANCELLED } from '@/utils/statusCodes'
+import {
+  STATUS_AUTHORISATION_PENDING_APPROVAL,
+  STATUS_CANCELLED,
+  STATUS_COMPLETED,
+  STATUS_NO_ACCESS,
+} from '@/utils/statusCodes'
 import {
   canSeeAppointmentDetailsInfo,
   canScheduleAppointment,
@@ -16,8 +21,25 @@ interface Props {
   workOrder: WorkOrder
 }
 
+const INACTIVE_STATUS_CODES = new Set<string>([
+  STATUS_CANCELLED.description,
+  STATUS_AUTHORISATION_PENDING_APPROVAL.description,
+  STATUS_COMPLETED.description,
+  STATUS_NO_ACCESS.description,
+])
+
 const AppointmentDetails = ({ workOrder }: Props) => {
   const { user } = useContext(UserContext)
+
+  const showDrsLifeCycleStatus = () => {
+    if (!canSeeAppointmentDetailsInfo(user)) return false
+    if (!workOrder?.appointment?.bookingLifeCycleStatus) return false
+
+    // hide when workorder is inactive
+    if (INACTIVE_STATUS_CODES.has(workOrder.status)) return false
+
+    return true
+  }
 
   return (
     <>
@@ -34,14 +56,13 @@ const AppointmentDetails = ({ workOrder }: Props) => {
             Appointment details
           </p>
 
-          {canSeeAppointmentDetailsInfo(user) &&
-            !!workOrder?.appointment?.bookingLifeCycleStatus && (
-              <DrsBookingLifeCycleStatusBadge
-                bookingLifeCycleStatus={
-                  workOrder?.appointment?.bookingLifeCycleStatus
-                }
-              />
-            )}
+          {showDrsLifeCycleStatus() && (
+            <DrsBookingLifeCycleStatusBadge
+              bookingLifeCycleStatus={
+                workOrder?.appointment?.bookingLifeCycleStatus
+              }
+            />
+          )}
 
           <div className="lbh-body-s govuk-!-margin-0">
             {user && (

--- a/src/components/WorkOrder/AppointmentDetails.tsx
+++ b/src/components/WorkOrder/AppointmentDetails.tsx
@@ -34,13 +34,14 @@ const AppointmentDetails = ({ workOrder }: Props) => {
             Appointment details
           </p>
 
-          {!!workOrder?.appointment?.bookingLifeCycleStatus && (
-            <DrsBookingLifeCycleStatusBadge
-              bookingLifeCycleStatus={
-                workOrder?.appointment?.bookingLifeCycleStatus
-              }
-            />
-          )}
+          {canSeeAppointmentDetailsInfo(user) &&
+            !!workOrder?.appointment?.bookingLifeCycleStatus && (
+              <DrsBookingLifeCycleStatusBadge
+                bookingLifeCycleStatus={
+                  workOrder?.appointment?.bookingLifeCycleStatus
+                }
+              />
+            )}
 
           <div className="lbh-body-s govuk-!-margin-0">
             {user && (

--- a/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderForm.tsx
+++ b/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderForm.tsx
@@ -11,6 +11,9 @@ import {
 } from '@/utils/helpers/priorities'
 import { isContractorScheduledInternally } from '@/utils/helpers/workOrders'
 import { useState } from 'react'
+import WarningInfoBox from '../../Template/WarningInfoBox'
+
+const DESPATCHED_BOOKING_STATUS = 'DESPATCHED'
 
 const CancelWorkOrderForm = ({ workOrder, onFormSubmit }) => {
   const { register, handleSubmit, errors } = useForm()
@@ -33,6 +36,16 @@ const CancelWorkOrderForm = ({ workOrder, onFormSubmit }) => {
           <h1 className="lbh-heading-h1 govuk-!-margin-bottom-2">
             Work order: {workOrder.reference}
           </h1>
+
+          {workOrder?.appointment?.bookingLifeCycleStatus ===
+            DESPATCHED_BOOKING_STATUS && (
+            <WarningInfoBox
+              className="variant-warning govuk-!-margin-bottom-4"
+              header="Work order cannot be cancelled"
+              name="despatched-warning"
+              text="The work order is locked after being dispatched to the operative. If you need to cancel the job, please contact a planner to unlock the job in DRS."
+            />
+          )}
 
           <WorkOrderInfoTable workOrder={workOrder} />
 
@@ -62,7 +75,6 @@ const CancelWorkOrderForm = ({ workOrder, onFormSubmit }) => {
             <input
               id="workOrderReference"
               name="workOrderReference"
-              label="workOrderReference"
               type="hidden"
               value={workOrder.reference}
               ref={register}

--- a/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderForm.tsx
+++ b/src/components/WorkOrder/CancelWorkOrder/CancelWorkOrderForm.tsx
@@ -11,9 +11,7 @@ import {
 } from '@/utils/helpers/priorities'
 import { isContractorScheduledInternally } from '@/utils/helpers/workOrders'
 import { useState } from 'react'
-import WarningInfoBox from '../../Template/WarningInfoBox'
-
-const DESPATCHED_BOOKING_STATUS = 'DESPATCHED'
+import { CannotCancelJobWarningBox } from '../../DrsBookingLifeCycleStatusBadge'
 
 const CancelWorkOrderForm = ({ workOrder, onFormSubmit }) => {
   const { register, handleSubmit, errors } = useForm()
@@ -37,15 +35,11 @@ const CancelWorkOrderForm = ({ workOrder, onFormSubmit }) => {
             Work order: {workOrder.reference}
           </h1>
 
-          {workOrder?.appointment?.bookingLifeCycleStatus ===
-            DESPATCHED_BOOKING_STATUS && (
-            <WarningInfoBox
-              className="variant-warning govuk-!-margin-bottom-4"
-              header="Work order cannot be cancelled"
-              name="despatched-warning"
-              text="The work order is locked after being dispatched to the operative. If you need to cancel the job, please contact a planner to unlock the job in DRS."
-            />
-          )}
+          <CannotCancelJobWarningBox
+            bookingLifeCycleStatus={
+              workOrder?.appointment?.bookingLifeCycleStatus
+            }
+          />
 
           <WorkOrderInfoTable workOrder={workOrder} />
 

--- a/src/components/WorkOrder/CancelWorkOrder/__snapshots__/CancelWorkOrderForm.test.js.snap
+++ b/src/components/WorkOrder/CancelWorkOrder/__snapshots__/CancelWorkOrderForm.test.js.snap
@@ -94,7 +94,6 @@ exports[`CancelWorkOrderForm component should render properly 1`] = `
         >
           <input
             id="workOrderReference"
-            label="workOrderReference"
             name="workOrderReference"
             type="hidden"
             value="10000012"
@@ -302,7 +301,6 @@ exports[`CancelWorkOrderForm component when the work order is for the DLO when t
         >
           <input
             id="workOrderReference"
-            label="workOrderReference"
             name="workOrderReference"
             type="hidden"
             value="10000012"
@@ -510,7 +508,6 @@ exports[`CancelWorkOrderForm component when the work order is for the DLO when t
         >
           <input
             id="workOrderReference"
-            label="workOrderReference"
             name="workOrderReference"
             type="hidden"
             value="10000012"

--- a/src/utils/statusCodes.ts
+++ b/src/utils/statusCodes.ts
@@ -121,3 +121,8 @@ export const CLOSED_STATUS_DESCRIPTIONS_FOR_OPERATIVES = [
   STATUS_NO_ACCESS.description,
   'Work Completed', // can be deleted following backend release of PR #641
 ]
+
+export const LOCKED_DRS_STATUS_CODES = new Set<string>([
+  'DESPATCHED',
+  'STARTED',
+])


### PR DESCRIPTION
## Summary of Changes

- Multiple statuses other than 'DESPATCHED' have this restriction, so the logic has been updated to handle this
- Display info box to notify users when a work order cannot be cancelled
- Only show status on work order page when user has permissions 

## Screenshots

<img width="1093" height="489" alt="image" src="https://github.com/user-attachments/assets/8681b47e-1fbc-4198-9b6e-31f765d98658" />

<img width="1063" height="768" alt="image" src="https://github.com/user-attachments/assets/8c768c4d-bb94-4cb3-97a7-6b8afb2255b5" />


<img width="1174" height="909" alt="image" src="https://github.com/user-attachments/assets/27399daf-c72a-4546-a2ad-6f84735778ad" />


<img width="886" height="984" alt="image" src="https://github.com/user-attachments/assets/fe6519e5-518e-41fa-b203-1d1a11c51e1e" />


