### PR TITLE
Clear cache after all uploads, not after each upload

### DIFF
--- a/src/components/WorkOrder/MobileWorkingWorkOrderView.tsx
+++ b/src/components/WorkOrder/MobileWorkingWorkOrderView.tsx
@@ -31,6 +31,7 @@ import { CurrentUser } from '../../types/variations/types'
 import { Property, Tenure } from '../../models/propertyTenure'
 import { SimpleFeatureToggleResponse } from '../../pages/api/simple-feature-toggle'
 import { WorkOrderAppointmentDetails } from '../../models/workOrderAppointmentDetails'
+import { clearIndexedDb } from './Photos/hooks/uploadFiles/cacheFile'
 
 interface Props {
   workOrderReference: string
@@ -293,6 +294,7 @@ const MobileWorkingWorkOrderView = ({ workOrderReference }: Props) => {
         }
       } // Clear cached form data
       setCloseFormValues(null)
+      await clearIndexedDb()
       router.push('/')
     } catch (e) {
       console.error(e)

--- a/src/components/WorkOrder/Photos/hooks/uploadFiles/index.ts
+++ b/src/components/WorkOrder/Photos/hooks/uploadFiles/index.ts
@@ -4,7 +4,7 @@ import completeUpload from './completeUpload'
 import { captureException } from '@sentry/nextjs'
 import fileUploadStatusLogger from './fileUploadStatusLogger'
 import compressFile from './compressFile'
-import { clearIndexedDb, getCachedFile, setCachedFile } from './cacheFile'
+import { getCachedFile, setCachedFile } from './cacheFile'
 import ensureAllFilesReadable from './ensureAllFilesReadable'
 
 export class FileUploadError extends Error {
@@ -82,9 +82,6 @@ const uploadFiles = async (
     )
     if (!completeUploadResult.success)
       throw new FileUploadError(completeUploadResult.error as string)
-
-    // Clear cache
-    await clearIndexedDb()
   } catch (error) {
     if (error instanceof FileUploadError)
       captureException('Failed to upload photos', {


### PR DESCRIPTION
Currently the cache is cleared after the work order files are uploaded and before the follow on files are uploaded which wastes time having to re-compress the follow-on files

This fixes it by clearing the cache after all uploads are complete