### PR TITLE
Fix for CloseByProxy form

### DIFF
--- a/src/components/Operatives/NewTaskForm.js
+++ b/src/components/Operatives/NewTaskForm.js
@@ -25,7 +25,7 @@ const NewTaskForm = ({ workOrderReference }) => {
     setError(null)
 
     try {
-      const workOrderResponse = await getWorkOrder(reference)
+      const workOrderResponse = await getWorkOrder(reference, false)
 
       if (!workOrderResponse.success) {
         throw workOrderResponse.error

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.js
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.js
@@ -131,7 +131,7 @@ const CloseWorkOrderByProxy = ({ reference }) => {
     setError(null)
 
     try {
-      const workOrderResponse = await getWorkOrder(reference)
+      const workOrderResponse = await getWorkOrder(reference, true)
 
       if (!workOrderResponse.success) {
         throw workOrderResponse.error


### PR DESCRIPTION
The feature toggle relies on the second parameter for fetching appointment details. 

This broke the closeByProxy form because it wasnt fetching appointment details (which includes operatives)