### PR TITLE
Fix view photos link in note

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -14,7 +14,6 @@ interface Props {
   budgetCode?: any
   workOrder?: WorkOrder
   appointmentDetails?: WorkOrderAppointmentDetails
-  setActiveTab?: (tabName: TabName) => void
 }
 
 const Tabs = (props: Props) => {
@@ -26,7 +25,6 @@ const Tabs = (props: Props) => {
     budgetCode,
     workOrder,
     appointmentDetails,
-    setActiveTab,
   } = props
 
   const router = useRouter()
@@ -94,7 +92,7 @@ const Tabs = (props: Props) => {
           budgetCode={budgetCode}
           workOrder={workOrder}
           appointmentDetails={appointmentDetails}
-          setActiveTab={setActiveTab}
+          setActiveTab={handleSelectTab}
         />
       </div>
     </div>


### PR DESCRIPTION
I found a bug, the view photos link wasnt opening the photos tab. This was missed when updating the tab component.

<img width="1009" height="852" alt="image" src="https://github.com/user-attachments/assets/7feb99db-5860-44b3-b621-25176b1ceea4" />
