### PR TITLE
Throw FileUploadError to capture unreadable file

### DIFF
--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/index.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/index.ts
@@ -34,7 +34,7 @@ const uploadFiles = async (
         } catch (err) {
           const errorMessage = `Could not read the file "${file.name}". Please remove and re-select it. Error: ${err.message}`
           console.error(errorMessage, err)
-          throw Error(errorMessage)
+          throw new FileUploadError(errorMessage)
         }
       })
     )


### PR DESCRIPTION
Currently we're not capturing the error centrally as only FileUploadErrors are captured by sentry