### PR TITLE
Debug file upload errors

### DIFF
--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
@@ -62,12 +62,33 @@ const uploadWrapper = async (
   } catch (err) {
     console.error(
       'failed to compress file - using original',
+      {
+        name: file.name,
+        size: file.size,
+        type: file.type,
+      },
+      'with error',
       JSON.stringify(err)
     )
   }
 
+  console.log('uploading file', file.name)
+
   const result = await faultTolerantRequest(
-    async () => await uploadFileToS3(fileToUpload, link)
+    async () =>
+      await uploadFileToS3(fileToUpload, link).catch((err) => {
+        console.error(
+          'uploadFileToS3 failed for file',
+          {
+            name: file.name,
+            size: file.size,
+            type: file.type,
+          },
+          'with error',
+          JSON.stringify(err)
+        )
+        throw err
+      })
   )
 
   return result

--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
@@ -72,7 +72,11 @@ const uploadWrapper = async (
     )
   }
 
-  console.log('uploading file', file.name)
+  console.log('uploading file', {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+  })
 
   const result = await faultTolerantRequest(
     async () =>

--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
@@ -55,6 +55,11 @@ const uploadWrapper = async (
   }
 
   let fileToUpload = file
+  // Need to destructure because these are non-enumerable properties
+  const { name, size, type } = file
+  const fileDetails = { name, size, type }
+
+  console.log('preparing to upload file', JSON.stringify(fileDetails))
 
   // try to compress file. If fails, just use file
   try {
@@ -62,32 +67,18 @@ const uploadWrapper = async (
   } catch (err) {
     console.error(
       'failed to compress file - using original',
-      {
-        name: file.name,
-        size: file.size,
-        type: file.type,
-      },
+      JSON.stringify(fileDetails),
       'with error',
       JSON.stringify(err)
     )
   }
-
-  console.log('uploading file', {
-    name: file.name,
-    size: file.size,
-    type: file.type,
-  })
 
   const result = await faultTolerantRequest(
     async () =>
       await uploadFileToS3(fileToUpload, link).catch((err) => {
         console.error(
           'uploadFileToS3 failed for file',
-          {
-            name: file.name,
-            size: file.size,
-            type: file.type,
-          },
+          JSON.stringify(fileDetails),
           'with error',
           JSON.stringify(err)
         )


### PR DESCRIPTION
From looking online, some reasons the compression might fail include invalid file types or excessively large file sizes.

This PR adds logging for the file details, so we can see what kinds of files are failing.