### PR TITLE
Hotfix: Fix null tenure for mobile view

### DIFF
--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.tsx
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.tsx
@@ -317,7 +317,6 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }: Props) => {
         property &&
         property.address &&
         property.hierarchyType &&
-        tenure &&
         workOrder && (
           <>
             <MobileWorkingWorkOrder


### PR DESCRIPTION
Recent change causes a blank page when tenure is null

<img width="1663" height="1272" alt="image" src="https://github.com/user-attachments/assets/2b471312-27f5-4010-8872-5d80d94c862f" />
