### PR TITLE
Add max auto reruns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,7 @@ jobs:
 
 workflows:
   continuous-delivery:
+    max_auto_reruns: 3
     jobs:
       - tests
       - e2e


### PR DESCRIPTION
Set `max_auto_reruns` to 3 for the continuous-delivery workflow to deal with occasional test flake