### PR TITLE
Make completeUplaod fault tolerant

### DIFF
--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/completeUpload.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/completeUpload.ts
@@ -1,4 +1,5 @@
 import { frontEndApiRequest } from '@/root/src/utils/frontEndApiClient/requests'
+import faultTolerantRequest from './faultTolerantRequest'
 
 const completeUpload = async (
   workOrderReference: string,
@@ -6,7 +7,7 @@ const completeUpload = async (
   description: string,
   uploadGroupLabel: string
 ) => {
-  try {
+  const requestOperation = async () => {
     const result = await frontEndApiRequest({
       method: 'post',
       path: `/api/workOrders/images/completeUpload`,
@@ -17,19 +18,19 @@ const completeUpload = async (
         uploadGroupLabel,
       },
     })
-
-    return { success: true, result }
-  } catch (error) {
-    let errorMessage = ''
-
-    if (typeof error == 'string') {
-      errorMessage = error
-    } else {
-      errorMessage = error.message
-    }
-
-    return { success: false, error: errorMessage }
+    return result
   }
+
+  const faultTolerantResult = await faultTolerantRequest(requestOperation, 5)
+
+  if (!faultTolerantResult.success) {
+    return {
+      success: false,
+      error: faultTolerantResult.error?.message || 'Request failed',
+    }
+  }
+
+  return { success: true, result: faultTolerantResult.data }
 }
 
 export default completeUpload


### PR DESCRIPTION
There are some cases where users successfully compress the files and upload them, but the final completeUpload step fails, presumably due to unstable internet connection.

By retrying this lightweight operation up to 5 times this should help to mitigate the issue.