### PR TITLE
Add variation version column

### DIFF
--- a/src/components/WorkOrder/Update/index.tsx
+++ b/src/components/WorkOrder/Update/index.tsx
@@ -91,7 +91,7 @@ const WorkOrderUpdateView = ({ reference }: Props) => {
         path: `/api/jobStatusUpdate`,
         requestData: {
           ...formData,
-          variationVersion: workOrder?.variationVersion
+          variationVersion: workOrder?.variationVersion,
         },
       })
       setOverSpendLimit(overSpendLimit)

--- a/src/components/WorkOrder/Update/index.tsx
+++ b/src/components/WorkOrder/Update/index.tsx
@@ -89,7 +89,10 @@ const WorkOrderUpdateView = ({ reference }: Props) => {
       await frontEndApiRequest({
         method: 'post',
         path: `/api/jobStatusUpdate`,
-        requestData: formData,
+        requestData: {
+          ...formData,
+          variationVersion: workOrder?.variationVersion
+        },
       })
       setOverSpendLimit(overSpendLimit)
       setShowUpdateSuccess(true)

--- a/src/models/workOrder.ts
+++ b/src/models/workOrder.ts
@@ -46,6 +46,8 @@ export class WorkOrder {
   canAssignOperative: boolean
   isSplit: boolean
 
+  variationVersion: string
+
   constructor(workOrderData) {
     Object.assign(this, workOrderData)
   }


### PR DESCRIPTION
Variations replace all SOR codes assigned to a workorder. This means, if an update occurs in the background, it will override the other changes.

 This is the frontend part of a feature that resolves this, by using a unique variationVersion id. If the provided id doesnt match the value in the database, a conflict exception will be thrown. 