### PR TITLE
Make getting presigned URLs fault tolerant

### DIFF
--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/faultTolerantRequest.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/faultTolerantRequest.ts
@@ -6,12 +6,13 @@ const DEFAULT_NUMBER_OF_RETRIES = 3
  * Returns a promise that tries to successfully resolve
  * a specified amount of times with exponential backoff
  */
-const faultTolerantRequest = async (
-  request: () => Promise<void>,
+const faultTolerantRequest = async <T>(
+  request: () => Promise<T>,
   retries: number = DEFAULT_NUMBER_OF_RETRIES
 ): Promise<{
   success: boolean
-  error?: any
+  data?: T
+  error?: Error
 }> => {
   const operation = retry.operation({
     retries,
@@ -20,9 +21,10 @@ const faultTolerantRequest = async (
   return new Promise((resolve) => {
     operation.attempt(() => {
       request()
-        .then(() => {
+        .then((result) => {
           resolve({
             success: true,
+            data: result,
           })
         })
         .catch((err) => {

--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/uploadFilesToS3.ts
@@ -69,7 +69,7 @@ const uploadWrapper = async (
       'failed to compress file - using original',
       JSON.stringify(fileDetails),
       'with error',
-      JSON.stringify({ name: err.name, message: err.message })
+      err
     )
     // Need to re-create the File as it may be corrupted after failed compression
     fileToUpload = new File([file], name, { type, lastModified })


### PR DESCRIPTION
Sometimes there's a network error getting the presigned URLs for photo upload. This should help to mitigate it by making it auto-retry with the `faultTolerantRequest`

