### PR TITLE
Add compressor js with feature toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "axios": "^0.21.1",
     "browser-image-compression": "^2.0.2",
     "classnames": "^2.3.2",
+    "compressorjs": "^1.2.1",
     "cookie": "^0.4.1",
     "date-fns": "^2.16.1",
     "dayjs": "^1.11.7",

--- a/serverless.yml
+++ b/serverless.yml
@@ -77,6 +77,7 @@ functions:
       SENTRY_RELEASE: ${env:CIRCLE_SHA1}
       NEW_APPOINTMENT_ENDPOINT_ENABLED: ${ssm:/repairs-hub/${self:provider.stage}/enable-new-appointments-endpoint}
       FOLLOW_ON_IS_EMERGENCY_FIELD_ENABLED: ${self:custom.follow-on-is-emergency-field-enabled.${self:provider.stage}}
+      USE_COMPRESSOR_JS: ${self:custom.use-compressor-js.${self:provider.stage}}
       TAG_MANAGER_ID: ${self:custom.tag-manager-id.${self:provider.stage}}
 
 resources:
@@ -165,3 +166,7 @@ custom:
     development: true
     staging: true
     production: true
+  use-compressor-js:
+    development: true
+    staging: false
+    production: false

--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/compressFile.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/compressFile.ts
@@ -1,0 +1,80 @@
+import { fetchSimpleFeatureToggles } from '@/root/src/utils/frontEndApiClient/requests'
+import imageCompression, {
+  Options as CompressionOptions,
+} from 'browser-image-compression'
+import Compressor from 'compressorjs'
+
+function fileDetails(file: File) {
+  return {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+  }
+}
+
+export interface CompressResult {
+  success: boolean
+  file: File
+}
+
+async function compressWithBrowserImageCompression(
+  file: File
+): Promise<CompressResult> {
+  console.log(
+    'Compressing file with browser-image-compression',
+    fileDetails(file)
+  )
+  const compressionOptions: CompressionOptions = {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+    maxIteration: 1,
+  }
+  const compressedFile = await imageCompression(file, compressionOptions)
+  return { success: true, file: compressedFile }
+}
+
+function compressWithCompressorJS(file: File): Promise<CompressResult> {
+  console.log('Compressing file with CompressorJS', fileDetails(file))
+  return new Promise((resolve, reject) => {
+    new Compressor(file, {
+      maxWidth: 1920,
+      maxHeight: 1920,
+      quality: 0.8,
+      success: (compressedFile: File) => {
+        resolve({ success: true, file: compressedFile })
+      },
+      error: (err) => reject(err),
+    })
+  })
+}
+
+export async function compressFile(file: File): Promise<CompressResult> {
+  const featureToggles = await fetchSimpleFeatureToggles()
+
+  // Use browser-image-compression as default
+  let compressResult: CompressResult
+
+  try {
+    if (featureToggles.useCompressorJS) {
+      compressResult = await compressWithCompressorJS(file)
+    } else {
+      // Use browser-image-compression as default
+      compressResult = await compressWithBrowserImageCompression(file)
+    }
+  } catch (error) {
+    console.error('File compression failed:', error)
+    compressResult = {
+      success: false,
+      file: new File([file], file.name, {
+        type: file.type,
+        lastModified: file.lastModified,
+      }),
+    }
+  }
+  console.log('compression result', {
+    success: compressResult.success,
+    ...fileDetails(compressResult.file),
+  })
+  return compressResult
+}

--- a/src/pages/api/simple-feature-toggle/index.ts
+++ b/src/pages/api/simple-feature-toggle/index.ts
@@ -5,6 +5,7 @@ export interface SimpleFeatureToggleResponse {
   googleTagManagerEnabled: boolean
   enableNewAppointmentEndpoint: boolean
   enableFollowOnIsEmergencyField: boolean
+  useCompressorJS: boolean
 }
 
 export default authoriseServiceAPIRequest(async (req, res) => {
@@ -16,6 +17,8 @@ export default authoriseServiceAPIRequest(async (req, res) => {
 
     enableFollowOnIsEmergencyField:
       process.env.FOLLOW_ON_IS_EMERGENCY_FIELD_ENABLED === 'true',
+
+    useCompressorJS: process.env.USE_COMPRESSOR_JS === 'true',
   }
 
   res.status(HttpStatus.StatusCodes.OK).json(data)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,6 +2863,11 @@ bluebird@3.7.2, bluebird@^3.5.5, bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+blueimp-canvas-to-blob@^3.29.0:
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz#d965f06cb1a67fdae207a2be56683f55ef531466"
+  integrity sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg==
+
 boxen@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
@@ -3412,6 +3417,14 @@ component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+compressorjs@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/compressorjs/-/compressorjs-1.2.1.tgz#4dee18ef5032f8166bd0a3258f045eda2cd07671"
+  integrity sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==
+  dependencies:
+    blueimp-canvas-to-blob "^3.29.0"
+    is-blob "^2.1.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -5425,6 +5438,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-blob@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-blob/-/is-blob-2.1.0.tgz#e36cd82c90653f1e1b930f11baf9c64216a05385"
+  integrity sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==
 
 is-boolean-object@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
A large number of users are getting errors with file upload. Every time there's an error with file upload there's first an error with the image compression, e.g:

```
failed to compress file - using original {"name":"1000001663.jpg","size":2407627,"type":"image/jpeg"} with error {
currentTarget: [object FileReader],
isTrusted: true,
target: [object FileReader],
type: error
}
```

It's not clear why this is happening - a theory is that users are running an excessively old Android system which somehow causes the file reading to fail in the library.

As an experimental way to try to fix this, this PR adds a feature toggle to use the CompressorJS library instead of browser-image-compression. CompressorJS is older and less sophisticated, which could mean it doesn't have the same issues on the older hardware.

However, CompressorJS is slower on modern hardware because it doesn't use a Web Worker to perform the tasks in a new process. We'll have to monitor this to ensure it helps with resolving this issue and does not introduce a performance issue.
