### PR TITLE
Use typescript for the cypress commands

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,30 +1,31 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-
 import 'cypress-audit/commands'
+import 'cypress'
+
+declare global {
+  // eslint-disable-next-line
+  namespace Cypress {
+    interface Chainable {
+      state(key: string): unknown
+      loginWithFollowOnAdminRole(): Chainable<void>
+      loginWithAgentRole(): Chainable<void>
+      loginWithContractorRole(): Chainable<void>
+      loginWithAgentAndContractorRole(): Chainable<void>
+      loginWithMultipleContractorRole(): Chainable<void>
+      loginWithContractManagerRole(): Chainable<void>
+      loginWithAuthorisationManagerRole(): Chainable<void>
+      loginWithOperativeRole(): Chainable<void>
+      loginWithOneJobAtATimeOperativeRole(): Chainable<void>
+      loginWithAgentAndBudgetCodeOfficerRole(): Chainable<void>
+      loginWithDataAdminRole(): Chainable<void>
+      requestsCountByUrl(url: string): Cypress.Chainable<number>
+      checkForTenureDetails(
+        tenure: string,
+        addressAlerts: string[],
+        contactAlerts: string[]
+      ): Cypress.Chainable<void>
+    }
+  }
+}
 
 Cypress.Commands.add('loginWithFollowOnAdminRole', () => {
   const gssoTestKey = Cypress.env('GSSO_TEST_KEY_FOLLOWON_ADMIN')
@@ -214,8 +215,10 @@ Cypress.Commands.add('loginWithDataAdminRole', () => {
 })
 
 Cypress.Commands.add('requestsCountByUrl', (url) =>
-  cy.wrap().then(() => {
-    const requests = cy.state('requests') || []
+  cy.wrap(null).then(() => {
+    const requests = (cy.state('requests') || []) as Array<{
+      xhr: { url: string }
+    }>
     return requests.filter((req) => req.xhr.url.match(new RegExp(`${url}`)))
       .length
   })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,5 @@
+/// <reference types="cypress" />
 import 'cypress-audit/commands'
-import 'cypress'
 
 declare global {
   // eslint-disable-next-line

--- a/src/utils/helpers/completionDateTimes.ts
+++ b/src/utils/helpers/completionDateTimes.ts
@@ -32,11 +32,8 @@ const isNonWorkingDay = (date: Date) => {
 }
 
 export const isCurrentTimeOperativeOvertime = () => {
-  // @ts-expect-error cypress hack
   if (typeof window.Cypress != 'undefined' && window.Cypress) {
-    // @ts-expect-error cypress hack
     if (typeof window.Cypress.env('IsCurrentOperativeOvertime') == 'boolean') {
-      // @ts-expect-error cypress hack
       return window.Cypress.env('IsCurrentOperativeOvertime')
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "jsx": "preserve",
     "incremental": true,
     "baseUrl": ".",
+    "types": ["cypress", "node"],
     "paths": {
       "@/root/*": ["./*"],
       "@/components/*": ["src/components/*"],


### PR DESCRIPTION
Convert the `commands.js` to `commands.ts` to allow for correct type annotation on the commands - makes them more developer friendly to work with and extend