### PR TITLE
Always clear indexeddb after photo upload

### DIFF
--- a/src/components/WorkOrder/Photos/PhotosTab.js
+++ b/src/components/WorkOrder/Photos/PhotosTab.js
@@ -6,6 +6,7 @@ import ErrorMessage from '../../Errors/ErrorMessage'
 import UploadPhotosForm from './UploadPhotosForm'
 import PhotoViewList from './PhotoViewList'
 import { formatRequestErrorMessage } from '@/root/src/utils/errorHandling/formatErrorMessage'
+import { clearIndexedDb } from './hooks/uploadFiles/cacheFile'
 
 const PhotosTab = ({ workOrderReference }) => {
   const [photos, setPhotos] = useState([])
@@ -67,9 +68,10 @@ const PhotosTab = ({ workOrderReference }) => {
       <span className="photos-tab-upload">
         <UploadPhotosForm
           workOrderReference={workOrderReference}
-          onSuccess={() => {
+          onSuccess={async () => {
             // reload photos
             getPhotos(workOrderReference)
+            await clearIndexedDb()
           }}
         />
       </span>

--- a/src/components/WorkOrders/CloseWorkOrderByProxy.tsx
+++ b/src/components/WorkOrders/CloseWorkOrderByProxy.tsx
@@ -24,6 +24,7 @@ import {
 import { APIResponseError } from '../../types/requests/types'
 import { formatRequestErrorMessage } from '../../utils/errorHandling/formatErrorMessage'
 import { Operative } from '../../models/operativeModel'
+import { clearIndexedDb } from '../WorkOrder/Photos/hooks/uploadFiles/cacheFile'
 
 // Named this way because this component exists to allow supervisors
 // to close work orders on behalf of (i.e. a proxy for) an operative.
@@ -228,7 +229,8 @@ const CloseWorkOrderByProxy = ({ reference }: Props) => {
       followOnDataRequest
     )
 
-    makePostRequest(closeWorkOrderFormData, operativeAssignmentFormData)
+    await makePostRequest(closeWorkOrderFormData, operativeAssignmentFormData)
+    await clearIndexedDb()
   }
 
   const changeCurrentPage = () => {


### PR DESCRIPTION
Currently the inexeddb photo cache is not cleared when photos are uploaded in the close-by-proxy process or in the photos tab of work orders.

This isn't an ideal solution but the simplest solution is manually clearing the indexeddb in these places after a successful file upload.

The ideal would be refactoring the photo upload hook, but that can get quite convoluted because there's a separation of work order and follow on files which would need to be consolidated somehow.