### PR TITLE
Expand error logging

### DIFF
--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/index.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/index.ts
@@ -57,7 +57,13 @@ const uploadFiles = async (
         },
         extra: {
           workOrderReference,
-          files,
+          files: JSON.stringify(
+            files.map((file) => ({
+              name: file.name,
+              size: file.size,
+              type: file.type,
+            }))
+          ),
           message: error.message,
         },
       })


### PR DESCRIPTION
Sentry just shows the files as [{},{},{}] which isn't helpful. Gotta explicitly map them