### PR TITLE
Fix Repairs Finder Page Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "serverless-http": "^2.6.0",
     "universal-cookie": "^4.0.4",
     "uuid": "^8.3.2",
+    "xml2js": "^0.6.2",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.32"
   },
@@ -102,8 +103,7 @@
     "sass": "^1.29.0",
     "start-server-and-test": "2",
     "timezone-mock": "^1.3.6",
-    "typescript": "^5.5.4",
-    "xml2js": "^0.6.2"
+    "typescript": "^5.5.4"
   },
   "lint-staged": {
     "**/*.{js,jsx}": "eslint --fix",


### PR DESCRIPTION
The new Repairs Finder page wasnt loading. Turns out, the XML parsing library was installed as a dev depdnency.

<img width="720" height="279" alt="image" src="https://github.com/user-attachments/assets/456f3b4b-e468-4843-95ec-913427ba20aa" />
