### PR TITLE
Fix logging

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,11 +34,6 @@ const moduleExports = {
     domains: ['utfs.io'],
   },
   headers: () => headers(),
-  experimental: {
-    // Added to suppress Sentry-related warnings for Next.js 12.3.4 compatibility
-    instrumentationHook: true,
-    serverComponentsExternalPackages: [],
-  },
 }
 
 const { NODE_ENV, SENTRY_RELEASE } = process.env


### PR DESCRIPTION
The logs weren't appearing because on AWS they were being sent as a buffer, but locally they're sent as objects.

So this PR makes the logging endpoint parse the buffer if it is a buffer