### PR TITLE
Fix getAlerts request

### DIFF
--- a/src/components/WorkOrder/WorkOrderView.tsx
+++ b/src/components/WorkOrder/WorkOrderView.tsx
@@ -125,6 +125,7 @@ const WorkOrderView = ({ workOrderReference }: Props) => {
   }, [])
 
   useEffect(() => {
+    if (!property?.propertyReference) return
     fetchAlerts()
   }, [property?.propertyReference])
 


### PR DESCRIPTION
### Description of change

Currently on the WorkOrderView the alerts request is first being sent with **propertyReference** as `undefined` 
<img width="563" height="52" alt="image" src="https://github.com/user-attachments/assets/ad1745f8-6f1a-46b0-87e7-cf8a0ac129f4" />. 

This pr fixes this by not calling **fetchAlerts** in **WorkOrderView** if the **propertyReference** is undefined. 
